### PR TITLE
feat: Improvements about zoom scale value and ultra-wide camera

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -138,6 +138,7 @@ class MobileScanner(
         torch: Boolean,
         detectionSpeed: DetectionSpeed,
         torchStateCallback: TorchStateCallback,
+        zoomScaleStateCallback: ZoomScaleStateCallback,
         mobileScannerStartedCallback: MobileScannerStartedCallback,
         detectionTimeout: Long
     ) {
@@ -199,6 +200,11 @@ class MobileScanner(
             camera!!.cameraInfo.torchState.observe(activity) { state ->
                 // TorchState.OFF = 0; TorchState.ON = 1
                 torchStateCallback(state)
+            }
+
+            // Register the zoom scale listener
+            camera!!.cameraInfo.zoomState.observe(activity) { state ->
+                zoomScaleStateCallback(state.linearZoom.toDouble())
             }
 
 

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -289,4 +289,13 @@ class MobileScanner(
         camera!!.cameraControl.setLinearZoom(scale.toFloat())
     }
 
+    /**
+     * Reset the zoom rate of the camera.
+     */
+    fun resetScale() {
+        if (camera == null) throw ZoomWhenStopped()
+        camera!!.cameraControl.setZoomRatio(1f)
+    }
+
+
 }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -297,5 +297,4 @@ class MobileScanner(
         camera!!.cameraControl.setZoomRatio(1f)
     }
 
-
 }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerCallbacks.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerCallbacks.kt
@@ -6,4 +6,5 @@ typealias MobileScannerCallback = (barcodes: List<Map<String, Any?>>, image: Byt
 typealias AnalyzerCallback = (barcodes: List<Map<String, Any?>>?) -> Unit
 typealias MobileScannerErrorCallback = (error: String) -> Unit
 typealias TorchStateCallback = (state: Int) -> Unit
+typealias ZoomScaleStateCallback = (zoomScale: Double) -> Unit
 typealias MobileScannerStartedCallback = (parameters: MobileScannerStartParameters) -> Unit

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -74,7 +74,6 @@ class MobileScannerHandler(
         barcodeHandler.publishEvent(mapOf("name" to "zoomScaleState", "data" to zoomScale))
     }
 
-
     init {
         methodChannel = MethodChannel(binaryMessenger,
             "dev.steenbakker.mobile_scanner/scanner/method")
@@ -240,7 +239,7 @@ class MobileScannerHandler(
             mobileScanner!!.resetScale()
             result.success(null)
         } catch (e: ZoomWhenStopped) {
-            result.error("MobileScanner", "Called setScale() while stopped!", null)
+            result.error("MobileScanner", "Called resetScale() while stopped!", null)
         }
     }
 

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -120,6 +120,7 @@ class MobileScannerHandler(
             "stop" -> stop(result)
             "analyzeImage" -> analyzeImage(call, result)
             "setScale" -> setScale(call, result)
+            "resetScale" -> resetScale(call, result)
             "updateScanWindow" -> updateScanWindow(call)
             else -> result.notImplemented()
         }
@@ -231,6 +232,15 @@ class MobileScannerHandler(
             result.error("MobileScanner", "Called setScale() while stopped!", null)
         } catch (e: ZoomNotInRange) {
             result.error("MobileScanner", "Scale should be within 0 and 1", null)
+        }
+    }
+
+    private fun resetScale(call: MethodCall, result: MethodChannel.Result) {
+        try {
+            mobileScanner!!.resetScale()
+            result.success(null)
+        } catch (e: ZoomWhenStopped) {
+            result.error("MobileScanner", "Called setScale() while stopped!", null)
         }
     }
 

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -70,6 +70,11 @@ class MobileScannerHandler(
         barcodeHandler.publishEvent(mapOf("name" to "torchState", "data" to state))
     }
 
+    private val zoomScaleStateCallback: ZoomScaleStateCallback = {zoomScale: Double ->
+        barcodeHandler.publishEvent(mapOf("name" to "zoomScaleState", "data" to zoomScale))
+    }
+
+
     init {
         methodChannel = MethodChannel(binaryMessenger,
             "dev.steenbakker.mobile_scanner/scanner/method")
@@ -152,7 +157,7 @@ class MobileScannerHandler(
         val detectionSpeed: DetectionSpeed = DetectionSpeed.values().first { it.intValue == speed}
 
         try {
-            mobileScanner!!.start(barcodeScannerOptions, returnImage, position, torch, detectionSpeed, torchStateCallback, mobileScannerStartedCallback = {
+            mobileScanner!!.start(barcodeScannerOptions, returnImage, position, torch, detectionSpeed, torchStateCallback, zoomScaleStateCallback, mobileScannerStartedCallback = {
                 result.success(mapOf(
                     "textureId" to it.id,
                     "size" to mapOf("width" to it.width, "height" to it.height),

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -204,6 +204,13 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
         } catch {
             print("Failed to set initial torch state.")
         }
+
+        do {
+            try resetScale()
+        } catch {
+            print("Failed to reset zoom scale")
+        }
+
         let dimensions = CMVideoFormatDescriptionGetDimensions(device.activeFormat.formatDescription)
 
         return MobileScannerStartParameters(width: Double(dimensions.height), height: Double(dimensions.width), hasTorch: device.hasTorch, textureId: textureId)

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -286,7 +286,7 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
             actualScale = min(maxZoomFactor, actualScale)
             
             // Limit to 1.0 scale
-            device.ramp(toVideoZoomFactor: actualScale, withRate: 5)
+            device.videoZoomFactor = actualScale
             device.unlockForConfiguration()
         } catch {
             throw MobileScannerError.zoomError(error)

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -40,7 +40,6 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
     /// When zoom scale is changes, this callback will be called
     let zoomScaleChangeCallback: ZoomScaleChangeCallback
 
-
     /// If provided, the Flutter registry will be used to send the output of the CaptureOutput to a Flutter texture.
     private let registry: FlutterTextureRegistry?
 

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -294,10 +294,10 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
         
     }
 
-    /// Set the zoom factor of the camera
+    /// Reset the zoom factor of the camera
     func resetScale() throws {
         if (device == nil) {
-            throw MobileScannerError.torchWhenStopped
+            throw MobileScannerError.zoomWhenStopped
         }
 
         do {

--- a/ios/Classes/SwiftMobileScannerPlugin.swift
+++ b/ios/Classes/SwiftMobileScannerPlugin.swift
@@ -87,6 +87,8 @@ public class SwiftMobileScannerPlugin: NSObject, FlutterPlugin {
             analyzeImage(call, result)
         case "setScale":
             setScale(call, result)
+        case "resetScale":
+            resetScale(call, result)
         case "updateScanWindow":
             updateScanWindow(call, result)
         default:
@@ -189,7 +191,28 @@ public class SwiftMobileScannerPlugin: NSObject, FlutterPlugin {
         }
         result(nil)
     }
-    
+
+    /// Reset the zoomScale
+    private func resetScale(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        do {
+            try mobileScanner.resetScale()
+        } catch MobileScannerError.zoomWhenStopped {
+            result(FlutterError(code: "MobileScanner",
+                                message: "Called resetScale() while stopped!",
+                                details: nil))
+        } catch MobileScannerError.zoomError(let error) {
+            result(FlutterError(code: "MobileScanner",
+                                message: "Error while zooming.",
+                                details: error))
+        } catch {
+            result(FlutterError(code: "MobileScanner",
+                                message: "Error while zooming.",
+                                details: nil))
+        }
+        result(nil)
+    }
+
+
     /// Toggles the torch
     func updateScanWindow(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let scanWindowData: Array? = (call.arguments as? [String: Any])?["rect"] as? [CGFloat]

--- a/ios/Classes/SwiftMobileScannerPlugin.swift
+++ b/ios/Classes/SwiftMobileScannerPlugin.swift
@@ -57,6 +57,8 @@ public class SwiftMobileScannerPlugin: NSObject, FlutterPlugin {
             }
         }, torchModeChangeCallback: { torchState in
             barcodeHandler.publishEvent(["name": "torchState", "data": torchState])
+        }, zoomScaleChangeCallback: { zoomScale in
+            barcodeHandler.publishEvent(["name": "zoomScaleState", "data": zoomScale])
         })
         self.barcodeHandler = barcodeHandler
         super.init()

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -88,7 +88,6 @@ class MobileScannerController {
   /// A notifier that provides zoomScale.
   final ValueNotifier<double> zoomScaleState = ValueNotifier(0.0);
 
-
   bool isStarting = false;
 
   /// A notifier that provides availability of the Torch (Flash)
@@ -326,7 +325,6 @@ class MobileScannerController {
   Future<void> resetZoomScale() async {
     await _methodChannel.invokeMethod('resetScale');
   }
-
 
   /// Disposes the MobileScannerController and closes all listeners.
   ///

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -322,6 +322,12 @@ class MobileScannerController {
     await _methodChannel.invokeMethod('setScale', zoomScale);
   }
 
+  /// Reset the zoomScale of the camera to use standard scale 1x.
+  Future<void> resetZoomScale() async {
+    await _methodChannel.invokeMethod('resetScale');
+  }
+
+
   /// Disposes the MobileScannerController and closes all listeners.
   ///
   /// If you call this, you cannot use this controller object anymore.

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -85,6 +85,10 @@ class MobileScannerController {
   late final ValueNotifier<CameraFacing> cameraFacingState =
       ValueNotifier(facing);
 
+  /// A notifier that provides zoomScale.
+  final ValueNotifier<double> zoomScaleState = ValueNotifier(0.0);
+
+
   bool isStarting = false;
 
   /// A notifier that provides availability of the Torch (Flash)
@@ -336,6 +340,9 @@ class MobileScannerController {
       case 'torchState':
         final state = TorchState.values[data as int? ?? 0];
         torchState.value = state;
+        break;
+      case 'zoomScaleState':
+        zoomScaleState.value = data as double? ?? 0.0;
         break;
       case 'barcode':
         if (data == null) return;


### PR DESCRIPTION
This PR is for improvements zoom scale feature, especially for avoiding to select ultra wide camera unintentionally. Please review and merge if looks good.

## New features

* added `zoomScale` value notifier in MobileScannerController for the application to know the zoom scale value set actually.  
  The value is notified from the native SDK(CameraX/AVFoundation).

* added `resetZoomScale()` in MobileScannerController to reset zoom ratio with 1x.  
  Both Android and iOS, if the device have ultra-wide camera, calling `setZoomScale` with small value causes to use ultra-wide camera and may be diffcult to detect barcodes.
  `resetZoomScale()` is useful to use standard camera with zoom 1x.
  `setZoomScale()` with the specific value can realize same effect, but added `resetZoomScale` for avoiding floating point errors.
  The application can know what zoom scale value is selected actually by subscribing `zoomScale` above after calling `resetZoomScale`.


## Changed behaviors

* (iOS only) call `resetZoomScale` while starting scan.
  Android camera is initialized with a zoom of 1x, whereas iOS is initialized with the minimum zoom value, which causes to select the ultra-wide camera unintentionally (#554).
  Fixed this issue by calling `resetZoomScale`

* (iOS only) remove zoom animation with `ramp` function to match Android behavior. 