### PR TITLE
fix: use rawValue on Android as well for formats

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -120,7 +120,7 @@ class MobileScannerHandler(
             "stop" -> stop(result)
             "analyzeImage" -> analyzeImage(call, result)
             "setScale" -> setScale(call, result)
-            "resetScale" -> resetScale(call, result)
+            "resetScale" -> resetScale(result)
             "updateScanWindow" -> updateScanWindow(call)
             else -> result.notImplemented()
         }
@@ -250,7 +250,7 @@ class MobileScannerHandler(
         }
     }
 
-    private fun resetScale(call: MethodCall, result: MethodChannel.Result) {
+    private fun resetScale(result: MethodChannel.Result) {
         try {
             mobileScanner!!.resetScale()
             result.success(null)

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -144,8 +144,8 @@ class MobileScannerHandler(
         var barcodeScannerOptions: BarcodeScannerOptions? = null
         if (formats != null) {
             val formatsList: MutableList<Int> = mutableListOf()
-            for (index in formats) {
-                formatsList.add(BarcodeFormats.values()[index].intValue)
+            for (formatValue in formats) {
+                formatsList.add(BarcodeFormats.fromRawValue(formatValue).intValue)
             }
             barcodeScannerOptions = if (formatsList.size == 1) {
                 BarcodeScannerOptions.Builder().setBarcodeFormats(formatsList.first())

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/objects/BarcodeFormats.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/objects/BarcodeFormats.kt
@@ -2,17 +2,41 @@ package dev.steenbakker.mobile_scanner.objects
 
 enum class BarcodeFormats(val intValue: Int) {
     UNKNOWN(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_UNKNOWN),
-    ALL_FORMATS(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_ALL_FORMATS), CODE_128(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODE_128), CODE_39(
-        com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODE_39
-    ),
-    CODE_93(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODE_93), CODABAR(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODABAR), DATA_MATRIX(
-        com.google.mlkit.vision.barcode.common.Barcode.FORMAT_DATA_MATRIX
-    ),
-    EAN_13(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_EAN_13), EAN_8(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_EAN_8), ITF(
-        com.google.mlkit.vision.barcode.common.Barcode.FORMAT_ITF
-    ),
-    QR_CODE(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_QR_CODE), UPC_A(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_UPC_A), UPC_E(
-        com.google.mlkit.vision.barcode.common.Barcode.FORMAT_UPC_E
-    ),
-    PDF417(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_PDF417), AZTEC(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_AZTEC);
+    ALL_FORMATS(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_ALL_FORMATS),
+    CODE_128(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODE_128),
+    CODE_39(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODE_39),
+    CODE_93(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODE_93),
+    CODABAR(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODABAR),
+    DATA_MATRIX(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_DATA_MATRIX),
+    EAN_13(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_EAN_13),
+    EAN_8(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_EAN_8),
+    ITF(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_ITF),
+    QR_CODE(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_QR_CODE),
+    UPC_A(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_UPC_A),
+    UPC_E(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_UPC_E),
+    PDF417(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_PDF417),
+    AZTEC(com.google.mlkit.vision.barcode.common.Barcode.FORMAT_AZTEC);
+
+    companion object {
+        fun fromRawValue(rawValue: Int): BarcodeFormats {
+            return when(rawValue) {
+                -1 -> UNKNOWN
+                0 -> ALL_FORMATS
+                1 -> CODE_128
+                2 -> CODE_39
+                4 -> CODE_93
+                8 -> CODABAR
+                16 -> DATA_MATRIX
+                32 -> EAN_13
+                64 -> EAN_8
+                128 -> ITF
+                256 -> QR_CODE
+                512 -> UPC_A
+                1024 -> UPC_E
+                2048 -> PDF417
+                4096 -> AZTEC
+                else -> UNKNOWN
+            }
+        }
+    }
 }

--- a/lib/mobile_scanner_web_plugin.dart
+++ b/lib/mobile_scanner_web_plugin.dart
@@ -139,7 +139,7 @@ class MobileScannerWebPlugin {
               'rawBytes': code.rawBytes,
               'format': code.format.rawValue,
               'displayValue': code.displayValue,
-              'type': code.type.index,
+              'type': code.type.rawValue,
               if (corners != null && corners.isNotEmpty)
                 'corners': corners
                     .map(

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -136,6 +136,7 @@ class MobileScannerController {
     arguments['torch'] = torchEnabled;
     arguments['speed'] = detectionSpeed.rawValue;
     arguments['timeout'] = detectionTimeoutMs;
+    arguments['returnImage'] = returnImage;
 
     /*    if (scanWindow != null) {
       arguments['scanWindow'] = [
@@ -147,19 +148,18 @@ class MobileScannerController {
     } */
 
     if (formats != null) {
-      if (kIsWeb || Platform.isIOS || Platform.isMacOS) {
+      if (kIsWeb || Platform.isIOS || Platform.isMacOS || Platform.isAndroid) {
         arguments['formats'] = formats!.map((e) => e.rawValue).toList();
-      } else if (Platform.isAndroid) {
-        arguments['formats'] = formats!.map((e) => e.index).toList();
-        if (cameraResolution != null) {
-          arguments['cameraResolution'] = <int>[
-            cameraResolution!.width.toInt(),
-            cameraResolution!.height.toInt(),
-          ];
-        }
       }
     }
-    arguments['returnImage'] = returnImage;
+
+    if (cameraResolution != null) {
+      arguments['cameraResolution'] = <int>[
+        cameraResolution!.width.toInt(),
+        cameraResolution!.height.toInt(),
+      ];
+    }
+
     return arguments;
   }
 

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -132,9 +132,9 @@ class MobileScannerController {
     final Map<String, dynamic> arguments = {};
 
     cameraFacingState.value = cameraFacingOverride ?? facing;
-    arguments['facing'] = cameraFacingState.value.index;
+    arguments['facing'] = cameraFacingState.value.rawValue;
     arguments['torch'] = torchEnabled;
-    arguments['speed'] = detectionSpeed.index;
+    arguments['speed'] = detectionSpeed.rawValue;
     arguments['timeout'] = detectionTimeoutMs;
 
     /*    if (scanWindow != null) {
@@ -329,7 +329,7 @@ class MobileScannerController {
     torchState.value =
         torchState.value == TorchState.off ? TorchState.on : TorchState.off;
 
-    await _methodChannel.invokeMethod('torch', torchState.value.index);
+    await _methodChannel.invokeMethod('torch', torchState.value.rawValue);
   }
 
   /// Changes the state of the camera (front or back).


### PR DESCRIPTION
This PR adjusts the Android implementation to accept the raw value of the format, to bring it in line with other platforms.

It also removes an unused argument, formats a Kotlin file, and moves the `cameraResolution` argument out of a platform check. If the `cameraResolution` is not supported by a platform, it is ignored in the implementation anyway.

Lastly, all the enums now use their `rawValue` instead of their `index` as serialized value to the platform side.