### PR TITLE
Improvements

### DIFF
--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -49,6 +49,7 @@ class _MobileScannerState extends State<MobileScanner>
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     controller = widget.controller ?? MobileScannerController();
+    if (!controller.isStarting) controller.start();
   }
 
   @override

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -35,7 +35,8 @@ class MobileScannerController {
   EventChannel eventChannel =
       const EventChannel('dev.steenbakker.mobile_scanner/scanner/event');
 
-  int? _controllerHashcode;
+  //Must be static to keep the same value on new instances
+  static int? _controllerHashcode;
   StreamSubscription? events;
 
   final ValueNotifier<MobileScannerArguments?> args = ValueNotifier(null);

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -76,8 +76,6 @@ class MobileScannerController {
         // onCancel: () => setAnalyzeMode(AnalyzeMode.none.index),
         );
 
-    start();
-
     // Listen to events from the platform specific code
     events = eventChannel
         .receiveBroadcastStream()

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -87,22 +87,22 @@ class MobileScannerController {
     final data = event['data'];
     switch (name) {
       case 'torchState':
-        final state = TorchState.values[data as int];
+        final state = TorchState.values[data as int? ?? 0];
         torchState.value = state;
         break;
       case 'barcode':
-        final barcode = Barcode.fromNative(data as Map);
+        final barcode = Barcode.fromNative(data as Map? ?? {});
         barcodesController.add(barcode);
         break;
       case 'barcodeMac':
         barcodesController.add(
           Barcode(
-            rawValue: (data as Map)['payload'] as String,
+            rawValue: (data as Map)['payload'] as String?,
           ),
         );
         break;
       case 'barcodeWeb':
-        barcodesController.add(Barcode(rawValue: data as String));
+        barcodesController.add(Barcode(rawValue: data as String?));
         break;
       default:
         throw UnimplementedError();
@@ -133,11 +133,11 @@ class MobileScannerController {
     // Check authorization status
     if (!kIsWeb) {
       MobileScannerState state = MobileScannerState
-          .values[await methodChannel.invokeMethod('state') as int];
+          .values[await methodChannel.invokeMethod('state') as int? ?? 0];
       switch (state) {
         case MobileScannerState.undetermined:
           final bool result =
-              await methodChannel.invokeMethod('request') as bool;
+              await methodChannel.invokeMethod('request') as bool? ?? false;
           state = result
               ? MobileScannerState.authorized
               : MobileScannerState.denied;
@@ -185,21 +185,21 @@ class MobileScannerController {
       throw PlatformException(code: 'INITIALIZATION ERROR');
     }
 
-    hasTorch = startResult['torchable'] as bool;
+    hasTorch = startResult['torchable'] as bool? ?? false;
 
     if (kIsWeb) {
       args.value = MobileScannerArguments(
         webId: startResult['ViewID'] as String?,
         size: Size(
-          startResult['videoWidth'] as double,
-          startResult['videoHeight'] as double,
+          startResult['videoWidth'] as double? ?? 0,
+          startResult['videoHeight'] as double? ?? 0,
         ),
         hasTorch: hasTorch,
       );
     } else {
       args.value = MobileScannerArguments(
-        textureId: startResult['textureId'] as int,
-        size: toSize(startResult['size'] as Map),
+        textureId: startResult['textureId'] as int?,
+        size: toSize(startResult['size'] as Map? ?? {}),
         hasTorch: hasTorch,
       );
     }


### PR DESCRIPTION
- start() call removed from MobileScannerController constructor
- MobileScanner widget starts controller from initState
- _controllerHashcode made static to keep the same value on new instances
- null-safe validations added to data casting from map, like `hasTorch = startResult['torchable'] as bool? ?? false` that sometimes caused exception on web when trying to get null torchable value from map

Possible fixes:
- [ISSUE-144](https://github.com/juliansteenbakker/mobile_scanner/issues/144)
- [ISSUE-101](https://github.com/juliansteenbakker/mobile_scanner/issues/101)

Tested in: iOS 15.5, Android 8.1.0 and Chrome 101.0.4951.41
