### PR TITLE
fix: bad state stream has already been listened to

### DIFF
--- a/lib/mobile_scanner_web_plugin.dart
+++ b/lib/mobile_scanner_web_plugin.dart
@@ -30,7 +30,7 @@ class MobileScannerWebPlugin {
   }
 
   // Controller to send events back to the framework
-  StreamController controller = StreamController();
+  StreamController controller = StreamController.broadcast();
 
   // The video stream. Will be initialized later to see which camera needs to be used.
   html.MediaStream? _localStream;


### PR DESCRIPTION
This PR fixes Issue #64 by setting stream controller to broadcast. The issue occurred because one can only listen to a normal stream at once. If stream is a broadcast stream one can listen multiple times.