### PR TITLE
feat: enable displayValue

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -278,7 +278,7 @@ class MobileScanner(private val activity: Activity, private val textureRegistry:
                 "calendarEvent" to calendarEvent?.data, "contactInfo" to contactInfo?.data,
                 "driverLicense" to driverLicense?.data, "email" to email?.data,
                 "geoPoint" to geoPoint?.data, "phone" to phone?.data, "sms" to sms?.data,
-                "url" to url?.data, "wifi" to wifi?.data)
+                "url" to url?.data, "wifi" to wifi?.data, "displayValue" to displayValue)
 
     private val Point.data: Map<String, Double>
         get() = mapOf("x" to x.toDouble(), "y" to y.toDouble())

--- a/ios/Classes/Util.swift
+++ b/ios/Classes/Util.swift
@@ -70,7 +70,7 @@ extension UIDeviceOrientation {
 extension Barcode {
     var data: [String: Any?] {
         let corners = cornerPoints?.map({$0.cgPointValue.data})
-        return ["corners": corners, "format": format.rawValue, "rawBytes": rawData, "rawValue": rawValue, "type": valueType.rawValue, "calendarEvent": calendarEvent?.data, "contactInfo": contactInfo?.data, "driverLicense": driverLicense?.data, "email": email?.data, "geoPoint": geoPoint?.data, "phone": phone?.data, "sms": sms?.data, "url": url?.data, "wifi": wifi?.data]
+        return ["corners": corners, "format": format.rawValue, "rawBytes": rawData, "rawValue": rawValue, "type": valueType.rawValue, "calendarEvent": calendarEvent?.data, "contactInfo": contactInfo?.data, "driverLicense": driverLicense?.data, "email": email?.data, "geoPoint": geoPoint?.data, "phone": phone?.data, "sms": sms?.data, "url": url?.data, "wifi": wifi?.data, "displayValue": displayValue]
     }
 }
 

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -27,6 +27,15 @@ class Barcode {
   /// Returns null if the raw value can not be determined.
   final String? rawValue;
 
+  /// Returns barcode value in a user-friendly format.
+  ///
+  /// This method may omit some of the information encoded in the barcode. For example, if [rawValue] returns 'MEBKM:TITLE:Google;URL://www.google.com;;', the display value might be '//www.google.com'.
+  ///
+  /// This value may be multiline, for example, when line breaks are encoded into the original TEXT barcode value. May include the supplement value.
+  ///
+  /// Returns null if nothing found.
+  final String? displayValue;
+
   /// Returns format type of the barcode value.
   ///
   /// For example, TYPE_TEXT, TYPE_PRODUCT, TYPE_URL, etc.
@@ -77,6 +86,7 @@ class Barcode {
     this.sms,
     this.url,
     this.wifi,
+    this.displayValue,
     required this.rawValue,
   });
 
@@ -86,6 +96,7 @@ class Barcode {
         format = toFormat(data['format'] as int),
         rawBytes = data['rawBytes'] as Uint8List?,
         rawValue = data['rawValue'] as String?,
+        displayValue = data['displayValue'] as String?,
         type = BarcodeType.values[data['type'] as int],
         calendarEvent = toCalendarEvent(data['calendarEvent'] as Map?),
         contactInfo = toContactInfo(data['contactInfo'] as Map?),


### PR DESCRIPTION
Enables the use of "displayValue" included in MLKit.
This can be used to easily read non-UTF-8 strings.

- https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/common/Barcode#public-string-getdisplayvalue
- https://developers.google.com/ml-kit/reference/swift/mlkitbarcodescanning/api/reference/Classes/Barcode#displayvalue