### PR TITLE
feat(iOS): Support the most recent camera device types

### DIFF
--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -122,7 +122,11 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
         textureId = registry?.register(self)
 
         // Open the camera device
-        if #available(iOS 10.0, *) {
+        if #available(iOS 13.0, *) {
+            device = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInTripleCamera, .builtInDualWideCamera, .builtInDualCamera, .builtInWideAngleCamera], mediaType: .video, position: cameraPosition).devices.first
+        } else if #available(iOS 10.2, *) {
+            device = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInDualCamera, .builtInWideAngleCamera], mediaType: .video, position: cameraPosition).devices.first
+        } else if #available(iOS 10.0, *) {
             device = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: .video, position: cameraPosition).devices.first
         } else {
             device = AVCaptureDevice.devices(for: .video).filter({$0.position == cameraPosition}).first


### PR DESCRIPTION
closes #468

I didn't notice a scanning speed enhancement, but users can now focus and scan from closer distances on iPhone 12, 13, and 14. Specific to iPhone14, I was actually able to find barcodes of a particular size and distortion that required this feature in order to be scanned at all.