### PR TITLE
Fix Zxing UNPKG reference

### DIFF
--- a/lib/src/web/zxing.dart
+++ b/lib/src/web/zxing.dart
@@ -170,7 +170,7 @@ extension JsZXingBrowserMultiFormatReaderExt
 
 const zxingJsLibrary = JsLibrary(
   contextName: 'ZXing',
-  url: 'https://unpkg.com/@zxing/library@0.19.1/umd/index.min.js',
+  url: 'https://unpkg.com/@zxing/library@0.19.1/esm/index.min.js',
   usesRequireJs: true,
 );
 

--- a/lib/src/web/zxing.dart
+++ b/lib/src/web/zxing.dart
@@ -170,7 +170,7 @@ extension JsZXingBrowserMultiFormatReaderExt
 
 const zxingJsLibrary = JsLibrary(
   contextName: 'ZXing',
-  url: 'https://unpkg.com/@zxing/library@0.20.0/esm/index.js',
+  url: 'https://unpkg.com/@zxing/library@0.19.1/esm/index.js',
   usesRequireJs: true,
 );
 

--- a/lib/src/web/zxing.dart
+++ b/lib/src/web/zxing.dart
@@ -170,7 +170,7 @@ extension JsZXingBrowserMultiFormatReaderExt
 
 const zxingJsLibrary = JsLibrary(
   contextName: 'ZXing',
-  url: 'https://unpkg.com/@zxing/library@0.19.1/esm/index.min.js',
+  url: 'https://unpkg.com/@zxing/library@0.19.3/esm',
   usesRequireJs: true,
 );
 

--- a/lib/src/web/zxing.dart
+++ b/lib/src/web/zxing.dart
@@ -170,7 +170,7 @@ extension JsZXingBrowserMultiFormatReaderExt
 
 const zxingJsLibrary = JsLibrary(
   contextName: 'ZXing',
-  url: 'https://unpkg.com/@zxing/library@0.19.1/esm/index.js',
+  url: 'https://unpkg.com/@zxing/library@0.19.3/umd/index.min.js',
   usesRequireJs: true,
 );
 

--- a/lib/src/web/zxing.dart
+++ b/lib/src/web/zxing.dart
@@ -170,7 +170,7 @@ extension JsZXingBrowserMultiFormatReaderExt
 
 const zxingJsLibrary = JsLibrary(
   contextName: 'ZXing',
-  url: 'https://unpkg.com/@zxing/library@0.19.1/esm',
+  url: 'https://unpkg.com/@zxing/library@0.20.0/esm/index.js',
   usesRequireJs: true,
 );
 

--- a/lib/src/web/zxing.dart
+++ b/lib/src/web/zxing.dart
@@ -170,7 +170,7 @@ extension JsZXingBrowserMultiFormatReaderExt
 
 const zxingJsLibrary = JsLibrary(
   contextName: 'ZXing',
-  url: 'https://unpkg.com/@zxing/library@0.20.0',
+  url: 'https://unpkg.com/@zxing/library@0.19.1/umd/index.min.js',
   usesRequireJs: true,
 );
 

--- a/lib/src/web/zxing.dart
+++ b/lib/src/web/zxing.dart
@@ -170,7 +170,7 @@ extension JsZXingBrowserMultiFormatReaderExt
 
 const zxingJsLibrary = JsLibrary(
   contextName: 'ZXing',
-  url: 'https://unpkg.com/@zxing/library@0.19.1',
+  url: 'https://unpkg.com/@zxing/library@0.20.0',
   usesRequireJs: true,
 );
 

--- a/lib/src/web/zxing.dart
+++ b/lib/src/web/zxing.dart
@@ -170,7 +170,7 @@ extension JsZXingBrowserMultiFormatReaderExt
 
 const zxingJsLibrary = JsLibrary(
   contextName: 'ZXing',
-  url: 'https://unpkg.com/@zxing/library@0.19.3/esm',
+  url: 'https://unpkg.com/@zxing/library@0.19.1/esm',
   usesRequireJs: true,
 );
 


### PR DESCRIPTION
Will fix #625 and #622.

UNPKG resolves to UMD packages now by default if unspecified. Enforces ESM package usage + update patch version to 0.19.3.