### PR TITLE
optionally return image with barcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,41 @@ import 'package:mobile_scanner/mobile_scanner.dart';
             }));
   }
 ```
+
+Example with controller and returning images
+
+```dart
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mobile Scanner')),
+      body: MobileScanner(
+        controller: MobileScannerController(
+          facing: CameraFacing.front,
+          torchEnabled: true,
+          returnImage: true,
+        ),
+        onDetect: (barcode, args) {
+          if (barcode.rawValue == null) {
+            debugPrint('Failed to scan Barcode');
+          } else {
+            final String code = barcode.rawValue!;
+            debugPrint('Barcode found! $code');
+
+            debugPrint(
+                'Image returned! length: ${barcode.image!.lengthInBytes}b');
+            showDialog(
+              context: context,
+              builder: (context) => Image(image: MemoryImage(barcode.image!)),
+            );
+            Future.delayed(const Duration(seconds: 2), () {
+              Navigator.pop(context);
+            });
+          }
+        },
+      ),
+    );
+  }
+```

--- a/example/lib/barcode_scanner_returning_image.dart
+++ b/example/lib/barcode_scanner_returning_image.dart
@@ -1,0 +1,162 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+class BarcodeScannerReturningImage extends StatefulWidget {
+  const BarcodeScannerReturningImage({Key? key}) : super(key: key);
+
+  @override
+  _BarcodeScannerReturningImageState createState() =>
+      _BarcodeScannerReturningImageState();
+}
+
+class _BarcodeScannerReturningImageState
+    extends State<BarcodeScannerReturningImage>
+    with SingleTickerProviderStateMixin {
+  String? barcode;
+  Uint8List? image;
+
+  MobileScannerController controller = MobileScannerController(
+    torchEnabled: true,
+    returnImage: true,
+    // formats: [BarcodeFormat.qrCode]
+    // facing: CameraFacing.front,
+  );
+
+  bool isStarted = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Builder(
+        builder: (context) {
+          return Stack(
+            children: [
+              MobileScanner(
+                controller: controller,
+                fit: BoxFit.contain,
+                // allowDuplicates: true,
+                // controller: MobileScannerController(
+                //   torchEnabled: true,
+                //   facing: CameraFacing.front,
+                // ),
+                onDetect: (barcode, args) {
+                  setState(() {
+                    this.barcode = barcode.rawValue;
+                    showDialog(
+                      context: context,
+                      builder: (context) => Image(
+                        image: MemoryImage(image!),
+                        fit: BoxFit.contain,
+                      ),
+                    );
+                    image = barcode.image;
+                  });
+                },
+              ),
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Container(
+                  alignment: Alignment.bottomCenter,
+                  height: 100,
+                  color: Colors.black.withOpacity(0.4),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      IconButton(
+                        color: Colors.white,
+                        icon: ValueListenableBuilder(
+                          valueListenable: controller.torchState,
+                          builder: (context, state, child) {
+                            if (state == null) {
+                              return const Icon(
+                                Icons.flash_off,
+                                color: Colors.grey,
+                              );
+                            }
+                            switch (state as TorchState) {
+                              case TorchState.off:
+                                return const Icon(
+                                  Icons.flash_off,
+                                  color: Colors.grey,
+                                );
+                              case TorchState.on:
+                                return const Icon(
+                                  Icons.flash_on,
+                                  color: Colors.yellow,
+                                );
+                            }
+                          },
+                        ),
+                        iconSize: 32.0,
+                        onPressed: () => controller.toggleTorch(),
+                      ),
+                      IconButton(
+                        color: Colors.white,
+                        icon: isStarted
+                            ? const Icon(Icons.stop)
+                            : const Icon(Icons.play_arrow),
+                        iconSize: 32.0,
+                        onPressed: () => setState(() {
+                          isStarted ? controller.stop() : controller.start();
+                          isStarted = !isStarted;
+                        }),
+                      ),
+                      Center(
+                        child: SizedBox(
+                          width: MediaQuery.of(context).size.width - 200,
+                          height: 50,
+                          child: FittedBox(
+                            child: Text(
+                              barcode ?? 'Scan something!',
+                              overflow: TextOverflow.fade,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .headline4!
+                                  .copyWith(color: Colors.white),
+                            ),
+                          ),
+                        ),
+                      ),
+                      IconButton(
+                        color: Colors.white,
+                        icon: ValueListenableBuilder(
+                          valueListenable: controller.cameraFacingState,
+                          builder: (context, state, child) {
+                            if (state == null) {
+                              return const Icon(Icons.camera_front);
+                            }
+                            switch (state as CameraFacing) {
+                              case CameraFacing.front:
+                                return const Icon(Icons.camera_front);
+                              case CameraFacing.back:
+                                return const Icon(Icons.camera_rear);
+                            }
+                          },
+                        ),
+                        iconSize: 32.0,
+                        onPressed: () => controller.switchCamera(),
+                      ),
+                      SizedBox(
+                        width: 50,
+                        height: 50,
+                        child: image != null
+                            ? Image(
+                                image: MemoryImage(image!),
+                                fit: BoxFit.contain,
+                              )
+                            : Container(),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner_example/barcode_scanner_controller.dart';
+import 'package:mobile_scanner_example/barcode_scanner_returning_image.dart';
 import 'package:mobile_scanner_example/barcode_scanner_without_controller.dart';
 
 void main() => runApp(const MaterialApp(home: MyHome()));
@@ -26,6 +27,17 @@ class MyHome extends StatelessWidget {
                 );
               },
               child: const Text('MobileScanner with Controller'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => const BarcodeScannerReturningImage(),
+                  ),
+                );
+              },
+              child:
+                  const Text('MobileScanner with Controller (returning image)'),
             ),
             ElevatedButton(
               onPressed: () {

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -12,6 +12,11 @@ class Barcode {
   /// Returns null if the corner points can not be determined.
   final List<Offset>? corners;
 
+  /// Returns raw bytes of the image buffer
+  ///
+  /// Returns null if the image was not returned
+  final Uint8List? image;
+
   /// Returns barcode format
   final BarcodeFormat format;
 
@@ -74,6 +79,7 @@ class Barcode {
 
   Barcode({
     this.corners,
+    this.image,
     this.format = BarcodeFormat.ean13,
     this.rawBytes,
     this.type = BarcodeType.text,
@@ -91,7 +97,7 @@ class Barcode {
   });
 
   /// Create a [Barcode] from native data.
-  Barcode.fromNative(Map data)
+  Barcode.fromNative(Map data, this.image)
       : corners = toCorners(data['corners'] as List?),
         format = toFormat(data['format'] as int),
         rawBytes = data['rawBytes'] as Uint8List?,


### PR DESCRIPTION
New controller option `returnImage`. When set to true a UInt8List containing the latest frame is returned with the `barcode` event.


<img alt="example app menu showing new option" src="https://user-images.githubusercontent.com/622455/184520346-ef8b5618-1a6e-48d0-bf3f-dceafc4719ae.PNG" height="300"/>
<img alt="example app showing returned image" src="https://user-images.githubusercontent.com/622455/184520349-06df53f1-beea-43ee-b3ae-855f7b3df701.PNG" height="300"/>


Good things:
 - Seems to work. 

Bad things:
 - iOS only
 - Returned image is JPEG at 0.8 compression only
 - Often get a blurry frame back. Good enough to scan, not great for verification. Not sure what could be done about that, if anything.

Things that could be added:
  - Configurable image compression, resizing, format
  - Helper method to crop the image using the `corners` to return just the barcode.

See: #251