### PR TITLE
fix: Remove -n option from format command

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           cache: true
       - name: Format
-        run: dart format -n --set-exit-if-changed .
+        run: dart format --set-exit-if-changed .

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,7 @@
 include: package:lint/analysis_options_package.yaml
+
+linter:
+  rules:
+    - combinators_ordering
+    - require_trailing_commas
+    - unnecessary_library_directive

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -1,5 +1,3 @@
-library mobile_scanner;
-
 export 'src/enums/camera_facing.dart';
 export 'src/enums/detection_speed.dart';
 export 'src/enums/mobile_scanner_error_code.dart';

--- a/lib/mobile_scanner_web.dart
+++ b/lib/mobile_scanner_web.dart
@@ -1,5 +1,3 @@
-library mobile_scanner_web;
-
 export 'src/web/base.dart';
 export 'src/web/jsqr.dart';
 export 'src/web/zxing.dart';

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -18,8 +18,9 @@ class MobileScannerController {
     this.torchEnabled = false,
     this.formats,
     this.returnImage = false,
-    @Deprecated('Instead, use the result of calling `start()` to determine if permissions were granted.')
-        this.onPermissionSet,
+    @Deprecated(
+        'Instead, use the result of calling `start()` to determine if permissions were granted.')
+    this.onPermissionSet,
     this.autoStart = true,
   });
 

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -19,7 +19,8 @@ class MobileScannerController {
     this.formats,
     this.returnImage = false,
     @Deprecated(
-        'Instead, use the result of calling `start()` to determine if permissions were granted.')
+      'Instead, use the result of calling `start()` to determine if permissions were granted.',
+    )
     this.onPermissionSet,
     this.autoStart = true,
   });

--- a/lib/src/web/utils.dart
+++ b/lib/src/web/utils.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:html' as html;
-import 'dart:js' show context, JsObject;
+import 'dart:js' show JsObject, context;
 
 import 'package:mobile_scanner/src/web/base.dart';
 

--- a/test/mobile_scanner_test.dart
+++ b/test/mobile_scanner_test.dart
@@ -7,12 +7,20 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
-      return '42';
-    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        return '42';
+      },
+    );
   });
 
   tearDown(() {
-    channel.setMockMethodCallHandler(null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      channel,
+      null,
+    );
   });
 }


### PR DESCRIPTION
This fixes the format command in CI, as the `-n` option is not supported by `dart format`.
It also fixes the analysis failures in CI.

See also https://github.com/juliansteenbakker/mobile_scanner/pull/651#discussion_r1210305593

cc @teolemon 