### PR TITLE
Preventing compilation error when adding or removing a WidgetsBinding observer

### DIFF
--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -47,7 +47,7 @@ class _MobileScannerState extends State<MobileScanner>
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance?.addObserver(this);
     controller = widget.controller ?? MobileScannerController();
   }
 
@@ -131,7 +131,7 @@ class _MobileScannerState extends State<MobileScanner>
   @override
   void dispose() {
     controller.dispose();
-    WidgetsBinding.instance.removeObserver(this);
+    WidgetsBinding.instance?.removeObserver(this);
     super.dispose();
   }
 }


### PR DESCRIPTION
When trying to implement the fixes suggested in #156 I stumbled upon a compiler error with the `WidgetsBinding` observers. This is a simple fix to prevent that.