### PR TITLE
expose the binaryData from the jsQR library

### DIFF
--- a/lib/mobile_scanner_web_plugin.dart
+++ b/lib/mobile_scanner_web_plugin.dart
@@ -200,7 +200,11 @@ class MobileScannerWebPlugin {
 
     final code = jsQR(imgData.data, canvas.width, canvas.height);
     if (code != null) {
-      controller.add({'name': 'barcodeWeb', 'data': code.data});
+      controller.add({
+        'name': 'barcodeWeb',
+        'data': code.data,
+        'binaryData': code.binaryData,
+      });
     }
   }
 }

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -89,6 +90,7 @@ class MobileScannerController {
   void handleEvent(Map event) {
     final name = event['name'];
     final data = event['data'];
+    final binaryData = event['binaryData'];
     switch (name) {
       case 'torchState':
         final state = TorchState.values[data as int? ?? 0];
@@ -106,7 +108,11 @@ class MobileScannerController {
         );
         break;
       case 'barcodeWeb':
-        barcodesController.add(Barcode(rawValue: data as String?));
+        final bytes = (binaryData as List).cast<int>();
+        barcodesController.add(Barcode(
+          rawValue: data as String?,
+          rawBytes: Uint8List.fromList(bytes),
+        ));
         break;
       default:
         throw UnimplementedError();

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -109,10 +109,12 @@ class MobileScannerController {
         break;
       case 'barcodeWeb':
         final bytes = (binaryData as List).cast<int>();
-        barcodesController.add(Barcode(
-          rawValue: data as String?,
-          rawBytes: Uint8List.fromList(bytes),
-        ));
+        barcodesController.add(
+          Barcode(
+            rawValue: data as String?,
+            rawBytes: Uint8List.fromList(bytes),
+          ),
+        );
         break;
       default:
         throw UnimplementedError();

--- a/lib/src/web/jsqr.dart
+++ b/lib/src/web/jsqr.dart
@@ -1,6 +1,8 @@
 @JS()
 library jsqr;
 
+import 'dart:typed_data';
+
 import 'package:js/js.dart';
 
 @JS('jsQR')
@@ -9,4 +11,6 @@ external Code? jsQR(dynamic data, int? width, int? height);
 @JS()
 class Code {
   external String get data;
+
+  external Uint8ClampedList get binaryData;
 }


### PR DESCRIPTION
Hi!, 

currently the jsQR exposes `data` and `binaryData` properties of the object as a result of its `scan: QRCode` method.
However, the mobile_scanner only ever uses the data.

In case the QRCode payload does not return a stringified data property, it still does return `binaryData` which corresponds 1:1 to the `rawBytes` of the mobile_scanner Barcode object. Otherwise, if you scan a QR code which payload is only binary data, the mobile_scanner returns null.

PS: I'm not a jsQR expert, but it seems to me that logically binaryData will never be null, otherwise the detection itself failed?

Hence the PR, if you have any comments I'm happy to review them.