### PR TITLE
fix "SwiftMobileScannerPlugin.swift:41:43: generic parameter 'ElementOfResult' could not be inferred"

### DIFF
--- a/ios/Classes/SwiftMobileScannerPlugin.swift
+++ b/ios/Classes/SwiftMobileScannerPlugin.swift
@@ -36,7 +36,7 @@ public class SwiftMobileScannerPlugin: NSObject, FlutterPlugin {
     }
     
     init(barcodeHandler: BarcodeHandler, registry: FlutterTextureRegistry) {
-        self.mobileScanner = MobileScanner(registry: registry, mobileScannerCallback: { barcodes, error, image in
+        self.mobileScanner = MobileScanner(registry: registry, mobileScannerCallback: { (barcodes:Array<Barcode>?, error:Error?, image:UIImage) in
             if barcodes != nil {
                 let barcodesMap = barcodes!.compactMap { barcode in
                     if (SwiftMobileScannerPlugin.scanWindow != nil) {


### PR DESCRIPTION
fix "SwiftMobileScannerPlugin.swift:41:43: generic parameter 'ElementOfResult' could not be inferred"

Related to the following questions
https://github.com/juliansteenbakker/mobile_scanner/issues/544
https://github.com/juliansteenbakker/mobile_scanner/issues/489
https://github.com/juliansteenbakker/mobile_scanner/issues/432