### PR TITLE
rotate scanner camera preview on orientation change 

### DIFF
--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import 'dart:math' as math;
 
 import 'mobile_scanner_arguments.dart';
 
@@ -85,7 +86,12 @@ class _MobileScannerState extends State<MobileScanner>
                     child: SizedBox(
                       width: value.size.width,
                       height: value.size.height,
-                      child: Texture(textureId: value.textureId),
+                      child: Transform.rotate(
+                          angle: MediaQuery.of(context).orientation ==
+                                  Orientation.portrait
+                              ? 0
+                              : -90 * math.pi / 180,
+                          child: Texture(textureId: value.textureId)),
                     ),
                   ),
                 ),


### PR DESCRIPTION
Currently when rotating the phone to landscape, the QR scanner is working but the camera preview is not rotated.
This fix rotates the preview with -90 degrees in landscape.
Since Flutter does not offer a solution to detect difference between landscape up and down, it will work only if the user rotates to landscape to the left.
If rotated to right, the preview will be upside down.