### PR TITLE
fix: Null exception when getting activity display on Android API >= 30

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -182,7 +182,7 @@ class MobileScanner(
     @Suppress("deprecation")
     private fun getResolution(cameraResolution: Size): Size {
         val rotation = if (Build.VERSION.SDK_INT >= 30) {
-            activity.applicationContext.display!!.rotation
+            activity.display!!.rotation
         } else {
             val windowManager = activity.applicationContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager
 


### PR DESCRIPTION
Fix https://github.com/juliansteenbakker/mobile_scanner/issues/799 introduced by https://github.com/juliansteenbakker/mobile_scanner/pull/785

When using cameraResolution, actual manner of getting display object lead to app crash.

Tested on Android >= 30 and <= 30.