### PR TITLE
fix: add import typed_data in mobile_scanner_controller file because error about Uint8List during build

### DIFF
--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';


### PR DESCRIPTION
# Summary
In my environment, I got the following error when I tried to pub get `^3.0.0-beta.2` and build it, so I imported what I needed. 

```
Launching lib/main.dart on Pixel 3a in debug mode...
lib/main.dart:1
Warning: Mapping new ns http://schemas.android.com/repository/android/common/02 to old ns http://schemas.android.com/repository/android/common/01
Warning: Mapping new ns http://schemas.android.com/repository/android/generic/02 to old ns http://schemas.android.com/repository/android/generic/01
Warning: Mapping new ns http://schemas.android.com/sdk/android/repo/addon2/02 to old ns http://schemas.android.com/sdk/android/repo/addon2/01
Warning: Mapping new ns http://schemas.android.com/sdk/android/repo/repository2/02 to old ns http://schemas.android.com/sdk/android/repo/repository2/01
Warning: Mapping new ns http://schemas.android.com/sdk/android/repo/sys-img2/02 to old ns http://schemas.android.com/sdk/android/repo/sys-img2/01
: Error: 'Uint8List' isn't a type.
../…/src/mobile_scanner_controller.dart:283
            image: event['image'] as Uint8List?,
                                     ^^^^^^^^^
FAILURE: Build failed with an exception.

* Where:
Script '/Users/r/fvm/versions/3.0.4/packages/flutter_tools/gradle/flutter.gradle' line: 1156

* What went wrong:
Execution failed for task ':app:compileFlutterBuildDebug'.
> Process 'command '/Users/r/fvm/versions/3.0.4/bin/flutter'' finished with non-zero exit value 1

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 30s
Exception: Gradle task assembleDebug failed with exit code 1
Exited
```

# flutter doctor

```
$ fvm flutter doctor
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel unknown, 3.0.4, on macOS 12.6 21G115 darwin-x64, locale ja-JP)
[✓] Android toolchain - develop for Android devices (Android SDK version 33.0.0-rc1)
[✓] Xcode - develop for iOS and macOS (Xcode 13.3.1)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2021.2)
[✓] VS Code (version 1.73.1)
[✓] Connected device (4 available)
    ! Error: iPhone (2) is busy: Fetching debug symbols for iPhone (2). Xcode will continue when iPhone (2) is finished. (code -10)
[✓] HTTP Host Availability

• No issues found!
```