### PR TITLE
Call cameraProvider.unbindAll() before create preview

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -113,7 +113,6 @@ class MobileScanner(private val activity: Activity, private val textureRegistry:
 
 
     private var scanner = BarcodeScanning.getClient()
-    private lateinit var imageCapture: ImageCapture
 
     @ExperimentalGetImage
     private fun start(call: MethodCall, result: MethodChannel.Result) {
@@ -137,6 +136,7 @@ class MobileScanner(private val activity: Activity, private val textureRegistry:
 
         future.addListener({
             cameraProvider = future.get()
+            cameraProvider!!.unbindAll()
             textureEntry = textureRegistry.createSurfaceTexture()
 
             // Preview
@@ -162,14 +162,10 @@ class MobileScanner(private val activity: Activity, private val textureRegistry:
             }
             val analysis = analysisBuilder.build().apply { setAnalyzer(executor, analyzer) }
 
-            imageCapture = ImageCapture.Builder()
-                .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
-                .build()
-
             // Select the correct camera
             val selector = if (facing == 0) CameraSelector.DEFAULT_FRONT_CAMERA else CameraSelector.DEFAULT_BACK_CAMERA
 
-            camera = cameraProvider!!.bindToLifecycle(activity as LifecycleOwner, selector, preview, imageCapture)
+            camera = cameraProvider!!.bindToLifecycle(activity as LifecycleOwner, selector, preview, analysis)
 
             val analysisSize = analysis.resolutionInfo?.resolution ?: Size(0, 0)
             val previewSize = preview.resolutionInfo?.resolution ?: Size(0, 0)

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -113,6 +113,7 @@ class MobileScanner(private val activity: Activity, private val textureRegistry:
 
 
     private var scanner = BarcodeScanning.getClient()
+    private lateinit var imageCapture: ImageCapture
 
     @ExperimentalGetImage
     private fun start(call: MethodCall, result: MethodChannel.Result) {
@@ -161,10 +162,14 @@ class MobileScanner(private val activity: Activity, private val textureRegistry:
             }
             val analysis = analysisBuilder.build().apply { setAnalyzer(executor, analyzer) }
 
+            imageCapture = ImageCapture.Builder()
+                .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
+                .build()
+
             // Select the correct camera
             val selector = if (facing == 0) CameraSelector.DEFAULT_FRONT_CAMERA else CameraSelector.DEFAULT_BACK_CAMERA
 
-            camera = cameraProvider!!.bindToLifecycle(activity as LifecycleOwner, selector, preview, analysis)
+            camera = cameraProvider!!.bindToLifecycle(activity as LifecycleOwner, selector, preview, imageCapture)
 
             val analysisSize = analysis.resolutionInfo?.resolution ?: Size(0, 0)
             val previewSize = preview.resolutionInfo?.resolution ?: Size(0, 0)


### PR DESCRIPTION
After user confirm the camera request, the apps will be force close because
```
Fatal Exception: java.lang.IllegalArgumentException
No supported surface combination is found for camera device - Id : 0. May be attempting to bind too many use cases. Existing surfaces: [SurfaceConfig{configType=PRIV, configSize=PREVIEW}, SurfaceConfig{configType=YUV, configSize=ANALYSIS}] New configs: [androidx.camera.core.impl.y0@b351737, androidx.camera.core.impl.q1@d784c36]
```

so unbindAll() camera provider before binding should be fix the problem

Tested on Google Pixel 3, Android 12
Flutter 2.23, Dart 2.12