### PR TITLE
fix: Change Kotlin version from 1.9.10 to 1.7.22 to fix Android builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'dev.steenbakker.mobile_scanner'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '1.7.22'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
This change fixes the issue #729 

As I shared in the mentioned issue to use Kotlin 1.9.x project needs to be already on Android Gradle Plugin 8.x, which is not something that every project can already do now. Thus, I suggest to rollback Kotlin version for better compatibility like I had to do in Plus Plugins as well (see https://github.com/fluttercommunity/plus_plugins/issues/2251)