### PR TITLE
fix: Android permission bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.0.0-beta.4
+Fixes:
+* Fixes a permission bug on Android where denying the permission would cause an infinite loop of permission requests.
+* Updates the example app to handle permission errors with the new builder parameter.
+  Now it no longer throws uncaught exceptions when the permission is denied.
+
+Features:
+* Added a new `errorBuilder` to the `MobileScanner` widget that can be used to customize the error state of the preview.
+
 ## 3.0.0-beta.3
 Deprecated:
 * The `onStart` method has been renamed to `onScannerStarted`.

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/BarcodeHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/BarcodeHandler.kt
@@ -2,15 +2,15 @@ package dev.steenbakker.mobile_scanner
 
 import android.os.Handler
 import android.os.Looper
-import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
 
-class BarcodeHandler(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) : EventChannel.StreamHandler {
+class BarcodeHandler(binaryMessenger: BinaryMessenger) : EventChannel.StreamHandler {
 
     private var eventSink: EventChannel.EventSink? = null
 
     private val eventChannel = EventChannel(
-        flutterPluginBinding.binaryMessenger,
+        binaryMessenger,
         "dev.steenbakker.mobile_scanner/scanner/event"
     )
 

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MethodCallHandlerImpl.kt
@@ -20,7 +20,7 @@ class MethodCallHandlerImpl(
     private val barcodeHandler: BarcodeHandler,
     binaryMessenger: BinaryMessenger,
     private val permissions: MobileScannerPermissions,
-    private val permissionsRegistry: MobileScannerPermissions.PermissionsRegistry,
+    private val addPermissionListener: (RequestPermissionsResultListener) -> Unit,
     textureRegistry: TextureRegistry): MethodChannel.MethodCallHandler {
 
     private val analyzerCallback: AnalyzerCallback = { barcodes: List<Map<String, Any?>>?->
@@ -98,7 +98,7 @@ class MethodCallHandlerImpl(
             "state" -> result.success(permissions.hasCameraPermission(activity))
             "request" -> permissions.requestPermission(
                 activity,
-                permissionsRegistry,
+                addPermissionListener,
                 object: MobileScannerPermissions.ResultCallback {
                     override fun onResult(errorCode: String?, errorDescription: String?) {
                         if(errorCode == null) {

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MethodCallHandlerImpl.kt
@@ -101,12 +101,11 @@ class MethodCallHandlerImpl(
                 addPermissionListener,
                 object: MobileScannerPermissions.ResultCallback {
                     override fun onResult(errorCode: String?, errorDescription: String?) {
-                        if(errorCode == null) {
-                            result.success(true)
-                            return
+                        when(errorCode) {
+                            null -> result.success(true)
+                            MobileScannerPermissions.CAMERA_ACCESS_DENIED -> result.success(false)
+                            else -> result.error(errorCode, errorDescription, null)
                         }
-
-                        result.error(errorCode, errorDescription, null)
                     }
                 })
             "start" -> start(call, result)

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MethodCallHandlerImpl.kt
@@ -1,0 +1,217 @@
+package dev.steenbakker.mobile_scanner
+
+import android.app.Activity
+import android.net.Uri
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ExperimentalGetImage
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import dev.steenbakker.mobile_scanner.objects.BarcodeFormats
+import dev.steenbakker.mobile_scanner.objects.DetectionSpeed
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.view.TextureRegistry
+import java.io.File
+
+class MethodCallHandlerImpl(
+    private val activity: Activity,
+    private val barcodeHandler: BarcodeHandler,
+    binaryMessenger: BinaryMessenger,
+    private val permissions: MobileScannerPermissions,
+    private val permissionsRegistry: MobileScannerPermissions.PermissionsRegistry,
+    textureRegistry: TextureRegistry): MethodChannel.MethodCallHandler {
+
+    private val analyzerCallback: AnalyzerCallback = { barcodes: List<Map<String, Any?>>?->
+        if (barcodes != null) {
+            barcodeHandler.publishEvent(mapOf(
+                "name" to "barcode",
+                "data" to barcodes
+            ))
+            analyzerResult?.success(true)
+        } else {
+            analyzerResult?.success(false)
+        }
+        analyzerResult = null
+    }
+
+    private var analyzerResult: MethodChannel.Result? = null
+
+    private val callback: MobileScannerCallback = { barcodes: List<Map<String, Any?>>, image: ByteArray? ->
+        if (image != null) {
+            barcodeHandler.publishEvent(mapOf(
+                "name" to "barcode",
+                "data" to barcodes,
+                "image" to image
+            ))
+        } else {
+            barcodeHandler.publishEvent(mapOf(
+                "name" to "barcode",
+                "data" to barcodes
+            ))
+        }
+    }
+
+    private val errorCallback: MobileScannerErrorCallback = {error: String ->
+        barcodeHandler.publishEvent(mapOf(
+            "name" to "error",
+            "data" to error,
+        ))
+    }
+
+    private var methodChannel: MethodChannel? = null
+
+    private var mobileScanner: MobileScanner? = null
+
+    private val torchStateCallback: TorchStateCallback = {state: Int ->
+        barcodeHandler.publishEvent(mapOf("name" to "torchState", "data" to state))
+    }
+
+    init {
+        methodChannel = MethodChannel(binaryMessenger,
+            "dev.steenbakker.mobile_scanner/scanner/method")
+        methodChannel!!.setMethodCallHandler(this)
+        mobileScanner = MobileScanner(activity, textureRegistry, callback, errorCallback)
+    }
+
+    fun dispose(activityPluginBinding: ActivityPluginBinding) {
+        methodChannel?.setMethodCallHandler(null)
+        methodChannel = null
+        mobileScanner = null
+
+        val listener: RequestPermissionsResultListener? = permissions.getPermissionListener()
+
+        if(listener != null) {
+            activityPluginBinding.removeRequestPermissionsResultListener(listener)
+        }
+
+    }
+
+    @ExperimentalGetImage
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        if (mobileScanner == null) {
+            result.error("MobileScanner", "Called ${call.method} before initializing.", null)
+            return
+        }
+        when (call.method) {
+            "state" -> result.success(permissions.hasCameraPermission(activity))
+            "request" -> permissions.requestPermission(
+                activity,
+                permissionsRegistry,
+                object: MobileScannerPermissions.ResultCallback {
+                    override fun onResult(errorCode: String?, errorDescription: String?) {
+                        if(errorCode == null) {
+                            result.success(true)
+                            return
+                        }
+
+                        result.error(errorCode, errorDescription, null)
+                    }
+                })
+            "start" -> start(call, result)
+            "torch" -> toggleTorch(call, result)
+            "stop" -> stop(result)
+            "analyzeImage" -> analyzeImage(call, result)
+            else -> result.notImplemented()
+        }
+    }
+
+    @ExperimentalGetImage
+    private fun start(call: MethodCall, result: MethodChannel.Result) {
+        val torch: Boolean = call.argument<Boolean>("torch") ?: false
+        val facing: Int = call.argument<Int>("facing") ?: 0
+        val formats: List<Int>? = call.argument<List<Int>>("formats")
+        val returnImage: Boolean = call.argument<Boolean>("returnImage") ?: false
+        val speed: Int = call.argument<Int>("speed") ?: 1
+        val timeout: Int = call.argument<Int>("timeout") ?: 250
+
+        var barcodeScannerOptions: BarcodeScannerOptions? = null
+        if (formats != null) {
+            val formatsList: MutableList<Int> = mutableListOf()
+            for (index in formats) {
+                formatsList.add(BarcodeFormats.values()[index].intValue)
+            }
+            barcodeScannerOptions = if (formatsList.size == 1) {
+                BarcodeScannerOptions.Builder().setBarcodeFormats(formatsList.first())
+                    .build()
+            } else {
+                BarcodeScannerOptions.Builder().setBarcodeFormats(
+                    formatsList.first(),
+                    *formatsList.subList(1, formatsList.size).toIntArray()
+                ).build()
+            }
+        }
+
+        val position =
+            if (facing == 0) CameraSelector.DEFAULT_FRONT_CAMERA else CameraSelector.DEFAULT_BACK_CAMERA
+
+        val detectionSpeed: DetectionSpeed = DetectionSpeed.values().first { it.intValue == speed}
+
+        try {
+            mobileScanner!!.start(barcodeScannerOptions, returnImage, position, torch, detectionSpeed, torchStateCallback, mobileScannerStartedCallback = {
+                result.success(mapOf(
+                    "textureId" to it.id,
+                    "size" to mapOf("width" to it.width, "height" to it.height),
+                    "torchable" to it.hasFlashUnit
+                ))
+            },
+                timeout.toLong())
+
+        } catch (e: AlreadyStarted) {
+            result.error(
+                "MobileScanner",
+                "Called start() while already started",
+                null
+            )
+        } catch (e: NoCamera) {
+            result.error(
+                "MobileScanner",
+                "No camera found or failed to open camera!",
+                null
+            )
+        } catch (e: TorchError) {
+            result.error(
+                "MobileScanner",
+                "Error occurred when setting torch!",
+                null
+            )
+        } catch (e: CameraError) {
+            result.error(
+                "MobileScanner",
+                "Error occurred when setting up camera!",
+                null
+            )
+        } catch (e: Exception) {
+            result.error(
+                "MobileScanner",
+                "Unknown error occurred..",
+                null
+            )
+        }
+    }
+
+    private fun stop(result: MethodChannel.Result) {
+        try {
+            mobileScanner!!.stop()
+            result.success(null)
+        } catch (e: AlreadyStopped) {
+            result.success(null)
+        }
+    }
+
+    private fun analyzeImage(call: MethodCall, result: MethodChannel.Result) {
+        analyzerResult = result
+        val uri = Uri.fromFile(File(call.arguments.toString()))
+        mobileScanner!!.analyzeImage(uri, analyzerCallback)
+    }
+
+    private fun toggleTorch(call: MethodCall, result: MethodChannel.Result) {
+        try {
+            mobileScanner!!.toggleTorch(call.arguments == 1)
+            result.success(null)
+        } catch (e: AlreadyStopped) {
+            result.error("MobileScanner", "Called toggleTorch() while stopped!", null)
+        }
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerPermissions.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerPermissions.kt
@@ -24,11 +24,6 @@ class MobileScannerPermissions {
         const val REQUEST_CODE = 0x0786
     }
 
-    interface PermissionsRegistry {
-        @SuppressWarnings("deprecation")
-        fun addListener(handler: RequestPermissionsResultListener)
-    }
-
     interface ResultCallback {
         fun onResult(errorCode: String?, errorDescription: String?)
     }
@@ -55,7 +50,7 @@ class MobileScannerPermissions {
     }
 
     fun requestPermission(activity: Activity,
-                          permissionsRegistry: PermissionsRegistry,
+                          addPermissionListener: (RequestPermissionsResultListener) -> Unit,
                           callback: ResultCallback) {
         if (ongoing) {
             callback.onResult(
@@ -79,7 +74,7 @@ class MobileScannerPermissions {
                     }
                 }
             )
-            permissionsRegistry.addListener(listener)
+            listener?.let { listener -> addPermissionListener(listener) }
         }
 
         ongoing = true

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerPermissions.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerPermissions.kt
@@ -1,0 +1,130 @@
+package dev.steenbakker.mobile_scanner
+
+import android.Manifest.permission
+import android.app.Activity
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener
+
+/**
+ * This class handles the camera permissions for the Mobile Scanner.
+ */
+class MobileScannerPermissions {
+    companion object {
+        const val CAMERA_ACCESS_DENIED = "CameraAccessDenied"
+        const val CAMERA_ACCESS_DENIED_MESSAGE = "Camera access permission was denied."
+        const val CAMERA_PERMISSIONS_REQUEST_ONGOING = "CameraPermissionsRequestOngoing"
+        const val CAMERA_PERMISSIONS_REQUEST_ONGOING_MESSAGE = "Another request is ongoing and multiple requests cannot be handled at once."
+
+        /**
+         * When the application's activity is [androidx.fragment.app.FragmentActivity], requestCode can only use the lower 16 bits.
+         * @see androidx.fragment.app.FragmentActivity.validateRequestPermissionsRequestCode
+         */
+        const val REQUEST_CODE = 0x0786
+    }
+
+    interface PermissionsRegistry {
+        @SuppressWarnings("deprecation")
+        fun addListener(handler: RequestPermissionsResultListener)
+    }
+
+    interface ResultCallback {
+        fun onResult(errorCode: String?, errorDescription: String?)
+    }
+
+    private var listener: RequestPermissionsResultListener? = null
+
+    fun getPermissionListener(): RequestPermissionsResultListener? {
+        return listener
+    }
+
+    private var ongoing: Boolean = false
+
+    fun hasCameraPermission(activity: Activity) : Int {
+        val hasPermission = ContextCompat.checkSelfPermission(
+            activity,
+            permission.CAMERA,
+        ) == PackageManager.PERMISSION_GRANTED
+
+        return if (hasPermission) {
+            1
+        } else {
+            0
+        }
+    }
+
+    fun requestPermission(activity: Activity,
+                          permissionsRegistry: PermissionsRegistry,
+                          callback: ResultCallback) {
+        if (ongoing) {
+            callback.onResult(
+                CAMERA_PERMISSIONS_REQUEST_ONGOING, CAMERA_PERMISSIONS_REQUEST_ONGOING_MESSAGE)
+            return
+        }
+
+        if(hasCameraPermission(activity) == 1) {
+            // Permissions already exist. Call the callback with success.
+            callback.onResult(null, null)
+            return
+        }
+
+        if(listener == null) {
+            // Keep track of the listener, so that it can be unregistered later.
+            listener = MobileScannerPermissionsListener(
+                object: ResultCallback {
+                    override fun onResult(errorCode: String?, errorDescription: String?) {
+                        ongoing = false
+                        callback.onResult(errorCode, errorDescription)
+                    }
+                }
+            )
+            permissionsRegistry.addListener(listener)
+        }
+
+        ongoing = true
+        ActivityCompat.requestPermissions(
+            activity,
+            arrayOf(permission.CAMERA),
+            REQUEST_CODE
+        )
+    }
+}
+
+/**
+ * This class handles incoming camera permission results.
+ */
+@SuppressWarnings("deprecation")
+private class MobileScannerPermissionsListener(
+    private val resultCallback: MobileScannerPermissions.ResultCallback,
+): RequestPermissionsResultListener {
+    // There's no way to unregister permission listeners in the v1 embedding, so we'll be called
+    // duplicate times in cases where the user denies and then grants a permission. Keep track of if
+    // we've responded before and bail out of handling the callback manually if this is a repeat
+    // call.
+    private var alreadyCalled: Boolean = false
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ): Boolean {
+        if (alreadyCalled || requestCode != MobileScannerPermissions.REQUEST_CODE) {
+            return false
+        }
+
+        alreadyCalled = true
+
+        // grantResults could be empty if the permissions request with the user is interrupted
+        // https://developer.android.com/reference/android/app/Activity#onRequestPermissionsResult(int,%20java.lang.String[],%20int[])
+        if (grantResults.isEmpty() || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
+            resultCallback.onResult(
+                MobileScannerPermissions.CAMERA_ACCESS_DENIED,
+                MobileScannerPermissions.CAMERA_ACCESS_DENIED_MESSAGE)
+        } else {
+            resultCallback.onResult(null, null)
+        }
+
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerPlugin.kt
@@ -1,92 +1,16 @@
 package dev.steenbakker.mobile_scanner
 
-import android.net.Uri
-import androidx.camera.core.CameraSelector
-import androidx.camera.core.ExperimentalGetImage
-import com.google.mlkit.vision.barcode.BarcodeScannerOptions
-import dev.steenbakker.mobile_scanner.objects.BarcodeFormats
-import dev.steenbakker.mobile_scanner.objects.DetectionSpeed
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
-import io.flutter.plugin.common.MethodCall
-import io.flutter.plugin.common.MethodChannel
-import java.io.File
 
 /** MobileScannerPlugin */
-class MobileScannerPlugin : FlutterPlugin, ActivityAware, MethodChannel.MethodCallHandler {
-
-    private var flutterPluginBinding: FlutterPlugin.FlutterPluginBinding? = null
+class MobileScannerPlugin : FlutterPlugin, ActivityAware {
     private var activityPluginBinding: ActivityPluginBinding? = null
-    private var handler: MobileScanner? = null
-    private var method: MethodChannel? = null
-
-    private lateinit var barcodeHandler: BarcodeHandler
-
-    private var analyzerResult: MethodChannel.Result? = null
-
-    private val callback: MobileScannerCallback = { barcodes: List<Map<String, Any?>>, image: ByteArray? ->
-        if (image != null) {
-            barcodeHandler.publishEvent(mapOf(
-                "name" to "barcode",
-                "data" to barcodes,
-                "image" to image
-            ))
-        } else {
-            barcodeHandler.publishEvent(mapOf(
-                "name" to "barcode",
-                "data" to barcodes
-            ))
-        }
-    }
-
-    private val analyzerCallback: AnalyzerCallback = { barcodes: List<Map<String, Any?>>?->
-        if (barcodes != null) {
-            barcodeHandler.publishEvent(mapOf(
-                "name" to "barcode",
-                "data" to barcodes
-            ))
-            analyzerResult?.success(true)
-        } else {
-            analyzerResult?.success(false)
-        }
-        analyzerResult = null
-    }
-
-    private val errorCallback: MobileScannerErrorCallback = {error: String ->
-        barcodeHandler.publishEvent(mapOf(
-            "name" to "error",
-            "data" to error,
-        ))
-    }
-
-    private val torchStateCallback: TorchStateCallback = {state: Int ->
-        barcodeHandler.publishEvent(mapOf("name" to "torchState", "data" to state))
-    }
-
-    @ExperimentalGetImage
-    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
-        if (handler == null) {
-            result.error("MobileScanner", "Called ${call.method} before initializing.", null)
-            return
-        }
-        when (call.method) {
-            "state" -> result.success(handler!!.hasCameraPermission())
-            "request" -> handler!!.requestPermission(result)
-            "start" -> start(call, result)
-            "torch" -> toggleTorch(call, result)
-            "stop" -> stop(result)
-            "analyzeImage" -> analyzeImage(call, result)
-            else -> result.notImplemented()
-        }
-    }
+    private var flutterPluginBinding: FlutterPlugin.FlutterPluginBinding? = null
+    private var methodCallHandler: MethodCallHandlerImpl? = null
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        method = MethodChannel(binding.binaryMessenger, "dev.steenbakker.mobile_scanner/scanner/method")
-        method!!.setMethodCallHandler(this)
-
-        barcodeHandler = BarcodeHandler(binding)
-
         this.flutterPluginBinding = binding
     }
 
@@ -95,124 +19,31 @@ class MobileScannerPlugin : FlutterPlugin, ActivityAware, MethodChannel.MethodCa
     }
 
     override fun onAttachedToActivity(activityPluginBinding: ActivityPluginBinding) {
-        handler = MobileScanner(activityPluginBinding.activity, flutterPluginBinding!!.textureRegistry, callback, errorCallback
+        val binaryMessenger = this.flutterPluginBinding!!.binaryMessenger
+
+        methodCallHandler = MethodCallHandlerImpl(
+            activityPluginBinding.activity,
+            BarcodeHandler(binaryMessenger),
+            binaryMessenger,
+            MobileScannerPermissions(),
+            activityPluginBinding::addRequestPermissionsResultListener,
+            this.flutterPluginBinding!!.textureRegistry,
         )
-        activityPluginBinding.addRequestPermissionsResultListener(handler!!)
 
         this.activityPluginBinding = activityPluginBinding
+    }
+
+    override fun onDetachedFromActivity() {
+        methodCallHandler?.dispose(this.activityPluginBinding!!)
+        methodCallHandler = null
+        activityPluginBinding = null
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
         onAttachedToActivity(binding)
     }
 
-    override fun onDetachedFromActivity() {
-        activityPluginBinding!!.removeRequestPermissionsResultListener(handler!!)
-        method!!.setMethodCallHandler(null)
-        method = null
-        handler = null
-        activityPluginBinding = null
-    }
-
     override fun onDetachedFromActivityForConfigChanges() {
         onDetachedFromActivity()
-    }
-
-    @ExperimentalGetImage
-    private fun start(call: MethodCall, result: MethodChannel.Result) {
-        val torch: Boolean = call.argument<Boolean>("torch") ?: false
-        val facing: Int = call.argument<Int>("facing") ?: 0
-        val formats: List<Int>? = call.argument<List<Int>>("formats")
-        val returnImage: Boolean = call.argument<Boolean>("returnImage") ?: false
-        val speed: Int = call.argument<Int>("speed") ?: 1
-        val timeout: Int = call.argument<Int>("timeout") ?: 250
-
-        var barcodeScannerOptions: BarcodeScannerOptions? = null
-        if (formats != null) {
-            val formatsList: MutableList<Int> = mutableListOf()
-            for (index in formats) {
-                formatsList.add(BarcodeFormats.values()[index].intValue)
-            }
-            barcodeScannerOptions = if (formatsList.size == 1) {
-                BarcodeScannerOptions.Builder().setBarcodeFormats(formatsList.first())
-                    .build()
-            } else {
-                BarcodeScannerOptions.Builder().setBarcodeFormats(
-                    formatsList.first(),
-                    *formatsList.subList(1, formatsList.size).toIntArray()
-                ).build()
-            }
-        }
-
-        val position =
-            if (facing == 0) CameraSelector.DEFAULT_FRONT_CAMERA else CameraSelector.DEFAULT_BACK_CAMERA
-
-        val detectionSpeed: DetectionSpeed = DetectionSpeed.values().first { it.intValue == speed}
-
-        try {
-            handler!!.start(barcodeScannerOptions, returnImage, position, torch, detectionSpeed, torchStateCallback, mobileScannerStartedCallback = {
-                result.success(mapOf(
-                    "textureId" to it.id,
-                    "size" to mapOf("width" to it.width, "height" to it.height),
-                    "torchable" to it.hasFlashUnit
-                ))
-            },
-                timeout.toLong())
-
-        } catch (e: AlreadyStarted) {
-            result.error(
-                "MobileScanner",
-            "Called start() while already started",
-                null
-            )
-        } catch (e: NoCamera) {
-            result.error(
-                "MobileScanner",
-                "No camera found or failed to open camera!",
-                null
-            )
-        } catch (e: TorchError) {
-            result.error(
-                "MobileScanner",
-                "Error occurred when setting torch!",
-                null
-            )
-        } catch (e: CameraError) {
-            result.error(
-                "MobileScanner",
-                "Error occurred when setting up camera!",
-                null
-            )
-        } catch (e: Exception) {
-            result.error(
-                "MobileScanner",
-                "Unknown error occurred..",
-                null
-            )
-        }
-    }
-
-    private fun stop(result: MethodChannel.Result) {
-        try {
-            handler!!.stop()
-            result.success(null)
-        } catch (e: AlreadyStopped) {
-            result.success(null)
-        }
-    }
-
-    private fun analyzeImage(call: MethodCall, result: MethodChannel.Result) {
-        analyzerResult = result
-        val uri = Uri.fromFile(File(call.arguments.toString()))
-        handler!!.analyzeImage(uri, analyzerCallback)
-    }
-
-    private fun toggleTorch(call: MethodCall, result: MethodChannel.Result) {
-        try {
-            handler!!.toggleTorch(call.arguments == 1)
-            result.success(null)
-        } catch (e: AlreadyStopped) {
-            result.error("MobileScanner", "Called toggleTorch() while stopped!", null)
-        }
     }
 }

--- a/example/lib/barcode_list_scanner_controller.dart
+++ b/example/lib/barcode_list_scanner_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:mobile_scanner_example/scanner_error_widget.dart';
 
 class BarcodeListScannerWithController extends StatefulWidget {
   const BarcodeListScannerWithController({Key? key}) : super(key: key);
@@ -25,7 +26,6 @@ class _BarcodeListScannerWithControllerState
   );
 
   bool isStarted = true;
-  MobileScannerException? exception;
 
   void _startOrStop() {
     if (isStarted) {
@@ -33,9 +33,7 @@ class _BarcodeListScannerWithControllerState
     } else {
       controller.start().catchError((error) {
         if (mounted) {
-          setState(() {
-            exception = error as MobileScannerException;
-          });
+          setState(() {});
         }
       });
     }
@@ -55,6 +53,9 @@ class _BarcodeListScannerWithControllerState
             children: [
               MobileScanner(
                 controller: controller,
+                errorBuilder: (context, error, child) {
+                  return ScannerErrorWidget(error: error);
+                },
                 fit: BoxFit.contain,
                 onDetect: (barcodeCapture) {
                   setState(() {

--- a/example/lib/barcode_list_scanner_controller.dart
+++ b/example/lib/barcode_list_scanner_controller.dart
@@ -25,23 +25,17 @@ class _BarcodeListScannerWithControllerState
   );
 
   bool isStarted = true;
+  MobileScannerException? exception;
 
   void _startOrStop() {
     if (isStarted) {
       controller.stop();
     } else {
       controller.start().catchError((error) {
-        final exception = error as MobileScannerException;
-
-        switch (exception.errorCode) {
-          case MobileScannerErrorCode.controllerUninitialized:
-            break; // This error code is not used by `start()`.
-          case MobileScannerErrorCode.genericError:
-            debugPrint('Scanner failed to start');
-            break;
-          case MobileScannerErrorCode.permissionDenied:
-            debugPrint('Camera permission denied');
-            break;
+        if (mounted) {
+          setState(() {
+            exception = error as MobileScannerException;
+          });
         }
       });
     }

--- a/example/lib/barcode_scanner_controller.dart
+++ b/example/lib/barcode_scanner_controller.dart
@@ -25,23 +25,17 @@ class _BarcodeScannerWithControllerState
   );
 
   bool isStarted = true;
+  MobileScannerException? exception;
 
   void _startOrStop() {
     if (isStarted) {
       controller.stop();
     } else {
       controller.start().catchError((error) {
-        final exception = error as MobileScannerException;
-
-        switch (exception.errorCode) {
-          case MobileScannerErrorCode.controllerUninitialized:
-            break; // This error code is not used by `start()`.
-          case MobileScannerErrorCode.genericError:
-            debugPrint('Scanner failed to start');
-            break;
-          case MobileScannerErrorCode.permissionDenied:
-            debugPrint('Camera permission denied');
-            break;
+        if (mounted) {
+          setState(() {
+            exception = error as MobileScannerException;
+          });
         }
       });
     }

--- a/example/lib/barcode_scanner_controller.dart
+++ b/example/lib/barcode_scanner_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:mobile_scanner_example/scanner_error_widget.dart';
 
 class BarcodeScannerWithController extends StatefulWidget {
   const BarcodeScannerWithController({Key? key}) : super(key: key);
@@ -25,7 +26,6 @@ class _BarcodeScannerWithControllerState
   );
 
   bool isStarted = true;
-  MobileScannerException? exception;
 
   void _startOrStop() {
     if (isStarted) {
@@ -33,9 +33,7 @@ class _BarcodeScannerWithControllerState
     } else {
       controller.start().catchError((error) {
         if (mounted) {
-          setState(() {
-            exception = error as MobileScannerException;
-          });
+          setState(() {});
         }
       });
     }
@@ -55,6 +53,9 @@ class _BarcodeScannerWithControllerState
             children: [
               MobileScanner(
                 controller: controller,
+                errorBuilder: (context, error, child) {
+                  return ScannerErrorWidget(error: error);
+                },
                 fit: BoxFit.contain,
                 onDetect: (barcode) {
                   setState(() {

--- a/example/lib/barcode_scanner_returning_image.dart
+++ b/example/lib/barcode_scanner_returning_image.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:mobile_scanner_example/scanner_error_widget.dart';
 
 class BarcodeScannerReturningImage extends StatefulWidget {
   const BarcodeScannerReturningImage({Key? key}) : super(key: key);
@@ -27,7 +28,6 @@ class _BarcodeScannerReturningImageState
   );
 
   bool isStarted = true;
-  MobileScannerException? exception;
 
   void _startOrStop() {
     if (isStarted) {
@@ -35,9 +35,7 @@ class _BarcodeScannerReturningImageState
     } else {
       controller.start().catchError((error) {
         if (mounted) {
-          setState(() {
-            exception = error as MobileScannerException;
-          });
+          setState(() {});
         }
       });
     }
@@ -77,6 +75,9 @@ class _BarcodeScannerReturningImageState
                   children: [
                     MobileScanner(
                       controller: controller,
+                      errorBuilder: (context, error, child) {
+                        return ScannerErrorWidget(error: error);
+                      },
                       fit: BoxFit.contain,
                       onDetect: (barcode) {
                         setState(() {

--- a/example/lib/barcode_scanner_returning_image.dart
+++ b/example/lib/barcode_scanner_returning_image.dart
@@ -27,23 +27,17 @@ class _BarcodeScannerReturningImageState
   );
 
   bool isStarted = true;
+  MobileScannerException? exception;
 
   void _startOrStop() {
     if (isStarted) {
       controller.stop();
     } else {
       controller.start().catchError((error) {
-        final exception = error as MobileScannerException;
-
-        switch (exception.errorCode) {
-          case MobileScannerErrorCode.controllerUninitialized:
-            break; // This error code is not used by `start()`.
-          case MobileScannerErrorCode.genericError:
-            debugPrint('Scanner failed to start');
-            break;
-          case MobileScannerErrorCode.permissionDenied:
-            debugPrint('Camera permission denied');
-            break;
+        if (mounted) {
+          setState(() {
+            exception = error as MobileScannerException;
+          });
         }
       });
     }

--- a/example/lib/barcode_scanner_without_controller.dart
+++ b/example/lib/barcode_scanner_without_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:mobile_scanner_example/scanner_error_widget.dart';
 
 class BarcodeScannerWithoutController extends StatefulWidget {
   const BarcodeScannerWithoutController({Key? key}) : super(key: key);
@@ -24,6 +25,9 @@ class _BarcodeScannerWithoutControllerState
             children: [
               MobileScanner(
                 fit: BoxFit.contain,
+                errorBuilder: (context, error, child) {
+                  return ScannerErrorWidget(error: error);
+                },
                 onDetect: (capture) {
                   setState(() {
                     this.capture = capture;

--- a/example/lib/scanner_error_widget.dart
+++ b/example/lib/scanner_error_widget.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+class ScannerErrorWidget extends StatelessWidget {
+  const ScannerErrorWidget({Key? key, required this.error}) : super(key: key);
+
+  final MobileScannerException error;
+
+  @override
+  Widget build(BuildContext context) {
+    String errorMessage;
+
+    switch (error.errorCode) {
+      case MobileScannerErrorCode.controllerUninitialized:
+        errorMessage = 'Controller not ready.';
+        break;
+      case MobileScannerErrorCode.permissionDenied:
+        errorMessage = 'Permission denied';
+        break;
+      default:
+        errorMessage = 'Generic Error';
+        break;
+    }
+
+    return ColoredBox(
+      color: Colors.black,
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Padding(
+              padding: EdgeInsets.only(bottom: 16),
+              child: Icon(Icons.error, color: Colors.white),
+            ),
+            Text(
+              errorMessage,
+              style: const TextStyle(color: Colors.white),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -7,6 +7,13 @@ import 'package:mobile_scanner/src/mobile_scanner_exception.dart';
 import 'package:mobile_scanner/src/objects/barcode_capture.dart';
 import 'package:mobile_scanner/src/objects/mobile_scanner_arguments.dart';
 
+/// The function signature for the error builder.
+typedef MobileScannerErrorBuilder = Widget Function(
+  BuildContext,
+  MobileScannerException,
+  Widget?,
+);
+
 /// The [MobileScanner] widget displays a live camera preview.
 class MobileScanner extends StatefulWidget {
   /// The controller that manages the barcode scanner.
@@ -19,7 +26,7 @@ class MobileScanner extends StatefulWidget {
   ///
   /// If this is null, defaults to a black [ColoredBox]
   /// with a centered white [Icons.error] icon.
-  final Widget Function(BuildContext, Object, Widget?)? errorBuilder;
+  final MobileScannerErrorBuilder? errorBuilder;
 
   /// The [BoxFit] for the camera preview.
   ///

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -226,7 +226,7 @@ class _MobileScannerState extends State<MobileScanner>
           valueListenable: _controller.startArguments,
           builder: (context, value, child) {
             if (value == null) {
-                return __buildPlaceholderOrError(context, child);
+              return __buildPlaceholderOrError(context, child);
             }
 
             if (widget.scanWindow != null) {

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -159,14 +159,23 @@ class MobileScannerController {
           .values[await _methodChannel.invokeMethod('state') as int? ?? 0];
       switch (state) {
         case MobileScannerState.undetermined:
-          final bool result =
-              await _methodChannel.invokeMethod('request') as bool? ?? false;
-          if (!result) {
-            isStarting = false;
+          try {
+            final bool result =
+                await _methodChannel.invokeMethod('request') as bool? ?? false;
+
+            if (!result) {
+              throw const MobileScannerException(
+                errorCode: MobileScannerErrorCode.permissionDenied,
+              );
+            }
+          } catch (error) {
             throw const MobileScannerException(
-              errorCode: MobileScannerErrorCode.permissionDenied,
+              errorCode: MobileScannerErrorCode.genericError,
             );
+          } finally {
+            isStarting = false;
           }
+
           break;
         case MobileScannerState.denied:
           isStarting = false;

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -159,21 +159,23 @@ class MobileScannerController {
           .values[await _methodChannel.invokeMethod('state') as int? ?? 0];
       switch (state) {
         case MobileScannerState.undetermined:
-          try {
-            final bool result =
-                await _methodChannel.invokeMethod('request') as bool? ?? false;
+          bool result = false;
 
-            if (!result) {
-              throw const MobileScannerException(
-                errorCode: MobileScannerErrorCode.permissionDenied,
-              );
-            }
+          try {
+            result =
+                await _methodChannel.invokeMethod('request') as bool? ?? false;
           } catch (error) {
+            isStarting = false;
             throw const MobileScannerException(
               errorCode: MobileScannerErrorCode.genericError,
             );
-          } finally {
+          }
+
+          if (!result) {
             isStarting = false;
+            throw const MobileScannerException(
+              errorCode: MobileScannerErrorCode.permissionDenied,
+            );
           }
 
           break;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal barcode and QR code scanner for Flutter based on MLKit. Uses CameraX on Android, AVFoundation on iOS and Apple Vision & AVFoundation on macOS.
-version: 3.0.0-beta.3
+version: 3.0.0-beta.4
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 environment:


### PR DESCRIPTION
This PR fixes #402

It also cleans up the plugin internals a bit:
- The `MobileScannerPlugin.kt` file now only handles Activity lifecycle things.
- The permission handling code was moved to its own class
- The method call handler was moved to its own class
- The barcode handler now only requires the BinaryMessenger instead of the entire binding
- Updates the example app to properly display permission errors in the UI
- Adds a new `errorBuilder` argument to the mobile scanner widget
