### PR TITLE
fix: iOS Orientation change from .left to .up

### DIFF
--- a/ios/Classes/MobileScannerUtilities.swift
+++ b/ios/Classes/MobileScannerUtilities.swift
@@ -21,7 +21,7 @@ extension CVBuffer {
     var image: UIImage {
         let ciImage = CIImage(cvPixelBuffer: self)
         let cgImage = CIContext().createCGImage(ciImage, from: ciImage.extent)
-        return UIImage(cgImage: cgImage!, scale: 1.0, orientation: UIImage.Orientation.left)
+        return UIImage(cgImage: cgImage!)
     }
     
     var image1: UIImage {


### PR DESCRIPTION
This PR fix the weird orientation seen in https://github.com/juliansteenbakker/mobile_scanner/issues/801.
I didn't find a way to determine the original orientation from the buffer, but it's definitly weird to fallback to the `left`.