### PR TITLE
fix: Initialize subscription for any autoStart value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,153 +1,191 @@
+## 3.0.1
+
+Fixes:
+
+- Fixes a bug where scanning did not work at all when using `autoStart:false`
+
 ## 3.0.0
+
 This big release contains all improvements from the beta releases.
 In addition to that, this release contains:
 
 Improvements:
-* Fixed an issue in which the scanner would freeze if two scanner widgets where placed in a page view,
-and the paged was swiped. An example has been added in the example app.
-You need to set startDelay: true if used in a page view.
-* [Web] Automatically inject js libraries.
-* [macOS] The minimum build version is now macOS 10.14 in according to the latest Flutter version.
-* [Android] Fixed an issue in which the scanWindow would remain even after disposing the scanner.
-* Updated dependencies.
+
+- Fixed an issue in which the scanner would freeze if two scanner widgets where placed in a page view,
+  and the paged was swiped. An example has been added in the example app.
+  You need to set startDelay: true if used in a page view.
+- [Web] Automatically inject js libraries.
+- [macOS] The minimum build version is now macOS 10.14 in according to the latest Flutter version.
+- [Android] Fixed an issue in which the scanWindow would remain even after disposing the scanner.
+- Updated dependencies.
 
 ## 3.0.0-beta.4
+
 Fixes:
-* Fixes a permission bug on Android where denying the permission would cause an infinite loop of permission requests.
-* Updates the example app to handle permission errors with the new builder parameter.
+
+- Fixes a permission bug on Android where denying the permission would cause an infinite loop of permission requests.
+- Updates the example app to handle permission errors with the new builder parameter.
   Now it no longer throws uncaught exceptions when the permission is denied.
-* Updated several dependencies
+- Updated several dependencies
 
 Features:
-* Added a new `errorBuilder` to the `MobileScanner` widget that can be used to customize the error state of the preview. (Thanks @navaronbracke !) 
+
+- Added a new `errorBuilder` to the `MobileScanner` widget that can be used to customize the error state of the preview. (Thanks @navaronbracke !)
 
 ## 3.0.0-beta.3
+
 Deprecated:
-* The `onStart` method has been renamed to `onScannerStarted`.
-* The `onPermissionSet` argument of the `MobileScannerController` is now deprecated.
+
+- The `onStart` method has been renamed to `onScannerStarted`.
+- The `onPermissionSet` argument of the `MobileScannerController` is now deprecated.
 
 Breaking changes:
-* `MobileScannerException` now uses an `errorCode` instead of a `message`.
-* `MobileScannerException` now contains additional details from the original error.
-* Refactored `MobileScannerController.start()` to throw `MobileScannerException`s
+
+- `MobileScannerException` now uses an `errorCode` instead of a `message`.
+- `MobileScannerException` now contains additional details from the original error.
+- Refactored `MobileScannerController.start()` to throw `MobileScannerException`s
   with consistent error codes, rather than string messages.
   To handle permission errors, consider catching the result of `MobileScannerController.start()`.
-* The `autoResume` attribute has been removed from the `MobileScanner` widget.
+- The `autoResume` attribute has been removed from the `MobileScanner` widget.
   The controller already automatically resumes, so it had no effect.
-* Removed `MobileScannerCallback` and `MobileScannerArgumentsCallback` typedef.
-* [Web] Replaced `jsqr` library with `zxing-js` for full barcode support.
+- Removed `MobileScannerCallback` and `MobileScannerArgumentsCallback` typedef.
+- [Web] Replaced `jsqr` library with `zxing-js` for full barcode support.
 
 Improvements:
-* Toggling the device torch now does nothing if the device has no torch, rather than throwing an error.
-* Removed `called stop while already stopped` messages.
+
+- Toggling the device torch now does nothing if the device has no torch, rather than throwing an error.
+- Removed `called stop while already stopped` messages.
 
 Features:
-* You can now provide a `scanWindow` to the `MobileScanner()` widget.
-* You can now draw an overlay over the scanned barcode. See the barcode scanner window in the example app for more information.
-* Added a new `placeholderBuilder` function to the `MobileScanner` widget to customize the preview placeholder.
-* Added `autoStart` parameter to MobileScannerController(). If set to false, controller won't start automatically.
-* Added `hasTorch` function on MobileScannerController(). After starting the controller, you can check if the device has a torch.
-* [iOS] Support `torchEnabled` parameter from MobileScannerController() on iOS
-* [Web] Added ability to use custom barcode scanning js libraries 
+
+- You can now provide a `scanWindow` to the `MobileScanner()` widget.
+- You can now draw an overlay over the scanned barcode. See the barcode scanner window in the example app for more information.
+- Added a new `placeholderBuilder` function to the `MobileScanner` widget to customize the preview placeholder.
+- Added `autoStart` parameter to MobileScannerController(). If set to false, controller won't start automatically.
+- Added `hasTorch` function on MobileScannerController(). After starting the controller, you can check if the device has a torch.
+- [iOS] Support `torchEnabled` parameter from MobileScannerController() on iOS
+- [Web] Added ability to use custom barcode scanning js libraries
   by extending `WebBarcodeReaderBase` class and changing `barCodeReader` property in `MobileScannerWebPlugin`
 
 Fixes:
-* Fixes the missing gradle setup for the Android project, which prevented gradle sync from working.
-* Fixes `MobileScannerController.stop()` throwing when already stopped.
-* Fixes `MobileScannerController.toggleTorch()` throwing if the device has no torch.
+
+- Fixes the missing gradle setup for the Android project, which prevented gradle sync from working.
+- Fixes `MobileScannerController.stop()` throwing when already stopped.
+- Fixes `MobileScannerController.toggleTorch()` throwing if the device has no torch.
   Now it does nothing if the torch is not available.
-* Fixes a memory leak where the `MobileScanner` would keep listening to the barcode events.
-* Fixes the `MobileScanner` preview depending on all attributes of `MediaQueryData`.
+- Fixes a memory leak where the `MobileScanner` would keep listening to the barcode events.
+- Fixes the `MobileScanner` preview depending on all attributes of `MediaQueryData`.
   Now it only depends on its layout constraints.
-* Fixed a potential crash when the scanner is restarted due to the app being resumed.
-* [iOS] Fix crash when changing torch state
-  
+- Fixed a potential crash when the scanner is restarted due to the app being resumed.
+- [iOS] Fix crash when changing torch state
+
 ## 3.0.0-beta.2
+
 Breaking changes:
-* The arguments parameter of onDetect is removed. The data is now returned by the onStart callback
-in the MobileScanner widget.
-* onDetect now returns the object BarcodeCapture, which contains a List of barcodes and, if enabled, an image.
-* allowDuplicates is removed and replaced by MobileScannerSpeed enum.
-* onPermissionSet in MobileScanner widget is deprecated and will be removed. Use the onPermissionSet
-onPermissionSet callback in MobileScannerController instead.
-* [iOS] The minimum deployment target is now 11.0 or higher.
+
+- The arguments parameter of onDetect is removed. The data is now returned by the onStart callback
+  in the MobileScanner widget.
+- onDetect now returns the object BarcodeCapture, which contains a List of barcodes and, if enabled, an image.
+- allowDuplicates is removed and replaced by MobileScannerSpeed enum.
+- onPermissionSet in MobileScanner widget is deprecated and will be removed. Use the onPermissionSet
+  onPermissionSet callback in MobileScannerController instead.
+- [iOS] The minimum deployment target is now 11.0 or higher.
 
 Features:
-* The returnImage is working for both iOS and Android. You can enable it in the MobileScannerController.
-The image will be returned in the BarcodeCapture object provided by onDetect.
-* You can now control the DetectionSpeed, as well as the timeout of the DetectionSpeed. For more
-info see the DetectionSpeed documentation. This replaces the allowDuplicates function.
+
+- The returnImage is working for both iOS and Android. You can enable it in the MobileScannerController.
+  The image will be returned in the BarcodeCapture object provided by onDetect.
+- You can now control the DetectionSpeed, as well as the timeout of the DetectionSpeed. For more
+  info see the DetectionSpeed documentation. This replaces the allowDuplicates function.
 
 Other improvements:
-* Both the [iOS] and [Android] codebases have been refactored completely.
-* [iOS] Updated POD dependencies
+
+- Both the [iOS] and [Android] codebases have been refactored completely.
+- [iOS] Updated POD dependencies
 
 ## 3.0.0-beta.1
+
 Breaking changes:
-* [Android] SDK updated to SDK 33.
+
+- [Android] SDK updated to SDK 33.
 
 Features:
-* [Web] Add binaryData for raw value.
-* [iOS] Captures the last scanned barcode with Barcode.image.
-* [iOS] Add support for multiple formats on iOS with BarcodeScannerOptions.
-* Add displayValue which returns barcode value in a user-friendly format.
-* Add autoResume option to MobileScannerController which automatically resumes the camera when the application is resumed
+
+- [Web] Add binaryData for raw value.
+- [iOS] Captures the last scanned barcode with Barcode.image.
+- [iOS] Add support for multiple formats on iOS with BarcodeScannerOptions.
+- Add displayValue which returns barcode value in a user-friendly format.
+- Add autoResume option to MobileScannerController which automatically resumes the camera when the application is resumed
 
 Other changes:
-* [Android] Revert camera2 dependency to stable release
-* [iOS] Update barcode scanning library to latest version
-* Several minor code improvements
+
+- [Android] Revert camera2 dependency to stable release
+- [iOS] Update barcode scanning library to latest version
+- Several minor code improvements
 
 ## 2.0.0
+
 Breaking changes:
 This version is only compatible with flutter 3.0.0 and later.
 
 ## 1.1.2-play-services
+
 This version uses the MLKit play-services model on Android in order to save space.
 With the example app, this version reduces the release version from 14.9MB to 7MB.
 More information: https://developers.google.com/ml-kit/vision/barcode-scanning/android
 
 ## 1.1.2
+
 This version is the last version that will run on Flutter 2.x
 
 Bugfixes:
-* Changed onDetect to be mandatory.
+
+- Changed onDetect to be mandatory.
 
 ## 1.1.1-play-services
+
 This version uses the MLKit play-services model on Android in order to save space.
 With the example app, this version reduces the release version from 14.9MB to 7MB.
 More information: https://developers.google.com/ml-kit/vision/barcode-scanning/android
 
 ## 1.1.1
+
 Bugfixes:
-* Add null checks for Android.
-* Update camera dependency for Android.
-* Fix return type for analyzeImage.
-* Add fixes for Flutter 3.
+
+- Add null checks for Android.
+- Update camera dependency for Android.
+- Fix return type for analyzeImage.
+- Add fixes for Flutter 3.
 
 ## 1.1.0
+
 Bugfixes:
-* Fix for 'stream already listened to' exception.
-* Fix building on Android with latest Flutter version.
-* Add several WEB improvements.
-* Upgraded several dependencies.
+
+- Fix for 'stream already listened to' exception.
+- Fix building on Android with latest Flutter version.
+- Add several WEB improvements.
+- Upgraded several dependencies.
 
 ## 1.0.0
+
 BREAKING CHANGES:
 This version adds a new allowDuplicates option which now defaults to FALSE. this means that it will only call onDetect once after a scan.
 If you still want duplicates, you can set allowDuplicates to true.
 This also means that you don't have to check for duplicates yourself anymore.
 
 New features:
-* We now have web support! Keep in mind that only QR codes are supported right now.
+
+- We now have web support! Keep in mind that only QR codes are supported right now.
 
 Bugfixes:
-* Fixed hot reload not working.
-* Fixed Navigator.of(context).pop() not working in the example app due to duplicate MaterialApp declaration.
-* Fixed iOS MLKit version not resolving the latest version.
-* Updated all dependencies
+
+- Fixed hot reload not working.
+- Fixed Navigator.of(context).pop() not working in the example app due to duplicate MaterialApp declaration.
+- Fixed iOS MLKit version not resolving the latest version.
+- Updated all dependencies
 
 ## 0.2.0
+
 You can provide a path to controller.analyzeImage(path) in order to scan a local photo from the gallery!
 Check out the example app to see how you can use the image_picker plugin to retrieve a photo from
 the gallery. Please keep in mind that this feature is only supported on Android and iOS.
@@ -156,42 +194,54 @@ Another feature that has been added is a format selector!
 Just keep in mind that iOS for now only supports 1 selected barcode.
 
 ## 0.1.3
-* Fixed crash after asking permission. [#29](https://github.com/juliansteenbakker/mobile_scanner/issues/29)
-* Upgraded cameraX from 1.1.0-beta01 to 1.1.0-beta02
+
+- Fixed crash after asking permission. [#29](https://github.com/juliansteenbakker/mobile_scanner/issues/29)
+- Upgraded cameraX from 1.1.0-beta01 to 1.1.0-beta02
 
 ## 0.1.2
-* MobileScannerArguments is now exported. [#7](https://github.com/juliansteenbakker/mobile_scanner/issues/7)
+
+- MobileScannerArguments is now exported. [#7](https://github.com/juliansteenbakker/mobile_scanner/issues/7)
 
 Bugfixes:
-* Fixed application crashing when stop() or start() is called multiple times. [#5](https://github.com/juliansteenbakker/mobile_scanner/issues/5)
-* Fixes controller not being disposed correctly. [#23](https://github.com/juliansteenbakker/mobile_scanner/issues/23)
-* Catch error when no camera is found. [#19](https://github.com/juliansteenbakker/mobile_scanner/issues/19)
+
+- Fixed application crashing when stop() or start() is called multiple times. [#5](https://github.com/juliansteenbakker/mobile_scanner/issues/5)
+- Fixes controller not being disposed correctly. [#23](https://github.com/juliansteenbakker/mobile_scanner/issues/23)
+- Catch error when no camera is found. [#19](https://github.com/juliansteenbakker/mobile_scanner/issues/19)
 
 ## 0.1.1
+
 mobile_scanner is now compatible with sdk >= 2.12 and flutter >= 2.2.0
 
 ## 0.1.0
+
 We now have MacOS support using Apple's Vision framework!
 Keep in mind that for now, only the raw value of the barcode object is supported.
 
 Bugfixes:
-* Fixed a crash when dispose is called in a overridden method. [#5](https://github.com/juliansteenbakker/mobile_scanner/issues/5) 
+
+- Fixed a crash when dispose is called in a overridden method. [#5](https://github.com/juliansteenbakker/mobile_scanner/issues/5)
 
 ## 0.0.3
-* Added some API docs and README
-* Updated the example app
+
+- Added some API docs and README
+- Updated the example app
 
 ## 0.0.2
+
 Fixed on iOS:
-* You can now set the torch
-* You can select the camera you want to use
+
+- You can now set the torch
+- You can select the camera you want to use
 
 ## 0.0.1
+
 Initial release!
 Things working on Android:
-* Scanning barcodes using the latest version of MLKit and CameraX!
-* Switching camera's
-* Toggling of the torch (flash)
+
+- Scanning barcodes using the latest version of MLKit and CameraX!
+- Switching camera's
+- Toggling of the torch (flash)
 
 Things working on iOS:
-* Scanning barcodes using the latest version of MLKit and AVFoundation!
+
+- Scanning barcodes using the latest version of MLKit and AVFoundation!

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -116,16 +116,16 @@ class _MobileScannerState extends State<MobileScanner>
       await Future.delayed(const Duration(seconds: 1, milliseconds: 500));
     }
 
+    _barcodesSubscription = _controller.barcodes.listen(
+      widget.onDetect,
+    );
+
     if (!_controller.autoStart) {
       debugPrint(
         'mobile_scanner: not starting automatically because autoStart is set to false in the controller.',
       );
       return;
     }
-
-    _barcodesSubscription = _controller.barcodes.listen(
-      widget.onDetect,
-    );
 
     _controller.start().then((arguments) {
       // ignore: deprecated_member_use_from_same_package

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal barcode and QR code scanner for Flutter based on MLKit. Uses CameraX on Android, AVFoundation on iOS and Apple Vision & AVFoundation on macOS.
-version: 3.0.0
+version: 3.0.1
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 environment:
@@ -13,7 +13,6 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   js: ^0.6.3
-
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
As also reported in https://github.com/juliansteenbakker/mobile_scanner/issues/499, and from our own usage of `mobile_scanner: 3.0.0`, I noticed that the `_barcodesSubscription` is not initialized when `autoStart: false` was used. 

This PR fixes this problem bei always initializing the subscription. This should not have any adverse effects as the actual `_controller.start()` call is still coming after the autoStart check.

VS-Code also applied default formatting for Markdown files, which I hope is no problem :) 