### PR TITLE
feat: In the `SurfacePreview`, ensure the camera is not stopped

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -208,6 +208,10 @@ class MobileScanner(
 
             // Preview
             val surfaceProvider = Preview.SurfaceProvider { request ->
+                if (isStopped()) {
+                    return@SurfaceProvider
+                }
+
                 val texture = textureEntry!!.surfaceTexture()
                 texture.setDefaultBufferSize(
                     request.resolution.width,
@@ -270,7 +274,7 @@ class MobileScanner(
      * Stop barcode scanning.
      */
     fun stop() {
-        if (camera == null && preview == null) {
+        if (isStopped()) {
             throw AlreadyStopped()
         }
 
@@ -284,6 +288,8 @@ class MobileScanner(
         textureEntry = null
         cameraProvider = null
     }
+
+    private fun isStopped() = camera == null && preview == null
 
     /**
      * Toggles the flash light on or off.


### PR DESCRIPTION
Hello,

In some rare cases, the callback of the `SurfaceProvider` may be call after the camera is stopped.
In that case, `textureEntry` is null, generating a `NullPointerException` (#666)
 
This PR ensure that the camera is not stopped in the callback.