### PR TITLE
fix: Use MediaQuery.sizeOf(context) instead of topmost LayoutBuilder

### DIFF
--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -259,9 +259,8 @@ class _MobileScannerState extends State<MobileScanner>
                     size: constraints.biggest,
                     child: FittedBox(
                       fit: widget.fit,
-                      child: SizedBox(
-                        width: value.size.width,
-                        height: value.size.height,
+                      child: SizedBox.fromSize(
+                        size: value.size,
                         child: kIsWeb
                             ? HtmlElementView(viewType: value.webId!)
                             : Texture(textureId: value.textureId!),

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -232,45 +232,43 @@ class _MobileScannerState extends State<MobileScanner>
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return ValueListenableBuilder<MobileScannerArguments?>(
-          valueListenable: _controller.startArguments,
-          builder: (context, value, child) {
-            if (value == null) {
-              return _buildPlaceholderOrError(context, child);
-            }
+    final Size size = MediaQuery.sizeOf(context);
 
-            if (widget.scanWindow != null && scanWindow == null) {
-              scanWindow = calculateScanWindowRelativeToTextureInPercentage(
-                widget.fit,
-                widget.scanWindow!,
-                value.size,
-                constraints.biggest,
+    return ValueListenableBuilder<MobileScannerArguments?>(
+      valueListenable: _controller.startArguments,
+      builder: (context, value, child) {
+        if (value == null) {
+          return _buildPlaceholderOrError(context, child);
+        }
+
+        if (widget.scanWindow != null && scanWindow == null) {
+          scanWindow = calculateScanWindowRelativeToTextureInPercentage(
+            widget.fit,
+            widget.scanWindow!,
+            value.size,
+            size,
+          );
+
+          _controller.updateScanWindow(scanWindow);
+        }
+
+        return ClipRect(
+          child: LayoutBuilder(
+            builder: (_, constraints) {
+              return SizedBox.fromSize(
+                size: constraints.biggest,
+                child: FittedBox(
+                  fit: widget.fit,
+                  child: SizedBox.fromSize(
+                    size: value.size,
+                    child: kIsWeb
+                        ? HtmlElementView(viewType: value.webId!)
+                        : Texture(textureId: value.textureId!),
+                  ),
+                ),
               );
-
-              _controller.updateScanWindow(scanWindow);
-            }
-
-            return ClipRect(
-              child: LayoutBuilder(
-                builder: (_, constraints) {
-                  return SizedBox.fromSize(
-                    size: constraints.biggest,
-                    child: FittedBox(
-                      fit: widget.fit,
-                      child: SizedBox.fromSize(
-                        size: value.size,
-                        child: kIsWeb
-                            ? HtmlElementView(viewType: value.webId!)
-                            : Texture(textureId: value.textureId!),
-                      ),
-                    ),
-                  );
-                },
-              ),
-            );
-          },
+            },
+          ),
         );
       },
     );

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -246,7 +246,7 @@ class _MobileScannerState extends State<MobileScanner>
                 widget.fit,
                 widget.scanWindow!,
                 value.size,
-                Size(constraints.maxWidth, constraints.maxHeight),
+                constraints.biggest,
               );
 
               _controller.updateScanWindow(scanWindow);


### PR DESCRIPTION
This PR fixes an issue where `IntrinsicHeight` could not be used for the placeholder / error builder.

It also cleans up minor usages of the `Size` class.

- Addresses https://github.com/juliansteenbakker/mobile_scanner/pull/373#discussion_r1148913892

cc @saibotma Is this what you were referring to?