### PR TITLE
Fix: iOS front camera switching crash issue

### DIFF
--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -138,7 +138,7 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
             if device.isFocusModeSupported(.continuousAutoFocus) {
                 device.focusMode = .continuousAutoFocus
             }
-            if #available(iOS 15.4, *) {
+            if #available(iOS 15.4, *) , device.isFocusModeSupported(.autoFocus){
                 device.automaticallyAdjustsFaceDrivenAutoFocusEnabled = false
             }
             device.unlockForConfiguration()


### PR DESCRIPTION
This PR Fixes #543 & #542

This issue was caused since `device.automaticallyAdjustsFaceDrivenAutoFocusEnabled` as being executed without checking if autofocus mode is present in the selected camera device. Which caused it to fail on fewer iOS modes.

Adding a check like `device.isFocusModeSupported(.autoFocus)` with the required iOS version was solution to the issue.
