### PR TITLE
fix: Reworked scan window calculation

### DIFF
--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -6,6 +6,7 @@ import 'package:mobile_scanner/src/mobile_scanner_controller.dart';
 import 'package:mobile_scanner/src/mobile_scanner_exception.dart';
 import 'package:mobile_scanner/src/objects/barcode_capture.dart';
 import 'package:mobile_scanner/src/objects/mobile_scanner_arguments.dart';
+import 'package:mobile_scanner/src/scan_window_calculation.dart';
 
 /// The function signature for the error builder.
 typedef MobileScannerErrorBuilder = Widget Function(
@@ -173,75 +174,6 @@ class _MobileScannerState extends State<MobileScanner>
       default:
         break;
     }
-  }
-
-  /// the [scanWindow] rect will be relative and scaled to the [widgetSize] not the texture. so it is possible,
-  /// depending on the [fit], for the [scanWindow] to partially or not at all overlap the [textureSize]
-  ///
-  /// since when using a [BoxFit] the content will always be centered on its parent. we can convert the rect
-  /// to be relative to the texture.
-  ///
-  /// since the textures size and the actuall image (on the texture size) might not be the same, we also need to
-  /// calculate the scanWindow in terms of percentages of the texture, not pixels.
-  Rect calculateScanWindowRelativeToTextureInPercentage(
-    BoxFit fit,
-    Rect scanWindow,
-    Size textureSize,
-    Size widgetSize,
-  ) {
-    double fittedTextureWidth;
-    double fittedTextureHeight;
-
-    switch (fit) {
-      case BoxFit.contain:
-        final widthRatio = widgetSize.width / textureSize.width;
-        final heightRatio = widgetSize.height / textureSize.height;
-        final scale = widthRatio < heightRatio ? widthRatio : heightRatio;
-        fittedTextureWidth = textureSize.width * scale;
-        fittedTextureHeight = textureSize.height * scale;
-        break;
-
-      case BoxFit.cover:
-        final widthRatio = widgetSize.width / textureSize.width;
-        final heightRatio = widgetSize.height / textureSize.height;
-        final scale = widthRatio > heightRatio ? widthRatio : heightRatio;
-        fittedTextureWidth = textureSize.width * scale;
-        fittedTextureHeight = textureSize.height * scale;
-        break;
-
-      case BoxFit.fill:
-        fittedTextureWidth = widgetSize.width;
-        fittedTextureHeight = widgetSize.height;
-        break;
-
-      case BoxFit.fitHeight:
-        final ratio = widgetSize.height / textureSize.height;
-        fittedTextureWidth = textureSize.width * ratio;
-        fittedTextureHeight = widgetSize.height;
-        break;
-
-      case BoxFit.fitWidth:
-        final ratio = widgetSize.width / textureSize.width;
-        fittedTextureWidth = widgetSize.width;
-        fittedTextureHeight = textureSize.height * ratio;
-        break;
-
-      case BoxFit.none:
-      case BoxFit.scaleDown:
-        fittedTextureWidth = textureSize.width;
-        fittedTextureHeight = textureSize.height;
-        break;
-    }
-
-    final offsetX = (widgetSize.width - fittedTextureWidth) / 2;
-    final offsetY = (widgetSize.height - fittedTextureHeight) / 2;
-
-    final left = (scanWindow.left - offsetX) / fittedTextureWidth;
-    final top = (scanWindow.top - offsetY) / fittedTextureHeight;
-    final right = (scanWindow.right - offsetX) / fittedTextureWidth;
-    final bottom = (scanWindow.bottom - offsetY) / fittedTextureHeight;
-
-    return Rect.fromLTRB(left, top, right, bottom);
   }
 
   Rect? scanWindow;

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -248,36 +248,38 @@ class _MobileScannerState extends State<MobileScanner>
 
   @override
   Widget build(BuildContext context) {
-    final Size size = MediaQuery.of(context).size;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return ValueListenableBuilder<MobileScannerArguments?>(
+          valueListenable: _controller.startArguments,
+          builder: (context, value, child) {
+            if (value == null) {
+              return _buildPlaceholderOrError(context, child);
+            }
 
-    return ValueListenableBuilder<MobileScannerArguments?>(
-      valueListenable: _controller.startArguments,
-      builder: (context, value, child) {
-        if (value == null) {
-          return _buildPlaceholderOrError(context, child);
-        }
+            if (widget.scanWindow != null && scanWindow == null) {
+              scanWindow = calculateScanWindowRelativeToTextureInPercentage(
+                widget.fit,
+                widget.scanWindow!,
+                value.size,
+                constraints.biggest,
+              );
 
-        if (widget.scanWindow != null && scanWindow == null) {
-          scanWindow = calculateScanWindowRelativeToTextureInPercentage(
-            widget.fit,
-            widget.scanWindow!,
-            value.size,
-            size,
-          );
-
-          _controller.updateScanWindow(scanWindow);
-        }
-        if (widget.overlay != null) {
-          return Stack(
-            alignment: Alignment.center,
-            children: [
-              _scanner(value.size, value.webId, value.textureId),
-              widget.overlay!
-            ],
-          );
-        } else {
-          return _scanner(value.size, value.webId, value.textureId);
-        }
+              _controller.updateScanWindow(scanWindow);
+            }
+            if (widget.overlay != null) {
+              return Stack(
+                alignment: Alignment.center,
+                children: [
+                  _scanner(value.size, value.webId, value.textureId),
+                  widget.overlay!
+                ],
+              );
+            } else {
+              return _scanner(value.size, value.webId, value.textureId);
+            }
+          },
+        );
       },
     );
   }

--- a/lib/src/scan_window_calculation.dart
+++ b/lib/src/scan_window_calculation.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/rendering.dart';
+
+/// the [scanWindow] rect will be relative and scaled to the [widgetSize] not the texture. so it is possible,
+/// depending on the [fit], for the [scanWindow] to partially or not at all overlap the [textureSize]
+///
+/// since when using a [BoxFit] the content will always be centered on its parent. we can convert the rect
+/// to be relative to the texture.
+///
+/// since the textures size and the actuall image (on the texture size) might not be the same, we also need to
+/// calculate the scanWindow in terms of percentages of the texture, not pixels.
+Rect calculateScanWindowRelativeToTextureInPercentage(
+  BoxFit fit,
+  Rect scanWindow,
+  Size textureSize,
+  Size widgetSize,
+) {
+  double fittedTextureWidth;
+  double fittedTextureHeight;
+
+  switch (fit) {
+    case BoxFit.contain:
+      final widthRatio = widgetSize.width / textureSize.width;
+      final heightRatio = widgetSize.height / textureSize.height;
+      final scale = widthRatio < heightRatio ? widthRatio : heightRatio;
+      fittedTextureWidth = textureSize.width * scale;
+      fittedTextureHeight = textureSize.height * scale;
+      break;
+
+    case BoxFit.cover:
+      final widthRatio = widgetSize.width / textureSize.width;
+      final heightRatio = widgetSize.height / textureSize.height;
+      final scale = widthRatio > heightRatio ? widthRatio : heightRatio;
+      fittedTextureWidth = textureSize.width * scale;
+      fittedTextureHeight = textureSize.height * scale;
+      break;
+
+    case BoxFit.fill:
+      fittedTextureWidth = widgetSize.width;
+      fittedTextureHeight = widgetSize.height;
+      break;
+
+    case BoxFit.fitHeight:
+      final ratio = widgetSize.height / textureSize.height;
+      fittedTextureWidth = textureSize.width * ratio;
+      fittedTextureHeight = widgetSize.height;
+      break;
+
+    case BoxFit.fitWidth:
+      final ratio = widgetSize.width / textureSize.width;
+      fittedTextureWidth = widgetSize.width;
+      fittedTextureHeight = textureSize.height * ratio;
+      break;
+
+    case BoxFit.none:
+    case BoxFit.scaleDown:
+      fittedTextureWidth = textureSize.width;
+      fittedTextureHeight = textureSize.height;
+      break;
+  }
+
+  final offsetX = (widgetSize.width - fittedTextureWidth) / 2;
+  final offsetY = (widgetSize.height - fittedTextureHeight) / 2;
+
+  final left = (scanWindow.left - offsetX) / fittedTextureWidth;
+  final top = (scanWindow.top - offsetY) / fittedTextureHeight;
+  final right = (scanWindow.right - offsetX) / fittedTextureWidth;
+  final bottom = (scanWindow.bottom - offsetY) / fittedTextureHeight;
+
+  return Rect.fromLTRB(left, top, right, bottom);
+}

--- a/test/scan_window_test.dart
+++ b/test/scan_window_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/scan_window_calculation.dart';
+
+void main() {
+  group('Scan window relative to texture', () {
+    group('Widget (landscape) smaller than texture (portrait)', () {
+      const textureSize = Size(480.0, 640.0);
+      const widgetSize = Size(432.0, 256.0);
+      final ctx = ScanWindowTestContext(
+        textureSize: textureSize,
+        widgetSize: widgetSize,
+        scanWindow: Rect.fromLTWH(
+          widgetSize.width / 4,
+          widgetSize.height / 4,
+          widgetSize.width / 2,
+          widgetSize.height / 2,
+        ),
+      );
+
+      test('wl tp: BoxFit.none', () {
+        ctx.testScanWindow(BoxFit.none, const Rect.fromLTRB(0.275, 0.4, 0.725, 0.6));
+      });
+
+      test('wl tp: BoxFit.fill', () {
+        ctx.testScanWindow(BoxFit.fill, const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75));
+      });
+
+      test('wl tp: BoxFit.fitHeight', () {
+        ctx.testScanWindow(BoxFit.fitHeight, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+      });
+
+      test('wl tp: BoxFit.fitWidth', () {
+        ctx.testScanWindow(BoxFit.fitWidth, const Rect.fromLTRB(0.25, 0.38888888888888895, 0.75, 0.6111111111111112));
+      });
+
+      test('wl tp: BoxFit.cover', () {
+        // equal to fitWidth
+        ctx.testScanWindow(BoxFit.cover, const Rect.fromLTRB(0.25, 0.38888888888888895, 0.75, 0.6111111111111112));
+      });
+
+      test('wl tp: BoxFit.contain', () {
+        // equal to fitHeigth
+        ctx.testScanWindow(BoxFit.contain, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+      });
+
+      test('wl tp: BoxFit.scaleDown', () {
+        // equal to fitHeigth, contain
+        ctx.testScanWindow(BoxFit.scaleDown, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+      });
+    });
+
+    group('Widget (landscape) smaller than texture and texture (landscape)', () {
+      const textureSize = Size(640.0, 480.0);
+      const widgetSize = Size(320.0, 120.0);
+      final ctx = ScanWindowTestContext(
+        textureSize: textureSize,
+        widgetSize: widgetSize,
+        scanWindow: Rect.fromLTWH(
+          widgetSize.width / 4,
+          widgetSize.height / 4,
+          widgetSize.width / 2,
+          widgetSize.height / 2,
+        ),
+      );
+
+      test('wl tl: BoxFit.none', () {
+        ctx.testScanWindow(BoxFit.none, const Rect.fromLTRB(0.375, 0.4375, 0.625, 0.5625));
+      });
+
+      test('wl tl: BoxFit.fill', () {
+        ctx.testScanWindow(BoxFit.fill, const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75));
+      });
+
+      test('wl tl: BoxFit.fitHeight', () {
+        ctx.testScanWindow(BoxFit.fitHeight, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+      });
+
+      test('wl tl: BoxFit.fitWidth', () {
+        ctx.testScanWindow(BoxFit.fitWidth, const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625));
+      });
+
+      test('wl tl: BoxFit.cover', () {
+        // equal to fitWidth
+        ctx.testScanWindow(BoxFit.cover, const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625));
+      });
+
+      test('wl tl: BoxFit.contain', () {
+        // equal to fitHeigth
+        ctx.testScanWindow(BoxFit.contain, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+      });
+
+      test('wl tl: BoxFit.scaleDown', () {
+        // equal to fitHeigth, contain
+        ctx.testScanWindow(BoxFit.scaleDown, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+      });
+    });
+  });
+}
+
+class ScanWindowTestContext {
+  final Size textureSize;
+  final Size widgetSize;
+  final Rect scanWindow;
+
+  ScanWindowTestContext({
+    required this.textureSize,
+    required this.widgetSize,
+    required this.scanWindow,
+  });
+
+  void testScanWindow(BoxFit fit, Rect expected) {
+    final actual = calculateScanWindowRelativeToTextureInPercentage(
+      fit,
+      scanWindow,
+      textureSize,
+      widgetSize,
+    );
+
+    // don't use expect(actual, expected) because Rect.toString() only shows one digit after the comma which can be confusing
+    expect(actual.left, expected.left);
+    expect(actual.top, expected.top);
+    expect(actual.right, expected.right);
+    expect(actual.bottom, expected.bottom);
+  }
+}

--- a/test/scan_window_test.dart
+++ b/test/scan_window_test.dart
@@ -19,38 +19,50 @@ void main() {
       );
 
       test('wl tp: BoxFit.none', () {
-        ctx.testScanWindow(BoxFit.none, const Rect.fromLTRB(0.275, 0.4, 0.725, 0.6));
+        ctx.testScanWindow(
+            BoxFit.none, const Rect.fromLTRB(0.275, 0.4, 0.725, 0.6));
       });
 
       test('wl tp: BoxFit.fill', () {
-        ctx.testScanWindow(BoxFit.fill, const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75));
+        ctx.testScanWindow(
+            BoxFit.fill, const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75));
       });
 
       test('wl tp: BoxFit.fitHeight', () {
-        ctx.testScanWindow(BoxFit.fitHeight, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+        ctx.testScanWindow(
+            BoxFit.fitHeight, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
       });
 
       test('wl tp: BoxFit.fitWidth', () {
-        ctx.testScanWindow(BoxFit.fitWidth, const Rect.fromLTRB(0.25, 0.38888888888888895, 0.75, 0.6111111111111112));
+        ctx.testScanWindow(
+            BoxFit.fitWidth,
+            const Rect.fromLTRB(
+                0.25, 0.38888888888888895, 0.75, 0.6111111111111112));
       });
 
       test('wl tp: BoxFit.cover', () {
         // equal to fitWidth
-        ctx.testScanWindow(BoxFit.cover, const Rect.fromLTRB(0.25, 0.38888888888888895, 0.75, 0.6111111111111112));
+        ctx.testScanWindow(
+            BoxFit.cover,
+            const Rect.fromLTRB(
+                0.25, 0.38888888888888895, 0.75, 0.6111111111111112));
       });
 
       test('wl tp: BoxFit.contain', () {
         // equal to fitHeigth
-        ctx.testScanWindow(BoxFit.contain, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+        ctx.testScanWindow(
+            BoxFit.contain, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
       });
 
       test('wl tp: BoxFit.scaleDown', () {
         // equal to fitHeigth, contain
-        ctx.testScanWindow(BoxFit.scaleDown, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+        ctx.testScanWindow(
+            BoxFit.scaleDown, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
       });
     });
 
-    group('Widget (landscape) smaller than texture and texture (landscape)', () {
+    group('Widget (landscape) smaller than texture and texture (landscape)',
+        () {
       const textureSize = Size(640.0, 480.0);
       const widgetSize = Size(320.0, 120.0);
       final ctx = ScanWindowTestContext(
@@ -65,34 +77,41 @@ void main() {
       );
 
       test('wl tl: BoxFit.none', () {
-        ctx.testScanWindow(BoxFit.none, const Rect.fromLTRB(0.375, 0.4375, 0.625, 0.5625));
+        ctx.testScanWindow(
+            BoxFit.none, const Rect.fromLTRB(0.375, 0.4375, 0.625, 0.5625));
       });
 
       test('wl tl: BoxFit.fill', () {
-        ctx.testScanWindow(BoxFit.fill, const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75));
+        ctx.testScanWindow(
+            BoxFit.fill, const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75));
       });
 
       test('wl tl: BoxFit.fitHeight', () {
-        ctx.testScanWindow(BoxFit.fitHeight, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+        ctx.testScanWindow(
+            BoxFit.fitHeight, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
       });
 
       test('wl tl: BoxFit.fitWidth', () {
-        ctx.testScanWindow(BoxFit.fitWidth, const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625));
+        ctx.testScanWindow(
+            BoxFit.fitWidth, const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625));
       });
 
       test('wl tl: BoxFit.cover', () {
         // equal to fitWidth
-        ctx.testScanWindow(BoxFit.cover, const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625));
+        ctx.testScanWindow(
+            BoxFit.cover, const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625));
       });
 
       test('wl tl: BoxFit.contain', () {
         // equal to fitHeigth
-        ctx.testScanWindow(BoxFit.contain, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+        ctx.testScanWindow(
+            BoxFit.contain, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
       });
 
       test('wl tl: BoxFit.scaleDown', () {
         // equal to fitHeigth, contain
-        ctx.testScanWindow(BoxFit.scaleDown, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+        ctx.testScanWindow(
+            BoxFit.scaleDown, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
       });
     });
   });


### PR DESCRIPTION
I'm using this pub in my app and found that the scanWindow parameter is not working correctly even in the latest version.
Imho the calculation of the relative scan window for the native code is not correct.

Note that the v3.3 implementation works fine as long as BoxFit.contain is used (like in the example). But in my use case, I'm displaying only a small part of the whole scan image using BoxFit.cover, where the calculation of the relative scan window fails.

I think in v3.4 the changes from @sdkysfzai improved the situation but is not correct for every BoxFit value. 

I started writing my changes based on the v3.3 version. For this reason, I wrote a completely new implementation instead of tweaking @sdkysfzai's code.
Also, the changes in 96af70a248ee0c494f32dbe1205de4b24417cf2c ended up in v3.4, which also broke my implementation. My code needs the widget size but MediaQuery returns the screen size. That's why I reverted that change. I don't know the reason why the LayoutBuilder was removed from the widget tree, maybe @navaronbracke can explain it. 

In this PR I added unit tests. At the moment the test cases don't cover every possible situation, so this still needs some more work, but, I started with the values from my use case. The expected values are based on svg images which that I created with Inkscape. If you want I can share those files.


Finally, I think that some part of the calculation should be refactored out into a separate public method so that the barcode corners in ``BarcodeCapture`` can be transformed from scan image coordinates to widget coordinates, which I would consider useful.
