### PR TITLE
fix: scan window fix (cherry-pick)

### DIFF
--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -193,8 +193,8 @@ class _MobileScannerState extends State<MobileScanner>
               scanWindow = calculateScanWindowRelativeToTextureInPercentage(
                 widget.fit,
                 widget.scanWindow!,
-                value.size,
-                constraints.biggest,
+                textureSize: value.size,
+                widgetSize: constraints.biggest,
               );
 
               _controller.updateScanWindow(scanWindow);

--- a/lib/src/scan_window_calculation.dart
+++ b/lib/src/scan_window_calculation.dart
@@ -2,14 +2,20 @@ import 'dart:math';
 
 import 'package:flutter/rendering.dart';
 
-/// the [scanWindow] rect will be relative and scaled to the [widgetSize] not the texture. so it is possible,
-/// depending on the [fit], for the [scanWindow] to partially or not at all overlap the [textureSize]
+/// Calculate the scan window rectangle relative to the texture size.
 ///
-/// since when using a [BoxFit] the content will always be centered on its parent. we can convert the rect
-/// to be relative to the texture.
+/// The [scanWindow] rectangle will be relative and scaled to [widgetSize], not [textureSize].
+/// Depending on the given [fit], the [scanWindow] can partially overlap the [textureSize],
+/// or not at all.
 ///
-/// since the textures size and the actuall image (on the texture size) might not be the same, we also need to
-/// calculate the scanWindow in terms of percentages of the texture, not pixels.
+/// Due to using [BoxFit] the content will always be centered on its parent,
+/// which enables converting the rectangle to be relative to the texture.
+///
+/// Because the size of the actual texture and the size of the texture in widget-space
+/// can be different, calculate the size of the scan window in percentages,
+/// rather than pixels.
+///
+/// Returns a [Rect] that represents the position and size of the scan window in the texture.
 Rect calculateScanWindowRelativeToTextureInPercentage(
   BoxFit fit,
   Rect scanWindow,
@@ -25,8 +31,7 @@ Rect calculateScanWindowRelativeToTextureInPercentage(
 
   switch (fit) {
     case BoxFit.fill:
-      // nop
-      // Just use sx and sy
+      // No-op, just use sx and sy.
       break;
     case BoxFit.contain:
       final s = min(sx, sy);
@@ -55,13 +60,13 @@ Rect calculateScanWindowRelativeToTextureInPercentage(
       break;
   }
 
-  // Fit the texture size to the widget rectangle given by the scaling values above
+  // Fit the texture size to the widget rectangle given by the scaling values above.
   final textureWindow = Alignment.center.inscribe(
     Size(textureSize.width * sx, textureSize.height * sy),
     Rect.fromLTWH(0, 0, widgetSize.width, widgetSize.height),
   );
 
-  // Transform the scan window from widget coordinates to texture coordinates
+  // Transform the scan window from widget coordinates to texture coordinates.
   final scanWindowInTexSpace = Rect.fromLTRB(
     (1 / sx) * (scanWindow.left - textureWindow.left),
     (1 / sy) * (scanWindow.top - textureWindow.top),
@@ -74,13 +79,14 @@ Rect calculateScanWindowRelativeToTextureInPercentage(
   final clippedScanWndInTexSpace = scanWindowInTexSpace
       .intersect(Rect.fromLTWH(0, 0, textureSize.width, textureSize.height));
 
-  // Compute relative rectangle coordinates with respect to the texture size, i.e. scan image
+  // Compute relative rectangle coordinates,
+  // with respect to the texture size, i.e. scan image.
   final percentageLeft = clippedScanWndInTexSpace.left / textureSize.width;
   final percentageTop = clippedScanWndInTexSpace.top / textureSize.height;
   final percentageRight = clippedScanWndInTexSpace.right / textureSize.width;
   final percentageBottom = clippedScanWndInTexSpace.bottom / textureSize.height;
 
-  // This rectangle can be send to native code and used to cut out a rectangle of the scan image
+  // This rectangle can be used to cut out a rectangle of the scan image.
   return Rect.fromLTRB(
     percentageLeft,
     percentageTop,

--- a/lib/src/scan_window_calculation.dart
+++ b/lib/src/scan_window_calculation.dart
@@ -18,11 +18,11 @@ import 'package:flutter/rendering.dart';
 /// Returns a [Rect] that represents the position and size of the scan window in the texture.
 Rect calculateScanWindowRelativeToTextureInPercentage(
   BoxFit fit,
-  Rect scanWindow,
-  Size textureSize,
-  Size widgetSize,
-) {
-  /// map the texture size to get its new size after fitted to screen
+  Rect scanWindow, {
+  required Size textureSize,
+  required Size widgetSize,
+}) {
+  // Convert the texture size to a size in widget-space, with the box fit applied.
   final fittedTextureSize = applyBoxFit(fit, textureSize, widgetSize);
 
   // Get the correct scaling values depending on the given BoxFit mode
@@ -76,8 +76,9 @@ Rect calculateScanWindowRelativeToTextureInPercentage(
 
   // Clip the scan window in texture coordinates with the texture bounds.
   // This prevents percentages outside the range [0; 1].
-  final clippedScanWndInTexSpace = scanWindowInTexSpace
-      .intersect(Rect.fromLTWH(0, 0, textureSize.width, textureSize.height));
+  final clippedScanWndInTexSpace = scanWindowInTexSpace.intersect(
+    Rect.fromLTWH(0, 0, textureSize.width, textureSize.height),
+  );
 
   // Compute relative rectangle coordinates,
   // with respect to the texture size, i.e. scan image.

--- a/test/scan_window_test.dart
+++ b/test/scan_window_test.dart
@@ -3,141 +3,155 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_scanner/src/scan_window_calculation.dart';
 
 void main() {
-  group('Scan window relative to texture', () {
-    group('Widget (landscape) smaller than texture (portrait)', () {
-      const textureSize = Size(480.0, 640.0);
-      const widgetSize = Size(432.0, 256.0);
-      final ctx = ScanWindowTestContext(
-        textureSize: textureSize,
-        widgetSize: widgetSize,
-        scanWindow: Rect.fromLTWH(
-          widgetSize.width / 4,
-          widgetSize.height / 4,
-          widgetSize.width / 2,
-          widgetSize.height / 2,
-        ),
-      );
-
-      test('wl tp: BoxFit.none', () {
-        ctx.testScanWindow(
-          BoxFit.none,
-          const Rect.fromLTRB(0.275, 0.4, 0.725, 0.6),
+  group(
+    'Scan window relative to texture',
+    () {
+      group('Widget (landscape) smaller than texture (portrait)', () {
+        const textureSize = Size(480.0, 640.0);
+        const widgetSize = Size(432.0, 256.0);
+        final ctx = ScanWindowTestContext(
+          textureSize: textureSize,
+          widgetSize: widgetSize,
+          scanWindow: Rect.fromLTWH(
+            widgetSize.width / 4,
+            widgetSize.height / 4,
+            widgetSize.width / 2,
+            widgetSize.height / 2,
+          ),
         );
+
+        test('wl tp: BoxFit.none', () {
+          ctx.testScanWindow(
+            BoxFit.none,
+            const Rect.fromLTRB(0.275, 0.4, 0.725, 0.6),
+          );
+        });
+
+        test('wl tp: BoxFit.fill', () {
+          ctx.testScanWindow(
+            BoxFit.fill,
+            const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75),
+          );
+        });
+
+        test('wl tp: BoxFit.fitHeight', () {
+          ctx.testScanWindow(
+            BoxFit.fitHeight,
+            const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
+          );
+        });
+
+        test('wl tp: BoxFit.fitWidth', () {
+          ctx.testScanWindow(
+            BoxFit.fitWidth,
+            const Rect.fromLTRB(
+              0.25,
+              0.38888888888888895,
+              0.75,
+              0.6111111111111112,
+            ),
+          );
+        });
+
+        test('wl tp: BoxFit.cover', () {
+          // equal to fitWidth
+          ctx.testScanWindow(
+            BoxFit.cover,
+            const Rect.fromLTRB(
+              0.25,
+              0.38888888888888895,
+              0.75,
+              0.6111111111111112,
+            ),
+          );
+        });
+
+        test('wl tp: BoxFit.contain', () {
+          // equal to fitHeigth
+          ctx.testScanWindow(
+            BoxFit.contain,
+            const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
+          );
+        });
+
+        test('wl tp: BoxFit.scaleDown', () {
+          // equal to fitHeigth, contain
+          ctx.testScanWindow(
+            BoxFit.scaleDown,
+            const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
+          );
+        });
       });
 
-      test('wl tp: BoxFit.fill', () {
-        ctx.testScanWindow(
-          BoxFit.fill,
-          const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75),
+      group('Widget (landscape) smaller than texture and texture (landscape)',
+          () {
+        const textureSize = Size(640.0, 480.0);
+        const widgetSize = Size(320.0, 120.0);
+        final ctx = ScanWindowTestContext(
+          textureSize: textureSize,
+          widgetSize: widgetSize,
+          scanWindow: Rect.fromLTWH(
+            widgetSize.width / 4,
+            widgetSize.height / 4,
+            widgetSize.width / 2,
+            widgetSize.height / 2,
+          ),
         );
-      });
 
-      test('wl tp: BoxFit.fitHeight', () {
-        ctx.testScanWindow(
-          BoxFit.fitHeight,
-          const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
-        );
-      });
+        test('wl tl: BoxFit.none', () {
+          ctx.testScanWindow(
+            BoxFit.none,
+            const Rect.fromLTRB(0.375, 0.4375, 0.625, 0.5625),
+          );
+        });
 
-      test('wl tp: BoxFit.fitWidth', () {
-        ctx.testScanWindow(
-          BoxFit.fitWidth,
-          const Rect.fromLTRB(0.25, 0.38888888888888895, 0.75, 0.6111111111111112),
-        );
-      });
+        test('wl tl: BoxFit.fill', () {
+          ctx.testScanWindow(
+            BoxFit.fill,
+            const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75),
+          );
+        });
 
-      test('wl tp: BoxFit.cover', () {
-        // equal to fitWidth
-        ctx.testScanWindow(
-          BoxFit.cover,
-          const Rect.fromLTRB(0.25, 0.38888888888888895, 0.75, 0.6111111111111112),
-        );
-      });
+        test('wl tl: BoxFit.fitHeight', () {
+          ctx.testScanWindow(
+            BoxFit.fitHeight,
+            const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
+          );
+        });
 
-      test('wl tp: BoxFit.contain', () {
-        // equal to fitHeigth
-        ctx.testScanWindow(
-          BoxFit.contain,
-          const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
-        );
-      });
+        test('wl tl: BoxFit.fitWidth', () {
+          ctx.testScanWindow(
+            BoxFit.fitWidth,
+            const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625),
+          );
+        });
 
-      test('wl tp: BoxFit.scaleDown', () {
-        // equal to fitHeigth, contain
-        ctx.testScanWindow(
-          BoxFit.scaleDown,
-          const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
-        );
-      });
-    });
+        test('wl tl: BoxFit.cover', () {
+          // equal to fitWidth
+          ctx.testScanWindow(
+            BoxFit.cover,
+            const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625),
+          );
+        });
 
-    group('Widget (landscape) smaller than texture and texture (landscape)', () {
-      const textureSize = Size(640.0, 480.0);
-      const widgetSize = Size(320.0, 120.0);
-      final ctx = ScanWindowTestContext(
-        textureSize: textureSize,
-        widgetSize: widgetSize,
-        scanWindow: Rect.fromLTWH(
-          widgetSize.width / 4,
-          widgetSize.height / 4,
-          widgetSize.width / 2,
-          widgetSize.height / 2,
-        ),
-      );
+        test('wl tl: BoxFit.contain', () {
+          // equal to fitHeigth
+          ctx.testScanWindow(
+            BoxFit.contain,
+            const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
+          );
+        });
 
-      test('wl tl: BoxFit.none', () {
-        ctx.testScanWindow(
-          BoxFit.none,
-          const Rect.fromLTRB(0.375, 0.4375, 0.625, 0.5625),
-        );
+        test('wl tl: BoxFit.scaleDown', () {
+          // equal to fitHeigth, contain
+          ctx.testScanWindow(
+            BoxFit.scaleDown,
+            const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
+          );
+        });
       });
-
-      test('wl tl: BoxFit.fill', () {
-        ctx.testScanWindow(
-          BoxFit.fill,
-          const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75),
-        );
-      });
-
-      test('wl tl: BoxFit.fitHeight', () {
-        ctx.testScanWindow(
-          BoxFit.fitHeight,
-          const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
-        );
-      });
-
-      test('wl tl: BoxFit.fitWidth', () {
-        ctx.testScanWindow(
-          BoxFit.fitWidth,
-          const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625),
-        );
-      });
-
-      test('wl tl: BoxFit.cover', () {
-        // equal to fitWidth
-        ctx.testScanWindow(
-          BoxFit.cover,
-          const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625),
-        );
-      });
-
-      test('wl tl: BoxFit.contain', () {
-        // equal to fitHeigth
-        ctx.testScanWindow(
-          BoxFit.contain,
-          const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
-        );
-      });
-
-      test('wl tl: BoxFit.scaleDown', () {
-        // equal to fitHeigth, contain
-        ctx.testScanWindow(
-          BoxFit.scaleDown,
-          const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
-        );
-      });
-    });
-  });
+    },
+  );
 }
 
 class ScanWindowTestContext {

--- a/test/scan_window_test.dart
+++ b/test/scan_window_test.dart
@@ -118,15 +118,15 @@ void main() {
 }
 
 class ScanWindowTestContext {
-  final Size textureSize;
-  final Size widgetSize;
-  final Rect scanWindow;
-
   ScanWindowTestContext({
     required this.textureSize,
     required this.widgetSize,
     required this.scanWindow,
   });
+
+  final Size textureSize;
+  final Size widgetSize;
+  final Rect scanWindow;
 
   void testScanWindow(BoxFit fit, Rect expected) {
     final actual = calculateScanWindowRelativeToTextureInPercentage(

--- a/test/scan_window_test.dart
+++ b/test/scan_window_test.dart
@@ -20,49 +20,58 @@ void main() {
 
       test('wl tp: BoxFit.none', () {
         ctx.testScanWindow(
-            BoxFit.none, const Rect.fromLTRB(0.275, 0.4, 0.725, 0.6));
+          BoxFit.none,
+          const Rect.fromLTRB(0.275, 0.4, 0.725, 0.6),
+        );
       });
 
       test('wl tp: BoxFit.fill', () {
         ctx.testScanWindow(
-            BoxFit.fill, const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75));
+          BoxFit.fill,
+          const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75),
+        );
       });
 
       test('wl tp: BoxFit.fitHeight', () {
         ctx.testScanWindow(
-            BoxFit.fitHeight, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+          BoxFit.fitHeight,
+          const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
+        );
       });
 
       test('wl tp: BoxFit.fitWidth', () {
         ctx.testScanWindow(
-            BoxFit.fitWidth,
-            const Rect.fromLTRB(
-                0.25, 0.38888888888888895, 0.75, 0.6111111111111112));
+          BoxFit.fitWidth,
+          const Rect.fromLTRB(0.25, 0.38888888888888895, 0.75, 0.6111111111111112),
+        );
       });
 
       test('wl tp: BoxFit.cover', () {
         // equal to fitWidth
         ctx.testScanWindow(
-            BoxFit.cover,
-            const Rect.fromLTRB(
-                0.25, 0.38888888888888895, 0.75, 0.6111111111111112));
+          BoxFit.cover,
+          const Rect.fromLTRB(0.25, 0.38888888888888895, 0.75, 0.6111111111111112),
+        );
       });
 
       test('wl tp: BoxFit.contain', () {
         // equal to fitHeigth
         ctx.testScanWindow(
-            BoxFit.contain, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+          BoxFit.contain,
+          const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
+        );
       });
 
       test('wl tp: BoxFit.scaleDown', () {
         // equal to fitHeigth, contain
         ctx.testScanWindow(
-            BoxFit.scaleDown, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+          BoxFit.scaleDown,
+          const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
+        );
       });
     });
 
-    group('Widget (landscape) smaller than texture and texture (landscape)',
-        () {
+    group('Widget (landscape) smaller than texture and texture (landscape)', () {
       const textureSize = Size(640.0, 480.0);
       const widgetSize = Size(320.0, 120.0);
       final ctx = ScanWindowTestContext(
@@ -78,40 +87,54 @@ void main() {
 
       test('wl tl: BoxFit.none', () {
         ctx.testScanWindow(
-            BoxFit.none, const Rect.fromLTRB(0.375, 0.4375, 0.625, 0.5625));
+          BoxFit.none,
+          const Rect.fromLTRB(0.375, 0.4375, 0.625, 0.5625),
+        );
       });
 
       test('wl tl: BoxFit.fill', () {
         ctx.testScanWindow(
-            BoxFit.fill, const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75));
+          BoxFit.fill,
+          const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75),
+        );
       });
 
       test('wl tl: BoxFit.fitHeight', () {
         ctx.testScanWindow(
-            BoxFit.fitHeight, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+          BoxFit.fitHeight,
+          const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
+        );
       });
 
       test('wl tl: BoxFit.fitWidth', () {
         ctx.testScanWindow(
-            BoxFit.fitWidth, const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625));
+          BoxFit.fitWidth,
+          const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625),
+        );
       });
 
       test('wl tl: BoxFit.cover', () {
         // equal to fitWidth
         ctx.testScanWindow(
-            BoxFit.cover, const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625));
+          BoxFit.cover,
+          const Rect.fromLTRB(0.25, 0.375, 0.75, 0.625),
+        );
       });
 
       test('wl tl: BoxFit.contain', () {
         // equal to fitHeigth
         ctx.testScanWindow(
-            BoxFit.contain, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+          BoxFit.contain,
+          const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
+        );
       });
 
       test('wl tl: BoxFit.scaleDown', () {
         // equal to fitHeigth, contain
         ctx.testScanWindow(
-            BoxFit.scaleDown, const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75));
+          BoxFit.scaleDown,
+          const Rect.fromLTRB(0.0, 0.25, 1.0, 0.75),
+        );
       });
     });
   });
@@ -132,8 +155,8 @@ class ScanWindowTestContext {
     final actual = calculateScanWindowRelativeToTextureInPercentage(
       fit,
       scanWindow,
-      textureSize,
-      widgetSize,
+      textureSize: textureSize,
+      widgetSize: widgetSize,
     );
 
     // don't use expect(actual, expected) because Rect.toString() only shows one digit after the comma which can be confusing


### PR DESCRIPTION
This is a cherry-pick of @MBulli his changes in #721 with the following additions:
- documentation adjustments for the scan window function
- using named parameters for the two `Size` arguments
- formatting adjustments by adding missing comma's in the test

Test still passes locally.

Fixes #633 