### PR TITLE
feat(iOS): Tweak iOS camera focus settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+Improvements:
+* [iOS] No longer automatically focus on faces
+
 ## 3.0.0
 This big release contains all improvements from the beta releases.
 In addition to that, this release contains:

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -124,12 +124,8 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
         // Open the camera device
         if #available(iOS 13.0, *) {
             device = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInTripleCamera, .builtInDualWideCamera, .builtInDualCamera, .builtInWideAngleCamera], mediaType: .video, position: cameraPosition).devices.first
-        } else if #available(iOS 10.2, *) {
-            device = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInDualCamera, .builtInWideAngleCamera], mediaType: .video, position: cameraPosition).devices.first
-        } else if #available(iOS 10.0, *) {
-            device = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: .video, position: cameraPosition).devices.first
         } else {
-            device = AVCaptureDevice.devices(for: .video).filter({$0.position == cameraPosition}).first
+            device = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInDualCamera, .builtInWideAngleCamera], mediaType: .video, position: cameraPosition).devices.first
         }
 
         if (device == nil) {

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -133,6 +133,17 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
         }
 
         device.addObserver(self, forKeyPath: #keyPath(AVCaptureDevice.torchMode), options: .new, context: nil)
+        do {
+            try device.lockForConfiguration()
+            if device.isFocusModeSupported(focusMode: .continuousAutoFocus) {
+                device.focusMode = .continuousAutoFocus
+            }
+            if #available(iOS 15.4, *) {
+                device.automaticallyAdjustsFaceDrivenAutoFocusEnabled = false
+            }
+            device.unlockForConfiguration()
+        } catch {}
+
         captureSession.beginConfiguration()
 
         // Add device input


### PR DESCRIPTION
- Disable face-driven autofocus on iOS 15.4+
- Enable continuous autofocus if available
