### PR TITLE
fix: Do not return image if returnImage is false / not specified.

### DIFF
--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -130,7 +130,7 @@ class MobileScannerController {
         arguments['formats'] = formats!.map((e) => e.index).toList();
       }
     }
-    arguments['returnImage'] = true;
+    arguments['returnImage'] = returnImage;
     return arguments;
   }
 


### PR DESCRIPTION
This PR avoids the error in #426 in the case `returnImage` is specified as null. Also, it actually fixes the intended behavior of the `returnImage` argument. 