### PR TITLE
fix: macos build error

### DIFF
--- a/macos/Classes/MobileScannerPlugin.swift
+++ b/macos/Classes/MobileScannerPlugin.swift
@@ -108,7 +108,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         latestBuffer = imageBuffer
         registry.textureFrameAvailable(textureId)
         
-        let currentTime = Date.now.timeIntervalSince1970
+        let currentTime = Date().timeIntervalSince1970
         let eligibleForScan = currentTime > nextScanTime && imagesCurrentlyBeingProcessed == 0;
         if ((detectionSpeed == DetectionSpeed.normal || detectionSpeed == DetectionSpeed.noDuplicates) && eligibleForScan || detectionSpeed == DetectionSpeed.unrestricted) {
             nextScanTime = currentTime + timeoutSeconds
@@ -118,7 +118,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                 orientation: .right)
             
                 do {
-                  try imageRequestHandler.perform([VNDetectBarcodesRequest { (request, error) in
+                  try imageRequestHandler.perform([VNDetectBarcodesRequest { [self] (request, error) in
                     imagesCurrentlyBeingProcessed -= 1
                       if error == nil {
                           if let results = request.results as? [VNBarcodeObservation] {
@@ -225,8 +225,8 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         let facing: Int = argReader.int(key: "facing") ?? 1
         let speed: Int = (call.arguments as! Dictionary<String, Any?>)["speed"] as? Int ?? 0
         let timeoutMs: Int = (call.arguments as! Dictionary<String, Any?>)["timeout"] as? Int ?? 0
-        
-        timeoutSeconds = timeoutMs * 1000.0
+
+        timeoutSeconds = Double(timeoutMs) * 1000.0
         detectionSpeed = DetectionSpeed(rawValue: speed)!
 
         // Set the camera to use


### PR DESCRIPTION
Fix some macOS build errors:

- Date.now (https://developer.apple.com/documentation/foundation/date/3766590-now) is only available in macOS 12.0 and above while Date.init() (https://developer.apple.com/documentation/foundation/date/1780470-init) is available in macOS 10.10 and above
- Int must be explicitly converted to Double
- self must be specified explicitly to access imagesCurrentlyBeingProcessed in closure