### PR TITLE
fix: Fix bad `AVCaptureDevice.isFocusModeSupported` call

### DIFF
--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -135,7 +135,7 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
         device.addObserver(self, forKeyPath: #keyPath(AVCaptureDevice.torchMode), options: .new, context: nil)
         do {
             try device.lockForConfiguration()
-            if device.isFocusModeSupported(focusMode: .continuousAutoFocus) {
+            if device.isFocusModeSupported(.continuousAutoFocus) {
                 device.focusMode = .continuousAutoFocus
             }
             if #available(iOS 15.4, *) {


### PR DESCRIPTION
Evidently I was testing against a cached old commit when I was testing this change, and the change in [#500](https://github.com/juliansteenbakker/mobile_scanner/pull/500) has code that doesn't compile.