### PR TITLE
feat: Unit tests for enhanced enums

### DIFF
--- a/example/lib/barcode_list_scanner_controller.dart
+++ b/example/lib/barcode_list_scanner_controller.dart
@@ -82,16 +82,10 @@ class _BarcodeListScannerWithControllerState
                     children: [
                       IconButton(
                         color: Colors.white,
-                        icon: ValueListenableBuilder(
+                        icon: ValueListenableBuilder<TorchState>(
                           valueListenable: controller.torchState,
                           builder: (context, state, child) {
-                            if (state == null) {
-                              return const Icon(
-                                Icons.flash_off,
-                                color: Colors.grey,
-                              );
-                            }
-                            switch (state as TorchState) {
+                            switch (state) {
                               case TorchState.off:
                                 return const Icon(
                                   Icons.flash_off,
@@ -134,13 +128,10 @@ class _BarcodeListScannerWithControllerState
                       ),
                       IconButton(
                         color: Colors.white,
-                        icon: ValueListenableBuilder(
+                        icon: ValueListenableBuilder<CameraFacing>(
                           valueListenable: controller.cameraFacingState,
                           builder: (context, state, child) {
-                            if (state == null) {
-                              return const Icon(Icons.camera_front);
-                            }
-                            switch (state as CameraFacing) {
+                            switch (state) {
                               case CameraFacing.front:
                                 return const Icon(Icons.camera_front);
                               case CameraFacing.back:

--- a/example/lib/barcode_scanner_controller.dart
+++ b/example/lib/barcode_scanner_controller.dart
@@ -85,16 +85,10 @@ class _BarcodeScannerWithControllerState
                           }
                           return IconButton(
                             color: Colors.white,
-                            icon: ValueListenableBuilder(
+                            icon: ValueListenableBuilder<TorchState>(
                               valueListenable: controller.torchState,
                               builder: (context, state, child) {
-                                if (state == null) {
-                                  return const Icon(
-                                    Icons.flash_off,
-                                    color: Colors.grey,
-                                  );
-                                }
-                                switch (state as TorchState) {
+                                switch (state) {
                                   case TorchState.off:
                                     return const Icon(
                                       Icons.flash_off,
@@ -140,13 +134,10 @@ class _BarcodeScannerWithControllerState
                       ),
                       IconButton(
                         color: Colors.white,
-                        icon: ValueListenableBuilder(
+                        icon: ValueListenableBuilder<CameraFacing>(
                           valueListenable: controller.cameraFacingState,
                           builder: (context, state, child) {
-                            if (state == null) {
-                              return const Icon(Icons.camera_front);
-                            }
-                            switch (state as CameraFacing) {
+                            switch (state) {
                               case CameraFacing.front:
                                 return const Icon(Icons.camera_front);
                               case CameraFacing.back:

--- a/example/lib/barcode_scanner_returning_image.dart
+++ b/example/lib/barcode_scanner_returning_image.dart
@@ -101,16 +101,10 @@ class _BarcodeScannerReturningImageState
                           children: [
                             IconButton(
                               color: Colors.white,
-                              icon: ValueListenableBuilder(
+                              icon: ValueListenableBuilder<TorchState>(
                                 valueListenable: controller.torchState,
                                 builder: (context, state, child) {
-                                  if (state == null) {
-                                    return const Icon(
-                                      Icons.flash_off,
-                                      color: Colors.grey,
-                                    );
-                                  }
-                                  switch (state as TorchState) {
+                                  switch (state) {
                                     case TorchState.off:
                                       return const Icon(
                                         Icons.flash_off,
@@ -154,13 +148,10 @@ class _BarcodeScannerReturningImageState
                             ),
                             IconButton(
                               color: Colors.white,
-                              icon: ValueListenableBuilder(
+                              icon: ValueListenableBuilder<CameraFacing>(
                                 valueListenable: controller.cameraFacingState,
                                 builder: (context, state, child) {
-                                  if (state == null) {
-                                    return const Icon(Icons.camera_front);
-                                  }
-                                  switch (state as CameraFacing) {
+                                  switch (state) {
                                     case CameraFacing.front:
                                       return const Icon(Icons.camera_front);
                                     case CameraFacing.back:

--- a/example/lib/barcode_scanner_zoom.dart
+++ b/example/lib/barcode_scanner_zoom.dart
@@ -65,16 +65,10 @@ class _BarcodeScannerWithZoomState extends State<BarcodeScannerWithZoom>
                         children: [
                           IconButton(
                             color: Colors.white,
-                            icon: ValueListenableBuilder(
+                            icon: ValueListenableBuilder<TorchState>(
                               valueListenable: controller.torchState,
                               builder: (context, state, child) {
-                                if (state == null) {
-                                  return const Icon(
-                                    Icons.flash_off,
-                                    color: Colors.grey,
-                                  );
-                                }
-                                switch (state as TorchState) {
+                                switch (state) {
                                   case TorchState.off:
                                     return const Icon(
                                       Icons.flash_off,
@@ -123,13 +117,10 @@ class _BarcodeScannerWithZoomState extends State<BarcodeScannerWithZoom>
                           ),
                           IconButton(
                             color: Colors.white,
-                            icon: ValueListenableBuilder(
+                            icon: ValueListenableBuilder<CameraFacing>(
                               valueListenable: controller.cameraFacingState,
                               builder: (context, state, child) {
-                                if (state == null) {
-                                  return const Icon(Icons.camera_front);
-                                }
-                                switch (state as CameraFacing) {
+                                switch (state) {
                                   case CameraFacing.front:
                                     return const Icon(Icons.camera_front);
                                   case CameraFacing.back:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 0.0.1
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/lib/src/enums/address_type.dart
+++ b/lib/src/enums/address_type.dart
@@ -13,13 +13,14 @@ enum AddressType {
 
   factory AddressType.fromRawValue(int value) {
     switch (value) {
+      case 0:
+        return AddressType.unknown;
       case 1:
         return AddressType.work;
       case 2:
         return AddressType.home;
-      case 0:
       default:
-        return AddressType.unknown;
+        throw ArgumentError.value(value, 'value', 'Invalid raw value.');
     }
   }
 

--- a/lib/src/enums/barcode_format.dart
+++ b/lib/src/enums/barcode_format.dart
@@ -49,6 +49,8 @@ enum BarcodeFormat {
 
   factory BarcodeFormat.fromRawValue(int value) {
     switch (value) {
+      case -1:
+        return BarcodeFormat.unknown;
       case 0:
         return BarcodeFormat.all;
       case 1:
@@ -77,9 +79,8 @@ enum BarcodeFormat {
         return BarcodeFormat.pdf417;
       case 4096:
         return BarcodeFormat.aztec;
-      case -1:
       default:
-        return BarcodeFormat.unknown;
+        throw ArgumentError.value(value, 'value', 'Invalid raw value.');
     }
   }
 

--- a/lib/src/enums/barcode_type.dart
+++ b/lib/src/enums/barcode_type.dart
@@ -43,6 +43,8 @@ enum BarcodeType {
 
   factory BarcodeType.fromRawValue(int value) {
     switch (value) {
+      case 0:
+        return BarcodeType.unknown;
       case 1:
         return BarcodeType.contactInfo;
       case 2:
@@ -67,9 +69,8 @@ enum BarcodeType {
         return BarcodeType.calendarEvent;
       case 12:
         return BarcodeType.driverLicense;
-      case 0:
       default:
-        return BarcodeType.unknown;
+        throw ArgumentError.value(value, 'value', 'Invalid raw value.');
     }
   }
 

--- a/lib/src/enums/camera_facing.dart
+++ b/lib/src/enums/camera_facing.dart
@@ -8,6 +8,17 @@ enum CameraFacing {
 
   const CameraFacing(this.rawValue);
 
+  factory CameraFacing.fromRawValue(int value) {
+    switch (value) {
+      case 0:
+        return CameraFacing.front;
+      case 1:
+        return CameraFacing.back;
+      default:
+        throw ArgumentError.value(value, 'value', 'Invalid raw value.');
+    }
+  }
+
   /// The raw value for the camera facing direction.
   final int rawValue;
 }

--- a/lib/src/enums/detection_speed.dart
+++ b/lib/src/enums/detection_speed.dart
@@ -3,19 +3,17 @@ enum DetectionSpeed {
   /// The scanner will only scan a barcode once, and never again until another
   /// barcode has been scanned.
   ///
-  /// NOTE: This mode does analyze every frame in order to check if the value
-  /// has changed.
+  /// Bear in mind that this mode analyzes every frame,
+  /// in order to check if the value has changed.
   noDuplicates(0),
 
-  /// The barcode scanner will scan one barcode, and wait 250 Miliseconds before
-  /// scanning again. This will prevent memory issues on older devices.
-  ///
-  /// You can change the timeout duration with [detectionTimeout] parameter.
+  /// The barcode scanner will scan barcodes,
+  /// while respecting the configured scan timeout between individual scans.
   normal(1),
 
-  /// Let the scanner detect barcodes without restriction.
+  /// The barcode scanner will scan barcodes, without any restrictions.
   ///
-  /// NOTE: This can cause memory issues with older devices.
+  /// Bear in mind that this mode can cause memory issues on older devices.
   unrestricted(2);
 
   const DetectionSpeed(this.rawValue);

--- a/lib/src/enums/detection_speed.dart
+++ b/lib/src/enums/detection_speed.dart
@@ -27,7 +27,7 @@ enum DetectionSpeed {
       case 2:
         return DetectionSpeed.unrestricted;
       default:
-        return DetectionSpeed.normal;
+        throw ArgumentError.value(value, 'value', 'Invalid raw value.');
     }
   }
 

--- a/lib/src/enums/detection_speed.dart
+++ b/lib/src/enums/detection_speed.dart
@@ -18,6 +18,19 @@ enum DetectionSpeed {
 
   const DetectionSpeed(this.rawValue);
 
+  factory DetectionSpeed.fromRawValue(int value) {
+    switch (value) {
+      case 0:
+        return DetectionSpeed.noDuplicates;
+      case 1:
+        return DetectionSpeed.normal;
+      case 2:
+        return DetectionSpeed.unrestricted;
+      default:
+        return DetectionSpeed.normal;
+    }
+  }
+
   /// The raw value for the detection speed.
   final int rawValue;
 }

--- a/lib/src/enums/email_type.dart
+++ b/lib/src/enums/email_type.dart
@@ -13,13 +13,14 @@ enum EmailType {
 
   factory EmailType.fromRawValue(int value) {
     switch (value) {
+      case 0:
+        return EmailType.unknown;
       case 1:
         return EmailType.work;
       case 2:
         return EmailType.home;
-      case 0:
       default:
-        return EmailType.unknown;
+        throw ArgumentError.value(value, 'value', 'Invalid raw value.');
     }
   }
 

--- a/lib/src/enums/encryption_type.dart
+++ b/lib/src/enums/encryption_type.dart
@@ -16,15 +16,16 @@ enum EncryptionType {
 
   factory EncryptionType.fromRawValue(int value) {
     switch (value) {
+      case 0:
+        return EncryptionType.none;
       case 1:
         return EncryptionType.open;
       case 2:
         return EncryptionType.wpa;
       case 3:
         return EncryptionType.wep;
-      case 0:
       default:
-        return EncryptionType.none;
+        throw ArgumentError.value(value, 'value', 'Invalid raw value.');
     }
   }
 

--- a/lib/src/enums/phone_type.dart
+++ b/lib/src/enums/phone_type.dart
@@ -19,6 +19,8 @@ enum PhoneType {
 
   factory PhoneType.fromRawValue(int value) {
     switch (value) {
+      case 0:
+        return PhoneType.unknown;
       case 1:
         return PhoneType.work;
       case 2:
@@ -27,9 +29,8 @@ enum PhoneType {
         return PhoneType.fax;
       case 4:
         return PhoneType.mobile;
-      case 0:
       default:
-        return PhoneType.unknown;
+        throw ArgumentError.value(value, 'value', 'Invalid raw value.');
     }
   }
 

--- a/lib/src/enums/torch_state.dart
+++ b/lib/src/enums/torch_state.dart
@@ -8,6 +8,17 @@ enum TorchState {
 
   const TorchState(this.rawValue);
 
+  factory TorchState.fromRawValue(int value) {
+    switch (value) {
+      case 0:
+        return TorchState.off;
+      case 1:
+        return TorchState.on;
+      default:
+        throw ArgumentError.value(value, 'value', 'Invalid raw value.');
+    }
+  }
+
   /// The raw value for the torch state.
   final int rawValue;
 }

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -49,11 +49,13 @@ class MobileScannerController {
   /// WARNING: DetectionSpeed.unrestricted can cause memory issues on some devices
   final DetectionSpeed detectionSpeed;
 
-  /// Sets the timeout of scanner.
-  /// The timeout is set in miliseconds.
+  /// Sets the timeout, in milliseconds, of the scanner.
   ///
-  /// NOTE: The timeout only works if the [detectionSpeed] is set to
-  /// [DetectionSpeed.normal] (which is the default value).
+  /// This timeout is ignored if the [detectionSpeed]
+  /// is not set to [DetectionSpeed.normal].
+  ///
+  /// By default this is set to `250` milliseconds,
+  /// which prevents memory issues on older devices.
   final int detectionTimeoutMs;
 
   /// Automatically start the mobileScanner on initialization.

--- a/test/enums/address_type_test.dart
+++ b/test/enums/address_type_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/address_type.dart';
+
+void main() {
+  group('$AddressType tests', () {
+    test('can be created from raw value', () {
+      const values = <int, AddressType>{
+        0: AddressType.unknown,
+        1: AddressType.work,
+        2: AddressType.home,
+      };
+
+      for (final MapEntry<int, AddressType> entry in values.entries) {
+        final AddressType result = AddressType.fromRawValue(entry.key);
+
+        expect(result, entry.value);
+      }
+    });
+
+    test('invalid raw value creates unknown address type', () {
+      final AddressType negative = AddressType.fromRawValue(-1);
+      final AddressType outOfRange = AddressType.fromRawValue(3);
+
+      expect(negative, AddressType.unknown);
+      expect(outOfRange, AddressType.unknown);
+    });
+
+    test('can be converted to raw value', () {
+      const values = <AddressType, int>{
+        AddressType.unknown: 0,
+        AddressType.work: 1,
+        AddressType.home: 2,
+      };
+
+      for (final MapEntry<AddressType, int> entry in values.entries) {
+        final int result = entry.key.rawValue;
+
+        expect(result, entry.value);
+      }
+    });
+  });
+}

--- a/test/enums/address_type_test.dart
+++ b/test/enums/address_type_test.dart
@@ -17,12 +17,12 @@ void main() {
       }
     });
 
-    test('invalid raw value creates unknown address type', () {
-      final AddressType negative = AddressType.fromRawValue(-1);
-      final AddressType outOfRange = AddressType.fromRawValue(3);
+    test('invalid raw value throws argument error', () {
+      const int negative = -1;
+      const int outOfRange = 3;
 
-      expect(negative, AddressType.unknown);
-      expect(outOfRange, AddressType.unknown);
+      expect(() => AddressType.fromRawValue(negative), throwsArgumentError);
+      expect(() => AddressType.fromRawValue(outOfRange), throwsArgumentError);
     });
 
     test('can be converted to raw value', () {

--- a/test/enums/barcode_format_test.dart
+++ b/test/enums/barcode_format_test.dart
@@ -29,12 +29,12 @@ void main() {
       }
     });
 
-    test('invalid raw value creates unknown barcode format', () {
-      final BarcodeFormat negative = BarcodeFormat.fromRawValue(-2);
-      final BarcodeFormat outOfRange = BarcodeFormat.fromRawValue(4097);
+    test('invalid raw value throws argument error', () {
+      const int negative = -2;
+      const int outOfRange = 4097;
 
-      expect(negative, BarcodeFormat.unknown);
-      expect(outOfRange, BarcodeFormat.unknown);
+      expect(() => BarcodeFormat.fromRawValue(negative), throwsArgumentError);
+      expect(() => BarcodeFormat.fromRawValue(outOfRange), throwsArgumentError);
     });
 
     test('can be converted to raw value', () {

--- a/test/enums/barcode_format_test.dart
+++ b/test/enums/barcode_format_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/barcode_format.dart';
+
+void main() {
+  group('$BarcodeFormat tests', () {
+    test('can be created from raw value', () {
+      const values = <int, BarcodeFormat>{
+        -1: BarcodeFormat.unknown,
+        0: BarcodeFormat.all,
+        1: BarcodeFormat.code128,
+        2: BarcodeFormat.code39,
+        4: BarcodeFormat.code93,
+        8: BarcodeFormat.codebar,
+        16: BarcodeFormat.dataMatrix,
+        32: BarcodeFormat.ean13,
+        64: BarcodeFormat.ean8,
+        128: BarcodeFormat.itf,
+        256: BarcodeFormat.qrCode,
+        512: BarcodeFormat.upcA,
+        1024: BarcodeFormat.upcE,
+        2048: BarcodeFormat.pdf417,
+        4096: BarcodeFormat.aztec,
+      };
+
+      for (final MapEntry<int, BarcodeFormat> entry in values.entries) {
+        final BarcodeFormat result = BarcodeFormat.fromRawValue(entry.key);
+
+        expect(result, entry.value);
+      }
+    });
+
+    test('invalid raw value creates unknown barcode format', () {
+      final BarcodeFormat negative = BarcodeFormat.fromRawValue(-2);
+      final BarcodeFormat outOfRange = BarcodeFormat.fromRawValue(4097);
+
+      expect(negative, BarcodeFormat.unknown);
+      expect(outOfRange, BarcodeFormat.unknown);
+    });
+
+    test('can be converted to raw value', () {
+      const values = <BarcodeFormat, int>{
+        BarcodeFormat.unknown: -1,
+        BarcodeFormat.all: 0,
+        BarcodeFormat.code128: 1,
+        BarcodeFormat.code39: 2,
+        BarcodeFormat.code93: 4,
+        BarcodeFormat.codebar: 8,
+        BarcodeFormat.dataMatrix: 16,
+        BarcodeFormat.ean13: 32,
+        BarcodeFormat.ean8: 64,
+        BarcodeFormat.itf: 128,
+        BarcodeFormat.qrCode: 256,
+        BarcodeFormat.upcA: 512,
+        BarcodeFormat.upcE: 1024,
+        BarcodeFormat.pdf417: 2048,
+        BarcodeFormat.aztec: 4096,
+      };
+
+      for (final MapEntry<BarcodeFormat, int> entry in values.entries) {
+        final int result = entry.key.rawValue;
+
+        expect(result, entry.value);
+      }
+    });
+  });
+}

--- a/test/enums/barcode_type_test.dart
+++ b/test/enums/barcode_type_test.dart
@@ -27,12 +27,12 @@ void main() {
       }
     });
 
-    test('invalid raw value creates unknown barcode type', () {
-      final BarcodeType negative = BarcodeType.fromRawValue(-1);
-      final BarcodeType outOfRange = BarcodeType.fromRawValue(13);
+    test('invalid raw value throws argument error', () {
+      const int negative = -1;
+      const int outOfRange = 13;
 
-      expect(negative, BarcodeType.unknown);
-      expect(outOfRange, BarcodeType.unknown);
+      expect(() => BarcodeType.fromRawValue(negative), throwsArgumentError);
+      expect(() => BarcodeType.fromRawValue(outOfRange), throwsArgumentError);
     });
 
     test('can be converted to raw value', () {

--- a/test/enums/barcode_type_test.dart
+++ b/test/enums/barcode_type_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/barcode_type.dart';
+
+void main() {
+  group('$BarcodeType tests', () {
+    test('can be created from raw value', () {
+      const values = <int, BarcodeType>{
+        0: BarcodeType.unknown,
+        1: BarcodeType.contactInfo,
+        2: BarcodeType.email,
+        3: BarcodeType.isbn,
+        4: BarcodeType.phone,
+        5: BarcodeType.product,
+        6: BarcodeType.sms,
+        7: BarcodeType.text,
+        8: BarcodeType.url,
+        9: BarcodeType.wifi,
+        10: BarcodeType.geo,
+        11: BarcodeType.calendarEvent,
+        12: BarcodeType.driverLicense,
+      };
+
+      for (final MapEntry<int, BarcodeType> entry in values.entries) {
+        final BarcodeType result = BarcodeType.fromRawValue(entry.key);
+
+        expect(result, entry.value);
+      }
+    });
+
+    test('invalid raw value creates unknown barcode type', () {
+      final BarcodeType negative = BarcodeType.fromRawValue(-1);
+      final BarcodeType outOfRange = BarcodeType.fromRawValue(13);
+
+      expect(negative, BarcodeType.unknown);
+      expect(outOfRange, BarcodeType.unknown);
+    });
+
+    test('can be converted to raw value', () {
+      const values = <BarcodeType, int>{
+        BarcodeType.unknown: 0,
+        BarcodeType.contactInfo: 1,
+        BarcodeType.email: 2,
+        BarcodeType.isbn: 3,
+        BarcodeType.phone: 4,
+        BarcodeType.product: 5,
+        BarcodeType.sms: 6,
+        BarcodeType.text: 7,
+        BarcodeType.url: 8,
+        BarcodeType.wifi: 9,
+        BarcodeType.geo: 10,
+        BarcodeType.calendarEvent: 11,
+        BarcodeType.driverLicense: 12,
+      };
+
+      for (final MapEntry<BarcodeType, int> entry in values.entries) {
+        final int result = entry.key.rawValue;
+
+        expect(result, entry.value);
+      }
+    });
+  });
+}

--- a/test/enums/camera_facing_test.dart
+++ b/test/enums/camera_facing_test.dart
@@ -16,7 +16,7 @@ void main() {
       }
     });
 
-    test('invalid raw value throws assertion error', () {
+    test('invalid raw value throws argument error', () {
       const int negative = -1;
       const int outOfRange = 2;
 

--- a/test/enums/camera_facing_test.dart
+++ b/test/enums/camera_facing_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/camera_facing.dart';
+
+void main() {
+  group('$CameraFacing tests', () {
+    test('can be created from raw value', () {
+      const values = <int, CameraFacing>{
+        0: CameraFacing.front,
+        1: CameraFacing.back,
+      };
+
+      for (final MapEntry<int, CameraFacing> entry in values.entries) {
+        final CameraFacing result = CameraFacing.fromRawValue(entry.key);
+
+        expect(result, entry.value);
+      }
+    });
+
+    test('invalid raw value throws assertion error', () {
+      const int negative = -1;
+      const int outOfRange = 2;
+
+      expect(() => CameraFacing.fromRawValue(negative), throwsArgumentError);
+      expect(() => CameraFacing.fromRawValue(outOfRange), throwsArgumentError);
+    });
+
+    test('can be converted to raw value', () {
+      const values = <CameraFacing, int>{
+        CameraFacing.front: 0,
+        CameraFacing.back: 1,
+      };
+
+      for (final MapEntry<CameraFacing, int> entry in values.entries) {
+        final int result = entry.key.rawValue;
+
+        expect(result, entry.value);
+      }
+    });
+  });
+}

--- a/test/enums/detection_speed_test.dart
+++ b/test/enums/detection_speed_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/detection_speed.dart';
+
+void main() {
+  group('$DetectionSpeed tests', () {
+    test('can be created from raw value', () {
+      const values = <int, DetectionSpeed>{
+        0: DetectionSpeed.noDuplicates,
+        1: DetectionSpeed.normal,
+        2: DetectionSpeed.unrestricted,
+      };
+
+      for (final MapEntry<int, DetectionSpeed> entry in values.entries) {
+        final DetectionSpeed result = DetectionSpeed.fromRawValue(entry.key);
+
+        expect(result, entry.value);
+      }
+    });
+
+    test('invalid raw value throws argument error', () {
+      const int negative = -1;
+      const int outOfRange = 3;
+
+      expect(() => DetectionSpeed.fromRawValue(negative), throwsArgumentError);
+      expect(() => DetectionSpeed.fromRawValue(outOfRange), throwsArgumentError);
+    });
+
+    test('can be converted to raw value', () {
+      const values = <DetectionSpeed, int>{
+        DetectionSpeed.noDuplicates: 0,
+        DetectionSpeed.normal: 1,
+        DetectionSpeed.unrestricted: 2,
+      };
+
+      for (final MapEntry<DetectionSpeed, int> entry in values.entries) {
+        final int result = entry.key.rawValue;
+
+        expect(result, entry.value);
+      }
+    });
+  });
+}

--- a/test/enums/detection_speed_test.dart
+++ b/test/enums/detection_speed_test.dart
@@ -22,7 +22,10 @@ void main() {
       const int outOfRange = 3;
 
       expect(() => DetectionSpeed.fromRawValue(negative), throwsArgumentError);
-      expect(() => DetectionSpeed.fromRawValue(outOfRange), throwsArgumentError);
+      expect(
+        () => DetectionSpeed.fromRawValue(outOfRange),
+        throwsArgumentError,
+      );
     });
 
     test('can be converted to raw value', () {

--- a/test/enums/email_type_test.dart
+++ b/test/enums/email_type_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/email_type.dart';
+
+void main() {
+  group('$EmailType tests', () {
+    test('can be created from raw value', () {
+      const values = <int, EmailType>{
+        0: EmailType.unknown,
+        1: EmailType.work,
+        2: EmailType.home,
+      };
+
+      for (final MapEntry<int, EmailType> entry in values.entries) {
+        final EmailType result = EmailType.fromRawValue(entry.key);
+
+        expect(result, entry.value);
+      }
+    });
+
+    test('invalid raw value throws argument error', () {
+      const int negative = -1;
+      const int outOfRange = 3;
+
+      expect(() => EmailType.fromRawValue(negative), throwsArgumentError);
+      expect(() => EmailType.fromRawValue(outOfRange), throwsArgumentError);
+    });
+
+    test('can be converted to raw value', () {
+      const values = <EmailType, int>{
+        EmailType.unknown: 0,
+        EmailType.work: 1,
+        EmailType.home: 2,
+      };
+
+      for (final MapEntry<EmailType, int> entry in values.entries) {
+        final int result = entry.key.rawValue;
+
+        expect(result, entry.value);
+      }
+    });
+  });
+}

--- a/test/enums/encryption_type_test.dart
+++ b/test/enums/encryption_type_test.dart
@@ -23,7 +23,10 @@ void main() {
       const int outOfRange = 4;
 
       expect(() => EncryptionType.fromRawValue(negative), throwsArgumentError);
-      expect(() => EncryptionType.fromRawValue(outOfRange), throwsArgumentError);
+      expect(
+        () => EncryptionType.fromRawValue(outOfRange),
+        throwsArgumentError,
+      );
     });
 
     test('can be converted to raw value', () {

--- a/test/enums/encryption_type_test.dart
+++ b/test/enums/encryption_type_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/encryption_type.dart';
+
+void main() {
+  group('$EncryptionType tests', () {
+    test('can be created from raw value', () {
+      const values = <int, EncryptionType>{
+        0: EncryptionType.none,
+        1: EncryptionType.open,
+        2: EncryptionType.wpa,
+        3: EncryptionType.wep,
+      };
+
+      for (final MapEntry<int, EncryptionType> entry in values.entries) {
+        final EncryptionType result = EncryptionType.fromRawValue(entry.key);
+
+        expect(result, entry.value);
+      }
+    });
+
+    test('invalid raw value throws argument error', () {
+      const int negative = -1;
+      const int outOfRange = 4;
+
+      expect(() => EncryptionType.fromRawValue(negative), throwsArgumentError);
+      expect(() => EncryptionType.fromRawValue(outOfRange), throwsArgumentError);
+    });
+
+    test('can be converted to raw value', () {
+      const values = <EncryptionType, int>{
+        EncryptionType.none: 0,
+        EncryptionType.open: 1,
+        EncryptionType.wpa: 2,
+        EncryptionType.wep: 3,
+      };
+
+      for (final MapEntry<EncryptionType, int> entry in values.entries) {
+        final int result = entry.key.rawValue;
+
+        expect(result, entry.value);
+      }
+    });
+  });
+}

--- a/test/enums/mobile_scanner_state_test.dart
+++ b/test/enums/mobile_scanner_state_test.dart
@@ -11,7 +11,9 @@ void main() {
       };
 
       for (final MapEntry<int, MobileScannerState> entry in values.entries) {
-        final MobileScannerState result = MobileScannerState.fromRawValue(entry.key);
+        final MobileScannerState result = MobileScannerState.fromRawValue(
+          entry.key,
+        );
 
         expect(result, entry.value);
       }
@@ -21,8 +23,14 @@ void main() {
       const int negative = -1;
       const int outOfRange = 3;
 
-      expect(() => MobileScannerState.fromRawValue(negative), throwsArgumentError);
-      expect(() => MobileScannerState.fromRawValue(outOfRange), throwsArgumentError);
+      expect(
+        () => MobileScannerState.fromRawValue(negative),
+        throwsArgumentError,
+      );
+      expect(
+        () => MobileScannerState.fromRawValue(outOfRange),
+        throwsArgumentError,
+      );
     });
 
     test('can be converted to raw value', () {

--- a/test/enums/mobile_scanner_state_test.dart
+++ b/test/enums/mobile_scanner_state_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/mobile_scanner_state.dart';
+
+void main() {
+  group('$MobileScannerState tests', () {
+    test('can be created from raw value', () {
+      const values = {
+        0: MobileScannerState.undetermined,
+        1: MobileScannerState.authorized,
+        2: MobileScannerState.denied,
+      };
+
+      for (final MapEntry<int, MobileScannerState> entry in values.entries) {
+        final MobileScannerState result = MobileScannerState.fromRawValue(entry.key);
+
+        expect(result, entry.value);
+      }
+    });
+
+    test('invalid raw value throws argument error', () {
+      const int negative = -1;
+      const int outOfRange = 3;
+
+      expect(() => MobileScannerState.fromRawValue(negative), throwsArgumentError);
+      expect(() => MobileScannerState.fromRawValue(outOfRange), throwsArgumentError);
+    });
+
+    test('can be converted to raw value', () {
+      const values = <MobileScannerState, int>{
+        MobileScannerState.undetermined: 0,
+        MobileScannerState.authorized: 1,
+        MobileScannerState.denied: 2,
+      };
+
+      for (final MapEntry<MobileScannerState, int> entry in values.entries) {
+        final int result = entry.key.rawValue;
+
+        expect(result, entry.value);
+      }
+    });
+  });
+}

--- a/test/enums/phone_type_test.dart
+++ b/test/enums/phone_type_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/phone_type.dart';
+
+void main() {
+  group('$PhoneType tests', () {
+    test('can be created from raw value', () {
+      const values = <int, PhoneType>{
+        0: PhoneType.unknown,
+        1: PhoneType.work,
+        2: PhoneType.home,
+        3: PhoneType.fax,
+        4: PhoneType.mobile,
+      };
+
+      for (final MapEntry<int, PhoneType> entry in values.entries) {
+        final PhoneType result = PhoneType.fromRawValue(entry.key);
+
+        expect(result, entry.value);
+      }
+    });
+
+    test('invalid raw value throws argument error', () {
+      const int negative = -1;
+      const int outOfRange = 5;
+
+      expect(() => PhoneType.fromRawValue(negative), throwsArgumentError);
+      expect(() => PhoneType.fromRawValue(outOfRange), throwsArgumentError);
+    });
+
+    test('can be converted to raw value', () {
+      const values = <PhoneType, int>{
+        PhoneType.unknown: 0,
+        PhoneType.work: 1,
+        PhoneType.home: 2,
+        PhoneType.fax: 3,
+        PhoneType.mobile: 4,
+      };
+
+      for (final MapEntry<PhoneType, int> entry in values.entries) {
+        final int result = entry.key.rawValue;
+
+        expect(result, entry.value);
+      }
+    });
+  });
+}

--- a/test/enums/torch_state_test.dart
+++ b/test/enums/torch_state_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/torch_state.dart';
+
+void main() {
+  group('$TorchState tests', () {
+    test('can be created from raw value', () {
+      const values = <int, TorchState>{
+        0: TorchState.off,
+        1: TorchState.on,
+      };
+
+      for (final MapEntry<int, TorchState> entry in values.entries) {
+        final TorchState result = TorchState.fromRawValue(entry.key);
+
+        expect(result, entry.value);
+      }
+    });
+
+    test('invalid raw value throws argument error', () {
+      const int negative = -1;
+      const int outOfRange = 2;
+
+      expect(() => TorchState.fromRawValue(negative), throwsArgumentError);
+      expect(() => TorchState.fromRawValue(outOfRange), throwsArgumentError);
+    });
+
+    test('can be converted to raw value', () {
+      const values = <TorchState, int>{
+        TorchState.off: 0,
+        TorchState.on: 1,
+      };
+
+      for (final MapEntry<TorchState, int> entry in values.entries) {
+        final int result = entry.key.rawValue;
+
+        expect(result, entry.value);
+      }
+    });
+  });
+}


### PR DESCRIPTION
This PR adds

- unit tests for the enums that were converted into Enhanced Enums in #813
- a fix for a redundant cast in the example app samples 
   - the analyzer only reports the issue from Dart 2.18 onwards, hence the bump of the Dart version in the example app
- adjusts the enums to have their `fromRawValue` constructors throw on unrecognised integers
   - this way the tests fail if we add new values to the enums
- adds missing `fromRawValue` constructors to some enums
- updates some documentation in `MobileScannerController` and `DetectionSpeed` so that `NOTE:` is no longer used
  - using the `note: ...` style and all-caps words is discouraged by the Flutter Style Guide, hence why I reworded the comments 
