### PR TITLE
more customization to MobileScanner widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,37 @@ import 'package:mobile_scanner/mobile_scanner.dart';
             }));
   }
 ```
+
+### More customization 
+
+Example using child property:
+
+```dart
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mobile Scanner')),
+      body: Center(
+        child: SizedBox(
+          width: 200,
+          height: 200,
+          child: MobileScanner(
+            child: (arguments) => ClipRRect(
+              borderRadius: BorderRadius.circular(20),
+              child: kIsWeb
+                  ? HtmlElementView(viewType: arguments!.webId!)
+                  : Texture(textureId: arguments!.textureId!),
+            ),
+            allowDuplicates: false,
+            onDetect: (barcode, args) {
+              final String code = barcode.rawValue!;
+              debugPrint('Barcode found! $code');
+            },
+          ),
+        ),
+      ),
+    );
+  }
+```

--- a/example/lib/barcode_scanner_customizable.dart
+++ b/example/lib/barcode_scanner_customizable.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+class BarcodeScannerCustomizable extends StatelessWidget {
+  const BarcodeScannerCustomizable({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mobile Scanner')),
+      body: Center(
+        child: SizedBox(
+          width: 200,
+          height: 200,
+          child: MobileScanner(
+            child: (arguments) => ClipRRect(
+              borderRadius: BorderRadius.circular(20),
+              child: kIsWeb
+                  ? HtmlElementView(viewType: arguments!.webId!)
+                  : Texture(textureId: arguments!.textureId!),
+            ),
+            allowDuplicates: false,
+            onDetect: (barcode, args) {
+              final String code = barcode.rawValue!;
+              debugPrint('Barcode found! $code');
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:mobile_scanner_example/barcode_scanner_controller.dart';
 import 'package:mobile_scanner_example/barcode_scanner_without_controller.dart';
 
+import 'barcode_scanner_customizable.dart';
+
 void main() => runApp(const MaterialApp(home: MyHome()));
 
 class MyHome extends StatelessWidget {
@@ -33,6 +35,14 @@ class MyHome extends StatelessWidget {
                 ));
               },
               child: const Text('MobileScanner without Controller'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(MaterialPageRoute(
+                  builder: (context) => const BarcodeScannerCustomizable(),
+                ));
+              },
+              child: const Text('MobileScanner custom'),
             ),
           ],
         ),

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -15,8 +15,8 @@ class MobileScanner extends StatefulWidget {
   /// [args] Information about the state of the MobileScanner widget
   final Function(Barcode barcode, MobileScannerArguments? args)? onDetect;
 
-  /// TODO: Function that gets called when the Widget is initialized. Can be usefull
-  /// to check wether the device has a torch(flash) or not.
+  /// TODO: Function that gets called when the Widget is initialized.
+  /// Can be usefull to check wether the device has a torch(flash) or not.
   ///
   /// [args] Information about the state of the MobileScanner widget
   // final Function(MobileScannerArguments args)? onInitialize;
@@ -27,11 +27,12 @@ class MobileScanner extends StatefulWidget {
   /// Set to false if you don't want duplicate scans.
   final bool allowDuplicates;
 
-  /// Function that has [MobileScannerArguments] and return a widget, this widget 
-  /// will replace the default widget to give more customization.
+  /// Function that has [MobileScannerArguments] and return a widget,
+  /// this widget will replace the default widget to give more customization.
   final Widget Function(MobileScannerArguments? arguments)? child;
 
-  /// Create a [MobileScanner] with a [controller], the [controller] must has been initialized.
+  /// Create a [MobileScanner] with a [controller], the [controller]
+  /// must has been initialized.
   const MobileScanner({
     Key? key,
     this.onDetect,
@@ -86,10 +87,16 @@ class _MobileScannerState extends State<MobileScanner>
                 if (!widget.allowDuplicates) {
                   if (lastScanned != barcode.rawValue) {
                     lastScanned = barcode.rawValue;
-                    widget.onDetect!(barcode, value as MobileScannerArguments);
+                    widget.onDetect!(
+                      barcode,
+                      value as MobileScannerArguments,
+                    );
                   }
                 } else {
-                  widget.onDetect!(barcode, value as MobileScannerArguments);
+                  widget.onDetect!(
+                    barcode,
+                    value as MobileScannerArguments,
+                  );
                 }
               });
 

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -27,14 +27,19 @@ class MobileScanner extends StatefulWidget {
   /// Set to false if you don't want duplicate scans.
   final bool allowDuplicates;
 
+  /// Function that has [MobileScannerArguments] and return a widget, this widget 
+  /// will replace the default widget to give more customization.
+  final Widget Function(MobileScannerArguments? arguments)? child;
+
   /// Create a [MobileScanner] with a [controller], the [controller] must has been initialized.
-  const MobileScanner(
-      {Key? key,
-      this.onDetect,
-      this.controller,
-      this.fit = BoxFit.cover,
-      this.allowDuplicates = false})
-      : super(key: key);
+  const MobileScanner({
+    Key? key,
+    this.onDetect,
+    this.controller,
+    this.fit = BoxFit.cover,
+    this.child,
+    this.allowDuplicates = false,
+  }) : super(key: key);
 
   @override
   State<MobileScanner> createState() => _MobileScannerState();
@@ -87,6 +92,11 @@ class _MobileScannerState extends State<MobileScanner>
                   widget.onDetect!(barcode, value as MobileScannerArguments);
                 }
               });
+
+              if (widget.child != null) {
+                return widget.child!(value);
+              }
+
               return ClipRect(
                 child: SizedBox(
                   width: MediaQuery.of(context).size.width,


### PR DESCRIPTION
Hi, here in my company, we decided to use mobile_scanner to read QR codes that our users needed. I like the package but we need here, more customization to follow our design system. So I propose this change, that added a new parameter (child) to MobileScanner widget, and this parameter is a function that returns a Widget and this function has the MobileScannerArguments to help who use this child parameter can use the textureId or webId  ou any information MobileScannerArguments have.

Best Regards, Eduardo.