### PR TITLE
adds hardcoded android scanwindow fix

### DIFF
--- a/example/lib/barcode_scanner_window.dart
+++ b/example/lib/barcode_scanner_window.dart
@@ -45,9 +45,10 @@ class _BarcodeScannerWithScanWindowState
       body: Builder(
         builder: (context) {
           return Stack(
+            fit: StackFit.expand,
             children: [
               MobileScanner(
-                fit: BoxFit.cover,
+                fit: BoxFit.contain,
                 scanWindow: scanWindow,
                 controller: controller,
                 onDetect: onDetect,


### PR DESCRIPTION
this pull request is a temp workaround to fix android scan window by manually flipping the scan image 90 degrees (switching width and height). this is in no way a good solution as it doesn't guarantee to work on all devices. currently something is wrong with the camera rotation (try and flip example to landscape) this should probably be fixed before also fixing it here. 

[how to fix rotation](https://developer.android.com/training/camerax/configuration#rotation)