### PR TITLE
fix: should check for the raw bytes instead of string, in case of a malformed utf8 string

### DIFF
--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -66,7 +66,7 @@ class _MobileScannerState extends State<MobileScanner>
     }
   }
 
-  String? lastScanned;
+  Uint8List? lastScanned;
 
   @override
   Widget build(BuildContext context) {
@@ -79,8 +79,8 @@ class _MobileScannerState extends State<MobileScanner>
         } else {
           controller.barcodes.listen((barcode) {
             if (!widget.allowDuplicates) {
-              if (lastScanned != barcode.rawValue) {
-                lastScanned = barcode.rawValue;
+              if (lastScanned != barcode.rawBytes) {
+                lastScanned = barcode.rawBytes;
                 widget.onDetect(barcode, value! as MobileScannerArguments);
               }
             } else {


### PR DESCRIPTION
If the QR code contains binary data that is not UTF8 (aka malformed code points) then the `rawValue` will be null. And then the if statement to check if `lastScanned` equals the `rawValue` will never return true as the value never gets set.

So instead of comparing the string representations I changed the code to compare the `Uint8List`, that way the first scan of a malformed QR code will succeed.