### PR TITLE
Error: Method 'removeObserver'/'addObserver' cannot be called on 'WidgetsBinding?' because it is potentially null.

### DIFF
--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -47,7 +47,7 @@ class _MobileScannerState extends State<MobileScanner>
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance?.addObserver(this);
     controller = widget.controller ?? MobileScannerController();
   }
 
@@ -131,7 +131,7 @@ class _MobileScannerState extends State<MobileScanner>
   @override
   void dispose() {
     controller.dispose();
-    WidgetsBinding.instance.removeObserver(this);
+    WidgetsBinding.instance?.removeObserver(this);
     super.dispose();
   }
 }


### PR DESCRIPTION
Error:
`Try calling using ?. instead.
        WidgetsBinding.instance.addObserver(this);
                                ^^^^^^^^^^^
    ../lib/src/mobile_scanner.dart:134:29: Error: Method 'removeObserver' cannot
    be called on 'WidgetsBinding?' because it is potentially null.
     - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart'
     ('../../../Documents/envs/flutter/packages/flutter/lib/src/widgets/binding.
     dart').
    Try calling using ?. instead.
        WidgetsBinding.instance.removeObserver(this);
                                ^^^^^^^^^^^^^^
    Failed to package /Users/vietlinhtspt/Desktop/mobile_scanner/example.
    Command PhaseScriptExecution failed with a nonzero exit code`

Flutter doctor:

`Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, 2.10.5, on macOS 12.4 21F79 darwin-arm, locale
    en-VN)
[✓] Android toolchain - develop for Android devices (Android SDK version
    32.1.0-rc1)
[✓] Xcode - develop for iOS and macOS (Xcode 13.3.1)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2021.1)
[✓] VS Code (version 1.67.2)`