### PR TITLE
Mac os fixes

### DIFF
--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -384,6 +384,7 @@ class MobileScannerController {
             barcodes: [
               Barcode(
                 rawValue: (data as Map)['payload'] as String?,
+                format: toFormat(data['symbology'] as int)
               )
             ],
           ),

--- a/macos/Classes/MobileScannerPlugin.swift
+++ b/macos/Classes/MobileScannerPlugin.swift
@@ -226,7 +226,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         let speed: Int = (call.arguments as! Dictionary<String, Any?>)["speed"] as? Int ?? 0
         let timeoutMs: Int = (call.arguments as! Dictionary<String, Any?>)["timeout"] as? Int ?? 0
 
-        timeoutSeconds = Double(timeoutMs) * 1000.0
+        timeoutSeconds = Double(timeoutMs) / 1000.0
         detectionSpeed = DetectionSpeed(rawValue: speed)!
 
         // Set the camera to use


### PR DESCRIPTION
These fixes will handle limiting the bar code types to the types passed in, and then making sure to return the type that was found as part of the object response.

It also fixes a bug where the time to next scan was getting multiplied by 1000 when it should be divided by 1000.  Otherwise you are adding in the case of a default value of 250 milliseconds 250,000 seconds to the next scan time instead of .25 seconds like it should be.