### PR TITLE
add autoResume Option

### DIFF
--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -55,7 +55,7 @@ class _MobileScannerState extends State<MobileScanner>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
-        if (!controller.isStarting) controller.start();
+        if (!controller.isStarting && controller.autoResume) controller.start();
         break;
       case AppLifecycleState.inactive:
       case AppLifecycleState.paused:

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -53,6 +53,9 @@ class MobileScannerController {
   bool hasTorch = false;
   late StreamController<Barcode> barcodesController;
 
+  /// Whether to automatically resume the camera when the application is resumed
+  bool autoResume;
+
   Stream<Barcode> get barcodes => barcodesController.stream;
 
   MobileScannerController({
@@ -60,6 +63,7 @@ class MobileScannerController {
     this.ratio,
     this.torchEnabled,
     this.formats,
+    this.autoResume = true,
   }) {
     // In case a new instance is created before calling dispose()
     if (_controllerHashcode != null) {


### PR DESCRIPTION
Resuming the app also starts the camera, but this is inconvenient if the developer wants to explicitly control it.
This pull request fixes this.
I am using Deepl.