### PR TITLE
For #28, we need a little change on method to override.

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -66,7 +66,7 @@ class MobileScanner(private val activity: Activity, private val textureRegistry:
         sink = null
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: IntArray?): Boolean {
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray): Boolean {
         return listener?.onRequestPermissionsResult(requestCode, permissions, grantResults) ?: false
     }
 


### PR DESCRIPTION
Flutter master recently added many @NonNull annotations on interface/class definitions and it breaks method overrides.

I think the PR should not be merged until the change lands on stable though I want to share the PR for future referencing purpose.