### PR TITLE
fix: Update dispose method

### DIFF
--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -151,7 +151,7 @@ class _MobileScannerState extends State<MobileScanner>
 
   @override
   void dispose() {
-    controller.dispose();
+    if (widget.controller == null) controller.dispose();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }


### PR DESCRIPTION
If developer give a controller, developer will dispose it. The package should not do it. Else we will have a double call to dispose.