### PR TITLE
fix: Add namespace to mobile_scanner for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+Bugs fixed:
+* [Android] Fix Gradle 8 compatibility by adding the `namespace` attribute to the build.gradle.
+
 ## 3.2.0
 Improvements:
 * [iOS] Updated GoogleMLKit/BarcodeScanning to 4.0.0 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,8 @@ android {
     defaultConfig {
         minSdkVersion 21
     }
+
+    namespace 'dev.steenbakker.mobile_scanner'
 }
 
 dependencies {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal barcode and QR code scanner for Flutter based on MLKit. Uses CameraX on Android, AVFoundation on iOS and Apple Vision & AVFoundation on macOS.
-version: 3.2.0
+version: 3.2.1
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 environment:


### PR DESCRIPTION
This PR adds the `namespace` attribute to `mobile_scanner`'s build.gradle. The `package` attribute is left in the Manifest for now, as it is required for older projects that do not recognise the new namespace attribute.

The example app already had its namespace attribute set, so that is left as-is.

Fixes #602 