### PR TITLE
fix: use correct package name in `AndroidManifest.xml` in example

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.steenbakker.mobile_scanner.example">
+    package="dev.steenbakker.mobile_scanner_example">
 
    <application
         android:label="mobile_scanner_example"


### PR DESCRIPTION
The correct is package name is `dev.steenbakker.mobile_scanner_example`:
https://github.com/juliansteenbakker/mobile_scanner/blob/0b415240715b1000552b2c3bd45853e3e78e3cd0/example/android/app/build.gradle#L46