### PR TITLE
fix: Adapt app lifecycle states. In Android would the permission pop …

### DIFF
--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -167,7 +167,6 @@ class _MobileScannerState extends State<MobileScanner>
         }
         break;
       case AppLifecycleState.paused:
-        _resumeFromBackground = true;
         break;
       case AppLifecycleState.inactive:
         _resumeFromBackground = true;

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -162,16 +162,16 @@ class _MobileScannerState extends State<MobileScanner>
 
     switch (state) {
       case AppLifecycleState.resumed:
-        _resumeFromBackground = false;
-        _startScanner();
+        if (_resumeFromBackground) {
+          _startScanner();
+        }
         break;
       case AppLifecycleState.paused:
         _resumeFromBackground = true;
         break;
       case AppLifecycleState.inactive:
-        if (!_resumeFromBackground) {
-          _controller.stop();
-        }
+        _resumeFromBackground = true;
+        _controller.stop();
         break;
       case AppLifecycleState.detached:
         break;


### PR DESCRIPTION
The App Lifecycle States do not work correctly on Android. 

When the permission popup appears and the user denies the camera permission it would trigger the resumed lifecycle that would start the controller and invokes the permission pop up again.

The variable names are confusing because the inactive lifecycle does not relate with the _resumeFromBackground. But it needs to be true, because the controller is stopped anyway.

The code can be taken as reference and rewritten in a cleaner way.