### PR TITLE
feat: Move classes into their own files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Improvements:
 * The `width` and `height` of `BarcodeCapture` are now non-null.
 * The `BarcodeCapture` class now exposes a `size`.
 * The list of `corners` of a `Barcode` is now non-null.
+* The internal `fromNative()` methods now accept a `Map<Object?, Object?>` instead of `Map<dynamic, dynamic>`.
 
 ## 3.5.0
 New Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Improvements:
 * The `phoneNumber` of an `SMS` is now non-null.
 * The `latitude` and `longitude` of a `GeoPoint` are now non-null.
 * The `phones` and `urls` of `ContactInfo` are now non-null.
+* The `url` of a `UrlBookmark` is now non-null.
 
 ## 3.5.0
 New Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Improvements:
 * The `type` of an `Email` is now non-null.
 * The `phoneNumber` of an `SMS` is now non-null.
+* The `latitude` and `longitude` of a `GeoPoint` are now non-null.
 
 ## 3.5.0
 New Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Improvements:
 * The `phones` and `urls` of `ContactInfo` are now non-null.
 * The `url` of a `UrlBookmark` is now non-null.
 * The `type` of `Phone` is now non-null.
+* The `width` and `height` of `BarcodeCapture` are now non-null.
+* The `BarcodeCapture` class now exposes a `size`.
 
 ## 3.5.0
 New Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 Improvements:
+* The `type` of an `Address` is now non-null.
 * The `type` of an `Email` is now non-null.
 * The `phoneNumber` of an `SMS` is now non-null.
 * The `latitude` and `longitude` of a `GeoPoint` are now non-null.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 Improvements:
-* The `type` of an `Email` is no longer null.
+* The `type` of an `Email` is now non-null.
+* The `phoneNumber` of an `SMS` is now non-null.
 
 ## 3.5.0
 New Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Improvements:
 * The `type` of an `Email` is now non-null.
 * The `phoneNumber` of an `SMS` is now non-null.
 * The `latitude` and `longitude` of a `GeoPoint` are now non-null.
+* The `phones` and `urls` of `ContactInfo` are now non-null.
 
 ## 3.5.0
 New Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,6 @@ Bugs fixed:
 * Fixed scan timeout not working on iOS. (thanks @navaronbracke !)
 * Fixed a crash on iOS when the device is nil. (thanks @navaronbracke !)
 * Fixed a case of an unhandled exception when starting the scanner. (thanks @navaronbracke !)
-* Fixed the default values for the `format` and `type` arguments of the Barcode constructor.
-  These now use `BarcodeFormat.unknown` and `BarcodeType.unknown`, rather than `BarcodeFormat.ean13` and `BarcodeType.text`.
-  (thanks @navaronbracke !)
 
 Improvements:
 * Improved MacOS memory footprint by using a background queue. (thanks @ryanduffyne !)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Improvements:
 * The `latitude` and `longitude` of a `GeoPoint` are now non-null.
 * The `phones` and `urls` of `ContactInfo` are now non-null.
 * The `url` of a `UrlBookmark` is now non-null.
+* The `type` of `Phone` is now non-null.
 
 ## 3.5.0
 New Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Improvements:
 * The `type` of `Phone` is now non-null.
 * The `width` and `height` of `BarcodeCapture` are now non-null.
 * The `BarcodeCapture` class now exposes a `size`.
+* The list of `corners` of a `Barcode` is now non-null.
 
 ## 3.5.0
 New Features:
@@ -26,6 +27,9 @@ Bugs fixed:
 * Fixed scan timeout not working on iOS. (thanks @navaronbracke !)
 * Fixed a crash on iOS when the device is nil. (thanks @navaronbracke !)
 * Fixed a case of an unhandled exception when starting the scanner. (thanks @navaronbracke !)
+* Fixed the default values for the `format` and `type` arguments of the Barcode constructor.
+  These now use `BarcodeFormat.unknown` and `BarcodeType.unknown`, rather than `BarcodeFormat.ean13` and `BarcodeType.text`.
+  (thanks @navaronbracke !)
 
 Improvements:
 * Improved MacOS memory footprint by using a background queue. (thanks @ryanduffyne !)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+Improvements:
+* The `type` of an `Email` is no longer null.
+
 ## 3.5.0
 New Features:
 * Added the option to switch between bundled and unbundled MLKit for Android. (thanks @woolfred !)

--- a/example/lib/barcode_scanner_window.dart
+++ b/example/lib/barcode_scanner_window.dart
@@ -151,7 +151,7 @@ class BarcodeOverlay extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    if (barcode.corners == null) {
+    if (barcode.corners.isEmpty) {
       return;
     }
 
@@ -183,7 +183,7 @@ class BarcodeOverlay extends CustomPainter {
     }
 
     final List<Offset> adjustedOffset = [];
-    for (final offset in barcode.corners!) {
+    for (final offset in barcode.corners) {
       adjustedOffset.add(
         Offset(
           offset.dx / ratioWidth + horizontalPadding,

--- a/example/lib/barcode_scanner_window.dart
+++ b/example/lib/barcode_scanner_window.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
@@ -150,7 +151,10 @@ class BarcodeOverlay extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    if (barcode.corners == null) return;
+    if (barcode.corners == null) {
+      return;
+    }
+
     final adjustedSize = applyBoxFit(boxFit, arguments.size, size);
 
     double verticalPadding = size.height - adjustedSize.destination.height;
@@ -167,12 +171,16 @@ class BarcodeOverlay extends CustomPainter {
       horizontalPadding = 0;
     }
 
-    final ratioWidth =
-        (Platform.isIOS ? capture.width! : arguments.size.width) /
-            adjustedSize.destination.width;
-    final ratioHeight =
-        (Platform.isIOS ? capture.height! : arguments.size.height) /
-            adjustedSize.destination.height;
+    final double ratioWidth;
+    final double ratioHeight;
+
+    if (!kIsWeb && Platform.isIOS) {
+      ratioWidth = capture.size.width / adjustedSize.destination.width;
+      ratioHeight = capture.size.height / adjustedSize.destination.height;
+    } else {
+      ratioWidth = arguments.size.width / adjustedSize.destination.width;
+      ratioHeight = arguments.size.height / adjustedSize.destination.height;
+    }
 
     final List<Offset> adjustedOffset = [];
     for (final offset in barcode.corners!) {

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -18,4 +18,5 @@ export 'src/objects/calendar_event.dart';
 export 'src/objects/driver_license.dart';
 export 'src/objects/email.dart';
 export 'src/objects/mobile_scanner_arguments.dart';
+export 'src/objects/sms.dart';
 export 'src/objects/wifi.dart';

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -18,3 +18,4 @@ export 'src/objects/calendar_event.dart';
 export 'src/objects/driver_license.dart';
 export 'src/objects/email.dart';
 export 'src/objects/mobile_scanner_arguments.dart';
+export 'src/objects/wifi.dart';

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -20,6 +20,7 @@ export 'src/objects/driver_license.dart';
 export 'src/objects/email.dart';
 export 'src/objects/geo_point.dart';
 export 'src/objects/mobile_scanner_arguments.dart';
+export 'src/objects/person_name.dart';
 export 'src/objects/sms.dart';
 export 'src/objects/url_bookmark.dart';
 export 'src/objects/wifi.dart';

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -14,5 +14,6 @@ export 'src/mobile_scanner_controller.dart';
 export 'src/mobile_scanner_exception.dart';
 export 'src/objects/barcode.dart';
 export 'src/objects/barcode_capture.dart';
+export 'src/objects/driver_license.dart';
 export 'src/objects/email.dart';
 export 'src/objects/mobile_scanner_arguments.dart';

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -17,6 +17,7 @@ export 'src/objects/barcode_capture.dart';
 export 'src/objects/calendar_event.dart';
 export 'src/objects/driver_license.dart';
 export 'src/objects/email.dart';
+export 'src/objects/geo_point.dart';
 export 'src/objects/mobile_scanner_arguments.dart';
 export 'src/objects/sms.dart';
 export 'src/objects/wifi.dart';

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -14,4 +14,5 @@ export 'src/mobile_scanner_controller.dart';
 export 'src/mobile_scanner_exception.dart';
 export 'src/objects/barcode.dart';
 export 'src/objects/barcode_capture.dart';
+export 'src/objects/email.dart';
 export 'src/objects/mobile_scanner_arguments.dart';

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -12,6 +12,7 @@ export 'src/enums/torch_state.dart';
 export 'src/mobile_scanner.dart';
 export 'src/mobile_scanner_controller.dart';
 export 'src/mobile_scanner_exception.dart';
+export 'src/objects/address.dart';
 export 'src/objects/barcode.dart';
 export 'src/objects/barcode_capture.dart';
 export 'src/objects/calendar_event.dart';

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -21,4 +21,5 @@ export 'src/objects/email.dart';
 export 'src/objects/geo_point.dart';
 export 'src/objects/mobile_scanner_arguments.dart';
 export 'src/objects/sms.dart';
+export 'src/objects/url_bookmark.dart';
 export 'src/objects/wifi.dart';

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -22,6 +22,7 @@ export 'src/objects/email.dart';
 export 'src/objects/geo_point.dart';
 export 'src/objects/mobile_scanner_arguments.dart';
 export 'src/objects/person_name.dart';
+export 'src/objects/phone.dart';
 export 'src/objects/sms.dart';
 export 'src/objects/url_bookmark.dart';
 export 'src/objects/wifi.dart';

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -15,6 +15,7 @@ export 'src/mobile_scanner_exception.dart';
 export 'src/objects/barcode.dart';
 export 'src/objects/barcode_capture.dart';
 export 'src/objects/calendar_event.dart';
+export 'src/objects/contact_info.dart';
 export 'src/objects/driver_license.dart';
 export 'src/objects/email.dart';
 export 'src/objects/geo_point.dart';

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -14,6 +14,7 @@ export 'src/mobile_scanner_controller.dart';
 export 'src/mobile_scanner_exception.dart';
 export 'src/objects/barcode.dart';
 export 'src/objects/barcode_capture.dart';
+export 'src/objects/calendar_event.dart';
 export 'src/objects/driver_license.dart';
 export 'src/objects/email.dart';
 export 'src/objects/mobile_scanner_arguments.dart';

--- a/lib/mobile_scanner_web_plugin.dart
+++ b/lib/mobile_scanner_web_plugin.dart
@@ -130,8 +130,6 @@ class MobileScannerWebPlugin {
       _barCodeStreamSubscription =
           barCodeReader.detectBarcodeContinuously().listen((code) {
         if (code != null) {
-          final List<Offset>? corners = code.corners;
-
           controller.add({
             'name': 'barcodeWeb',
             'data': {
@@ -140,8 +138,8 @@ class MobileScannerWebPlugin {
               'format': code.format.rawValue,
               'displayValue': code.displayValue,
               'type': code.type.rawValue,
-              if (corners != null && corners.isNotEmpty)
-                'corners': corners
+              if (code.corners.isNotEmpty)
+                'corners': code.corners
                     .map(
                       (Offset c) => <Object?, Object?>{'x': c.dx, 'y': c.dy},
                     )

--- a/lib/src/barcode_utility.dart
+++ b/lib/src/barcode_utility.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:mobile_scanner/src/objects/geo_point.dart';
 
 Size toSize(Map data) {
   final width = data['width'] as double;

--- a/lib/src/barcode_utility.dart
+++ b/lib/src/barcode_utility.dart
@@ -2,7 +2,6 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
-import 'package:mobile_scanner/src/objects/geo_point.dart';
 
 Size toSize(Map data) {
   final width = data['width'] as double;

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -442,9 +442,10 @@ class MobileScannerController {
                   rawBytes: barcode['rawBytes'] as Uint8List?,
                   format: toFormat(barcode['format'] as int),
                   corners: toCorners(
-                    (barcode['corners'] as List<Object?>? ?? [])
-                        .cast<Map<Object?, Object?>>(),
-                  ),
+                        (barcode['corners'] as List<Object?>? ?? [])
+                            .cast<Map<Object?, Object?>>(),
+                      ) ??
+                      const <Offset>[],
                 ),
             ],
           ),

--- a/lib/src/objects/address.dart
+++ b/lib/src/objects/address.dart
@@ -1,0 +1,33 @@
+import 'package:mobile_scanner/src/enums/address_type.dart';
+
+/// An address.
+class Address {
+  /// Creates a new [Address] instance.
+  const Address({
+    this.addressLines = const <String>[],
+    this.type = AddressType.unknown,
+  });
+
+  /// Creates a new [Address] instance from a map.
+  factory Address.fromNative(Map<Object?, Object?> data) {
+    final List<Object?>? addressLines = data['addressLines'] as List<Object?>?;
+    final AddressType type = AddressType.fromRawValue(
+      data['type'] as int? ?? 0,
+    );
+
+    if (addressLines == null) {
+      return Address(type: type);
+    }
+
+    return Address(
+      addressLines: List.unmodifiable(addressLines.cast<String>()),
+      type: type,
+    );
+  }
+
+  /// The address lines that represent this address.
+  final List<String> addressLines;
+
+  /// Gets type of the address.
+  final AddressType type;
+}

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -7,6 +7,7 @@ import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/barcode_type.dart';
 import 'package:mobile_scanner/src/enums/encryption_type.dart';
 import 'package:mobile_scanner/src/enums/phone_type.dart';
+import 'package:mobile_scanner/src/objects/calendar_event.dart';
 import 'package:mobile_scanner/src/objects/driver_license.dart';
 import 'package:mobile_scanner/src/objects/email.dart';
 
@@ -116,58 +117,6 @@ class Barcode {
         sms = toSMS(data['sms'] as Map?),
         url = toUrl(data['url'] as Map?),
         wifi = toWiFi(data['wifi'] as Map?);
-}
-
-/// A calendar event extracted from QRCode.
-class CalendarEvent {
-  /// Gets the description of the calendar event.
-  ///
-  /// Returns null if not available.
-  final String? description;
-
-  /// Gets the start date time of the calendar event.
-  ///
-  /// Returns null if not available.
-  final DateTime? start;
-
-  /// Gets the end date time of the calendar event.
-  ///
-  /// Returns null if not available.
-  final DateTime? end;
-
-  /// Gets the location of the calendar event.
-  ///
-  /// Returns null if not available.
-  final String? location;
-
-  /// Gets the organizer of the calendar event.
-  ///
-  /// Returns null if not available.
-  final String? organizer;
-
-  /// Gets the status of the calendar event.
-  ///
-  /// Returns null if not available.
-  final String? status;
-
-  /// Gets the summary of the calendar event.
-  ///
-  /// Returns null if not available.
-  final String? summary;
-
-  /// Create a [CalendarEvent] from native data.
-  CalendarEvent.fromNative(Map data)
-      : description = data['description'] as String?,
-        start = data['start'] != null
-            ? DateTime.tryParse(data['start'] as String)
-            : null,
-        end = data['end'] != null
-            ? DateTime.tryParse(data['end'] as String)
-            : null,
-        location = data['location'] as String?,
-        organizer = data['organizer'] as String?,
-        status = data['status'] as String?,
-        summary = data['summary'] as String?;
 }
 
 /// A person's or organization's business card. For example a VCARD.

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -7,6 +7,7 @@ import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/barcode_type.dart';
 import 'package:mobile_scanner/src/enums/encryption_type.dart';
 import 'package:mobile_scanner/src/enums/phone_type.dart';
+import 'package:mobile_scanner/src/objects/driver_license.dart';
 import 'package:mobile_scanner/src/objects/email.dart';
 
 /// Represents a single recognized barcode and its value.
@@ -289,98 +290,6 @@ class PersonName {
         suffix = data['suffix'] as String?,
         formattedName = data['formattedName'] as String?,
         pronunciation = data['pronunciation'] as String?;
-}
-
-/// A driver license or ID card.
-class DriverLicense {
-  /// Gets city of holder's address.
-  ///
-  /// Returns null if not available.
-  final String? addressCity;
-
-  /// Gets state of holder's address.
-  ///
-  /// Returns null if not available.
-  final String? addressState;
-
-  /// Gets holder's street address.
-  ///
-  /// Returns null if not available.
-  final String? addressStreet;
-
-  /// Gets postal code of holder's address.
-  ///
-  /// Returns null if not available.
-  final String? addressZip;
-
-  /// Gets birth date of the holder.
-  ///
-  /// Returns null if not available.
-  final String? birthDate;
-
-  /// Gets "DL" for driver licenses, "ID" for ID cards.
-  ///
-  /// Returns null if not available.
-  final String? documentType;
-
-  /// Gets expiry date of the license.
-  ///
-  /// Returns null if not available.
-  final String? expiryDate;
-
-  /// Gets holder's first name.
-  ///
-  /// Returns null if not available.
-  final String? firstName;
-
-  /// Gets holder's gender. 1 - male, 2 - female.
-  ///
-  /// Returns null if not available.
-  final String? gender;
-
-  /// Gets issue date of the license.
-  ///
-  /// The date format depends on the issuing country. MMDDYYYY for the US, YYYYMMDD for Canada.
-  ///
-  /// Returns null if not available.
-  final String? issueDate;
-
-  /// Gets the three-letter country code in which DL/ID was issued.
-  ///
-  /// Returns null if not available.
-  final String? issuingCountry;
-
-  /// Gets holder's last name.
-  ///
-  /// Returns null if not available.
-  final String? lastName;
-
-  /// Gets driver license ID number.
-  ///
-  /// Returns null if not available.
-  final String? licenseNumber;
-
-  /// Gets holder's middle name.
-  ///
-  /// Returns null if not available.
-  final String? middleName;
-
-  /// Create a [DriverLicense] from native data.
-  DriverLicense.fromNative(Map data)
-      : addressCity = data['addressCity'] as String?,
-        addressState = data['addressState'] as String?,
-        addressStreet = data['addressStreet'] as String?,
-        addressZip = data['addressZip'] as String?,
-        birthDate = data['birthDate'] as String?,
-        documentType = data['documentType'] as String?,
-        expiryDate = data['expiryDate'] as String?,
-        firstName = data['firstName'] as String?,
-        gender = data['gender'] as String?,
-        issueDate = data['issueDate'] as String?,
-        issuingCountry = data['issuingCountry'] as String?,
-        lastName = data['lastName'] as String?,
-        licenseNumber = data['licenseNumber'] as String?,
-        middleName = data['middleName'] as String?;
 }
 
 /// GPS coordinates from a 'GEO:' or similar QRCode type.

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 import 'dart:ui';
 
+import 'package:mobile_scanner/src/barcode_utility.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/barcode_type.dart';
 import 'package:mobile_scanner/src/objects/calendar_event.dart';
@@ -15,147 +16,109 @@ import 'package:mobile_scanner/src/objects/wifi.dart';
 
 /// Represents a single recognized barcode and its value.
 class Barcode {
-  /// Creates a new [Barcode] instance.
-  const Barcode({
-    this.calendarEvent,
-    this.contactInfo,
-    this.corners = const <Offset>[],
-    this.displayValue,
-    this.driverLicense,
-    this.email,
-    this.format = BarcodeFormat.unknown,
-    this.geoPoint,
-    this.phone,
-    this.rawBytes,
-    this.rawValue,
-    this.sms,
-    this.type = BarcodeType.unknown,
-    this.url,
-    this.wifi,
-  });
-
-  /// Creates a new [Barcode] instance from the given [data].
-  factory Barcode.fromNative(Map<Object?, Object?> data) {
-    final Map<Object?, Object?>? calendarEvent =
-        data['calendarEvent'] as Map<Object?, Object?>?;
-    final List<Object?>? corners = data['corners'] as List<Object?>?;
-    final Map<Object?, Object?>? contactInfo =
-        data['contactInfo'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? driverLicense =
-        data['driverLicense'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? email =
-        data['email'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? geoPoint =
-        data['geoPoint'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? phone =
-        data['phone'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? sms = data['sms'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? url = data['url'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? wifi = data['wifi'] as Map<Object?, Object?>?;
-
-    return Barcode(
-      calendarEvent: calendarEvent == null
-          ? null
-          : CalendarEvent.fromNative(calendarEvent),
-      contactInfo:
-          contactInfo == null ? null : ContactInfo.fromNative(contactInfo),
-      corners: corners == null
-          ? const <Offset>[]
-          : List.unmodifiable(
-              corners.cast<Map<String, double>>().map((Map<String, double> e) {
-                return Offset(e['x']!, e['y']!);
-              }),
-            ),
-      displayValue: data['displayValue'] as String?,
-      driverLicense: driverLicense == null
-          ? null
-          : DriverLicense.fromNative(driverLicense),
-      email: email == null ? null : Email.fromNative(email),
-      format: BarcodeFormat.fromRawValue(data['format'] as int? ?? -1),
-      geoPoint: geoPoint == null ? null : GeoPoint.fromNative(geoPoint),
-      phone: phone == null ? null : Phone.fromNative(phone),
-      rawBytes: data['rawBytes'] as Uint8List?,
-      rawValue: data['rawValue'] as String?,
-      sms: sms == null ? null : SMS.fromNative(sms),
-      type: BarcodeType.fromRawValue(data['type'] as int? ?? 0),
-      url: url == null ? null : UrlBookmark.fromNative(url),
-      wifi: wifi == null ? null : WiFi.fromNative(wifi),
-    );
-  }
-
-  /// The calendar event that is embedded in the barcode.
-  final CalendarEvent? calendarEvent;
-
-  /// The contact information that is embedded in the barcode.
-  final ContactInfo? contactInfo;
-
-  /// The four corner points of the barcode,
-  /// in clockwise order, starting with the top-left point.
+  /// Returns four corner points in clockwise direction starting with top-left.
   ///
   /// Due to the possible perspective distortions, this is not necessarily a rectangle.
   ///
-  /// This list is empty if the corners can not be determined.
+  /// Returns null if the corner points can not be determined.
   final List<Offset> corners;
 
-  /// The barcode value in a user-friendly format.
-  ///
-  /// This value may omit some of the information encoded in the barcode.
-  /// For example, if [rawValue] returns `MEBKM:TITLE:Google;URL://www.google.com;;`,
-  /// the display value might be `//www.google.com`.
-  ///
-  /// This value may be multiline if line breaks are encoded in the barcode.
-  /// This value may include the supplement value.
-  ///
-  /// This is null if there is no user-friendly value for the given barcode.
-  final String? displayValue;
-
-  /// The driver license information that is embedded in the barcode.
-  final DriverLicense? driverLicense;
-
-  /// The email message that is embedded in the barcode.
-  final Email? email;
-
-  /// The format of the barcode.
+  /// Returns barcode format
   final BarcodeFormat format;
 
-  /// The geographic point that is embedded in the barcode.
-  final GeoPoint? geoPoint;
-
-  /// The phone number that is embedded in the barcode.
-  final Phone? phone;
-
-  /// The raw bytes of the barcode.
+  /// Returns raw bytes as it was encoded in the barcode.
   ///
-  /// This is null if the raw bytes are not available.
+  /// Returns null if the raw bytes can not be determined.
   final Uint8List? rawBytes;
 
-  /// The raw value of `UTF-8` encoded barcodes.
+  /// Returns barcode value as it was encoded in the barcode. Structured values are not parsed, for example: 'MEBKM:TITLE:Google;URL://www.google.com;;'.
   ///
-  /// Structured values are not parsed,
-  /// for example: 'MEBKM:TITLE:Google;URL://www.google.com;;'.
+  /// It's only available when the barcode is encoded in the UTF-8 format, and for non-UTF8 ones use [rawBytes] instead.
   ///
-  /// For non-UTF-8 barcodes, prefer using [rawBytes] instead.
-  ///
-  /// This is null if the raw value is not available.
+  /// Returns null if the raw value can not be determined.
   final String? rawValue;
 
-  /// The SMS message that is embedded in the barcode.
-  final SMS? sms;
+  /// Returns barcode value in a user-friendly format.
+  ///
+  /// This method may omit some of the information encoded in the barcode. For example, if [rawValue] returns 'MEBKM:TITLE:Google;URL://www.google.com;;', the display value might be '//www.google.com'.
+  ///
+  /// This value may be multiline, for example, when line breaks are encoded into the original TEXT barcode value. May include the supplement value.
+  ///
+  /// Returns null if nothing found.
+  final String? displayValue;
 
-  /// The type of the [format] of the barcode.
+  /// Returns format type of the barcode value.
   ///
-  /// For types that are recognized,
-  /// but could not be parsed correctly, [BarcodeType.text] will be returned.
+  /// For example, TYPE_TEXT, TYPE_PRODUCT, TYPE_URL, etc.
   ///
-  /// For types that are not recognised, [BarcodeType.unknown] will be returned.
+  /// If the value structure cannot be parsed, TYPE_TEXT will be returned. If the recognized structure type is not defined in your current version of SDK, TYPE_UNKNOWN will be returned.
   ///
-  /// If a given barcode was not correctly identified,
-  /// consider parsing [rawValue] manually instead.
+  /// Note that the built-in parsers only recognize a few popular value structures. For your specific use case, you might want to directly consume rawValue and implement your own parsing logic.
   final BarcodeType type;
 
-  /// The URL bookmark that is embedded in the barcode.
+  /// Gets parsed calendar event details.
+  final CalendarEvent? calendarEvent;
+
+  /// Gets parsed contact details.
+  final ContactInfo? contactInfo;
+
+  /// Gets parsed driver license details.
+  final DriverLicense? driverLicense;
+
+  /// Gets parsed email details.
+  final Email? email;
+
+  /// Gets parsed geo coordinates.
+  final GeoPoint? geoPoint;
+
+  /// Gets parsed phone number details.
+  final Phone? phone;
+
+  /// Gets parsed SMS details.
+  final SMS? sms;
+
+  /// Gets parsed URL bookmark details.
   final UrlBookmark? url;
 
-  /// The Wireless network information that is embedded in the barcode.
+  /// Gets parsed WiFi AP details.
   final WiFi? wifi;
+
+  Barcode({
+    this.corners = const <Offset>[],
+    this.format = BarcodeFormat.ean13,
+    this.rawBytes,
+    this.type = BarcodeType.text,
+    this.calendarEvent,
+    this.contactInfo,
+    this.driverLicense,
+    this.email,
+    this.geoPoint,
+    this.phone,
+    this.sms,
+    this.url,
+    this.wifi,
+    this.displayValue,
+    required this.rawValue,
+  });
+
+  /// Create a [Barcode] from native data.
+  Barcode.fromNative(Map data)
+      : corners = toCorners(
+              (data['corners'] as List?)?.cast<Map<Object?, Object?>>(),
+            ) ??
+            const <Offset>[],
+        format = toFormat(data['format'] as int),
+        rawBytes = data['rawBytes'] as Uint8List?,
+        rawValue = data['rawValue'] as String?,
+        displayValue = data['displayValue'] as String?,
+        type = BarcodeType.values[data['type'] as int],
+        calendarEvent = toCalendarEvent(data['calendarEvent'] as Map?),
+        contactInfo = toContactInfo(data['contactInfo'] as Map?),
+        driverLicense = toDriverLicense(data['driverLicense'] as Map?),
+        email = toEmail(data['email'] as Map?),
+        geoPoint = toGeoPoint(data['geoPoint'] as Map?),
+        phone = toPhone(data['phone'] as Map?),
+        sms = toSMS(data['sms'] as Map?),
+        url = toUrl(data['url'] as Map?),
+        wifi = toWiFi(data['wifi'] as Map?);
 }

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -9,6 +9,7 @@ import 'package:mobile_scanner/src/enums/phone_type.dart';
 import 'package:mobile_scanner/src/objects/calendar_event.dart';
 import 'package:mobile_scanner/src/objects/driver_license.dart';
 import 'package:mobile_scanner/src/objects/email.dart';
+import 'package:mobile_scanner/src/objects/sms.dart';
 import 'package:mobile_scanner/src/objects/wifi.dart';
 
 /// Represents a single recognized barcode and its value.
@@ -272,24 +273,6 @@ class Phone {
   Phone.fromNative(Map data)
       : number = data['number'] as String?,
         type = PhoneType.values[data['type'] as int];
-}
-
-/// A sms message from a 'SMS:' or similar QRCode type.
-class SMS {
-  /// Gets the message content of the sms.
-  ///
-  /// Returns null if not available.
-  final String? message;
-
-  /// Gets the phone number of the sms.
-  ///
-  /// Returns null if not available.
-  final String? phoneNumber;
-
-  /// Create a [SMS] from native data.
-  SMS.fromNative(Map data)
-      : message = data['message'] as String?,
-        phoneNumber = data['phoneNumber'] as String?;
 }
 
 /// A URL and title from a 'MEBKM:' or similar QRCode type.

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -5,9 +5,9 @@ import 'package:mobile_scanner/src/barcode_utility.dart';
 import 'package:mobile_scanner/src/enums/address_type.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/barcode_type.dart';
-import 'package:mobile_scanner/src/enums/email_type.dart';
 import 'package:mobile_scanner/src/enums/encryption_type.dart';
 import 'package:mobile_scanner/src/enums/phone_type.dart';
+import 'package:mobile_scanner/src/objects/email.dart';
 
 /// Represents a single recognized barcode and its value.
 class Barcode {
@@ -381,37 +381,6 @@ class DriverLicense {
         lastName = data['lastName'] as String?,
         licenseNumber = data['licenseNumber'] as String?,
         middleName = data['middleName'] as String?;
-}
-
-/// An email message from a 'MAILTO:' or similar QRCode type.
-class Email {
-  /// Gets email's address.
-  ///
-  /// Returns null if not available.
-  final String? address;
-
-  /// Gets email's body.
-  ///
-  /// Returns null if not available.
-  final String? body;
-
-  /// Gets email's subject.
-  ///
-  /// Returns null if not available.
-  final String? subject;
-
-  /// Gets type of the email.
-  ///
-  /// See also [EmailType].
-  /// Returns null if not available.
-  final EmailType? type;
-
-  /// Create a [Email] from native data.
-  Email.fromNative(Map data)
-      : address = data['address'] as String?,
-        body = data['body'] as String?,
-        subject = data['subject'] as String?,
-        type = EmailType.values[data['type'] as int];
 }
 
 /// GPS coordinates from a 'GEO:' or similar QRCode type.

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -5,11 +5,11 @@ import 'package:mobile_scanner/src/barcode_utility.dart';
 import 'package:mobile_scanner/src/enums/address_type.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/barcode_type.dart';
-import 'package:mobile_scanner/src/enums/encryption_type.dart';
 import 'package:mobile_scanner/src/enums/phone_type.dart';
 import 'package:mobile_scanner/src/objects/calendar_event.dart';
 import 'package:mobile_scanner/src/objects/driver_license.dart';
 import 'package:mobile_scanner/src/objects/email.dart';
+import 'package:mobile_scanner/src/objects/wifi.dart';
 
 /// Represents a single recognized barcode and its value.
 class Barcode {
@@ -308,28 +308,4 @@ class UrlBookmark {
   UrlBookmark.fromNative(Map data)
       : title = data['title'] as String?,
         url = data['url'] as String?;
-}
-
-/// A wifi network parameters from a 'WIFI:' or similar QRCode type.
-class WiFi {
-  /// Gets the encryption type of the WIFI.
-  ///
-  /// See all [EncryptionType].
-  final EncryptionType encryptionType;
-
-  /// Gets the ssid of the WIFI.
-  ///
-  /// Returns null if not available.
-  final String? ssid;
-
-  /// Gets the password of the WIFI.
-  ///
-  /// Returns null if not available.
-  final String? password;
-
-  /// Create a [WiFi] from native data.
-  WiFi.fromNative(Map data)
-      : encryptionType = EncryptionType.values[data['encryptionType'] as int],
-        ssid = data['ssid'] as String?,
-        password = data['password'] as String?;
 }

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -2,7 +2,6 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:mobile_scanner/src/barcode_utility.dart';
-import 'package:mobile_scanner/src/enums/address_type.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/barcode_type.dart';
 import 'package:mobile_scanner/src/enums/phone_type.dart';
@@ -121,24 +120,6 @@ class Barcode {
         sms = toSMS(data['sms'] as Map?),
         url = toUrl(data['url'] as Map?),
         wifi = toWiFi(data['wifi'] as Map?);
-}
-
-/// An address.
-class Address {
-  /// Gets formatted address, multiple lines when appropriate. This field always contains at least one line.
-  final List<String> addressLines;
-
-  /// Gets type of the address.
-  ///
-  /// Returns null if not available.
-  final AddressType? type;
-
-  /// Create a [Address] from native data.
-  Address.fromNative(Map data)
-      : addressLines = List.unmodifiable(
-          (data['addressLines'] as List? ?? []).cast<String>(),
-        ),
-        type = AddressType.values[data['type'] as int];
 }
 
 /// Phone number info.

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -9,6 +9,7 @@ import 'package:mobile_scanner/src/enums/phone_type.dart';
 import 'package:mobile_scanner/src/objects/calendar_event.dart';
 import 'package:mobile_scanner/src/objects/driver_license.dart';
 import 'package:mobile_scanner/src/objects/email.dart';
+import 'package:mobile_scanner/src/objects/geo_point.dart';
 import 'package:mobile_scanner/src/objects/sms.dart';
 import 'package:mobile_scanner/src/objects/wifi.dart';
 
@@ -240,20 +241,6 @@ class PersonName {
         suffix = data['suffix'] as String?,
         formattedName = data['formattedName'] as String?,
         pronunciation = data['pronunciation'] as String?;
-}
-
-/// GPS coordinates from a 'GEO:' or similar QRCode type.
-class GeoPoint {
-  /// Gets the latitude.
-  final double? latitude;
-
-  /// Gets the longitude.
-  final double? longitude;
-
-  /// Create a [GeoPoint] from native data.
-  GeoPoint.fromNative(Map data)
-      : latitude = data['latitude'] as double?,
-        longitude = data['longitude'] as double?;
 }
 
 /// Phone number info.

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 import 'dart:ui';
 
-import 'package:mobile_scanner/src/barcode_utility.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/barcode_type.dart';
 import 'package:mobile_scanner/src/objects/calendar_event.dart';
@@ -16,108 +15,147 @@ import 'package:mobile_scanner/src/objects/wifi.dart';
 
 /// Represents a single recognized barcode and its value.
 class Barcode {
-  /// Returns four corner points in clockwise direction starting with top-left.
+  /// Creates a new [Barcode] instance.
+  const Barcode({
+    this.calendarEvent,
+    this.contactInfo,
+    this.corners = const <Offset>[],
+    this.displayValue,
+    this.driverLicense,
+    this.email,
+    this.format = BarcodeFormat.unknown,
+    this.geoPoint,
+    this.phone,
+    this.rawBytes,
+    this.rawValue,
+    this.sms,
+    this.type = BarcodeType.unknown,
+    this.url,
+    this.wifi,
+  });
+
+  /// Creates a new [Barcode] instance from the given [data].
+  factory Barcode.fromNative(Map<Object?, Object?> data) {
+    final Map<Object?, Object?>? calendarEvent =
+        data['calendarEvent'] as Map<Object?, Object?>?;
+    final List<Object?>? corners = data['corners'] as List<Object?>?;
+    final Map<Object?, Object?>? contactInfo =
+        data['contactInfo'] as Map<Object?, Object?>?;
+    final Map<Object?, Object?>? driverLicense =
+        data['driverLicense'] as Map<Object?, Object?>?;
+    final Map<Object?, Object?>? email =
+        data['email'] as Map<Object?, Object?>?;
+    final Map<Object?, Object?>? geoPoint =
+        data['geoPoint'] as Map<Object?, Object?>?;
+    final Map<Object?, Object?>? phone =
+        data['phone'] as Map<Object?, Object?>?;
+    final Map<Object?, Object?>? sms = data['sms'] as Map<Object?, Object?>?;
+    final Map<Object?, Object?>? url = data['url'] as Map<Object?, Object?>?;
+    final Map<Object?, Object?>? wifi = data['wifi'] as Map<Object?, Object?>?;
+
+    return Barcode(
+      calendarEvent: calendarEvent == null
+          ? null
+          : CalendarEvent.fromNative(calendarEvent),
+      contactInfo:
+          contactInfo == null ? null : ContactInfo.fromNative(contactInfo),
+      corners: corners == null
+          ? const <Offset>[]
+          : List.unmodifiable(
+              corners.cast<Map<String, double>>().map((Map<String, double> e) {
+                return Offset(e['x']!, e['y']!);
+              }),
+            ),
+      displayValue: data['displayValue'] as String?,
+      driverLicense: driverLicense == null
+          ? null
+          : DriverLicense.fromNative(driverLicense),
+      email: email == null ? null : Email.fromNative(email),
+      format: BarcodeFormat.fromRawValue(data['format'] as int? ?? -1),
+      geoPoint: geoPoint == null ? null : GeoPoint.fromNative(geoPoint),
+      phone: phone == null ? null : Phone.fromNative(phone),
+      rawBytes: data['rawBytes'] as Uint8List?,
+      rawValue: data['rawValue'] as String?,
+      sms: sms == null ? null : SMS.fromNative(sms),
+      type: BarcodeType.fromRawValue(data['type'] as int? ?? 0),
+      url: url == null ? null : UrlBookmark.fromNative(url),
+      wifi: wifi == null ? null : WiFi.fromNative(wifi),
+    );
+  }
+
+  /// The calendar event that is embedded in the barcode.
+  final CalendarEvent? calendarEvent;
+
+  /// The contact information that is embedded in the barcode.
+  final ContactInfo? contactInfo;
+
+  /// The four corner points of the barcode,
+  /// in clockwise order, starting with the top-left point.
   ///
   /// Due to the possible perspective distortions, this is not necessarily a rectangle.
   ///
-  /// Returns null if the corner points can not be determined.
-  final List<Offset>? corners;
+  /// This list is empty if the corners can not be determined.
+  final List<Offset> corners;
 
-  /// Returns barcode format
-  final BarcodeFormat format;
-
-  /// Returns raw bytes as it was encoded in the barcode.
+  /// The barcode value in a user-friendly format.
   ///
-  /// Returns null if the raw bytes can not be determined.
-  final Uint8List? rawBytes;
-
-  /// Returns barcode value as it was encoded in the barcode. Structured values are not parsed, for example: 'MEBKM:TITLE:Google;URL://www.google.com;;'.
+  /// This value may omit some of the information encoded in the barcode.
+  /// For example, if [rawValue] returns `MEBKM:TITLE:Google;URL://www.google.com;;`,
+  /// the display value might be `//www.google.com`.
   ///
-  /// It's only available when the barcode is encoded in the UTF-8 format, and for non-UTF8 ones use [rawBytes] instead.
+  /// This value may be multiline if line breaks are encoded in the barcode.
+  /// This value may include the supplement value.
   ///
-  /// Returns null if the raw value can not be determined.
-  final String? rawValue;
-
-  /// Returns barcode value in a user-friendly format.
-  ///
-  /// This method may omit some of the information encoded in the barcode. For example, if [rawValue] returns 'MEBKM:TITLE:Google;URL://www.google.com;;', the display value might be '//www.google.com'.
-  ///
-  /// This value may be multiline, for example, when line breaks are encoded into the original TEXT barcode value. May include the supplement value.
-  ///
-  /// Returns null if nothing found.
+  /// This is null if there is no user-friendly value for the given barcode.
   final String? displayValue;
 
-  /// Returns format type of the barcode value.
-  ///
-  /// For example, TYPE_TEXT, TYPE_PRODUCT, TYPE_URL, etc.
-  ///
-  /// If the value structure cannot be parsed, TYPE_TEXT will be returned. If the recognized structure type is not defined in your current version of SDK, TYPE_UNKNOWN will be returned.
-  ///
-  /// Note that the built-in parsers only recognize a few popular value structures. For your specific use case, you might want to directly consume rawValue and implement your own parsing logic.
-  final BarcodeType type;
-
-  /// Gets parsed calendar event details.
-  final CalendarEvent? calendarEvent;
-
-  /// Gets parsed contact details.
-  final ContactInfo? contactInfo;
-
-  /// Gets parsed driver license details.
+  /// The driver license information that is embedded in the barcode.
   final DriverLicense? driverLicense;
 
-  /// Gets parsed email details.
+  /// The email message that is embedded in the barcode.
   final Email? email;
 
-  /// Gets parsed geo coordinates.
+  /// The format of the barcode.
+  final BarcodeFormat format;
+
+  /// The geographic point that is embedded in the barcode.
   final GeoPoint? geoPoint;
 
-  /// Gets parsed phone number details.
+  /// The phone number that is embedded in the barcode.
   final Phone? phone;
 
-  /// Gets parsed SMS details.
+  /// The raw bytes of the barcode.
+  ///
+  /// This is null if the raw bytes are not available.
+  final Uint8List? rawBytes;
+
+  /// The raw value of `UTF-8` encoded barcodes.
+  ///
+  /// Structured values are not parsed,
+  /// for example: 'MEBKM:TITLE:Google;URL://www.google.com;;'.
+  ///
+  /// For non-UTF-8 barcodes, prefer using [rawBytes] instead.
+  ///
+  /// This is null if the raw value is not available.
+  final String? rawValue;
+
+  /// The SMS message that is embedded in the barcode.
   final SMS? sms;
 
-  /// Gets parsed URL bookmark details.
+  /// The type of the [format] of the barcode.
+  ///
+  /// For types that are recognized,
+  /// but could not be parsed correctly, [BarcodeType.text] will be returned.
+  ///
+  /// For types that are not recognised, [BarcodeType.unknown] will be returned.
+  ///
+  /// If a given barcode was not correctly identified,
+  /// consider parsing [rawValue] manually instead.
+  final BarcodeType type;
+
+  /// The URL bookmark that is embedded in the barcode.
   final UrlBookmark? url;
 
-  /// Gets parsed WiFi AP details.
+  /// The Wireless network information that is embedded in the barcode.
   final WiFi? wifi;
-
-  Barcode({
-    this.corners,
-    this.format = BarcodeFormat.ean13,
-    this.rawBytes,
-    this.type = BarcodeType.text,
-    this.calendarEvent,
-    this.contactInfo,
-    this.driverLicense,
-    this.email,
-    this.geoPoint,
-    this.phone,
-    this.sms,
-    this.url,
-    this.wifi,
-    this.displayValue,
-    required this.rawValue,
-  });
-
-  /// Create a [Barcode] from native data.
-  Barcode.fromNative(Map data)
-      : corners = toCorners(
-          (data['corners'] as List?)?.cast<Map<Object?, Object?>>(),
-        ),
-        format = toFormat(data['format'] as int),
-        rawBytes = data['rawBytes'] as Uint8List?,
-        rawValue = data['rawValue'] as String?,
-        displayValue = data['displayValue'] as String?,
-        type = BarcodeType.values[data['type'] as int],
-        calendarEvent = toCalendarEvent(data['calendarEvent'] as Map?),
-        contactInfo = toContactInfo(data['contactInfo'] as Map?),
-        driverLicense = toDriverLicense(data['driverLicense'] as Map?),
-        email = toEmail(data['email'] as Map?),
-        geoPoint = toGeoPoint(data['geoPoint'] as Map?),
-        phone = toPhone(data['phone'] as Map?),
-        sms = toSMS(data['sms'] as Map?),
-        url = toUrl(data['url'] as Map?),
-        wifi = toWiFi(data['wifi'] as Map?);
 }

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -12,6 +12,7 @@ import 'package:mobile_scanner/src/objects/driver_license.dart';
 import 'package:mobile_scanner/src/objects/email.dart';
 import 'package:mobile_scanner/src/objects/geo_point.dart';
 import 'package:mobile_scanner/src/objects/sms.dart';
+import 'package:mobile_scanner/src/objects/url_bookmark.dart';
 import 'package:mobile_scanner/src/objects/wifi.dart';
 
 /// Represents a single recognized barcode and its value.
@@ -205,22 +206,4 @@ class Phone {
   Phone.fromNative(Map data)
       : number = data['number'] as String?,
         type = PhoneType.values[data['type'] as int];
-}
-
-/// A URL and title from a 'MEBKM:' or similar QRCode type.
-class UrlBookmark {
-  /// Gets the title of the bookmark.
-  ///
-  /// Returns null if not available.
-  final String? title;
-
-  /// Gets the url of the bookmark.
-  ///
-  /// Returns null if not available.
-  final String? url;
-
-  /// Create a [UrlBookmark] from native data.
-  UrlBookmark.fromNative(Map data)
-      : title = data['title'] as String?,
-        url = data['url'] as String?;
 }

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -4,12 +4,12 @@ import 'dart:ui';
 import 'package:mobile_scanner/src/barcode_utility.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/barcode_type.dart';
-import 'package:mobile_scanner/src/enums/phone_type.dart';
 import 'package:mobile_scanner/src/objects/calendar_event.dart';
 import 'package:mobile_scanner/src/objects/contact_info.dart';
 import 'package:mobile_scanner/src/objects/driver_license.dart';
 import 'package:mobile_scanner/src/objects/email.dart';
 import 'package:mobile_scanner/src/objects/geo_point.dart';
+import 'package:mobile_scanner/src/objects/phone.dart';
 import 'package:mobile_scanner/src/objects/sms.dart';
 import 'package:mobile_scanner/src/objects/url_bookmark.dart';
 import 'package:mobile_scanner/src/objects/wifi.dart';
@@ -120,23 +120,4 @@ class Barcode {
         sms = toSMS(data['sms'] as Map?),
         url = toUrl(data['url'] as Map?),
         wifi = toWiFi(data['wifi'] as Map?);
-}
-
-/// Phone number info.
-class Phone {
-  /// Gets phone number.
-  ///
-  /// Returns null if not available.
-  final String? number;
-
-  /// Gets type of the phone number.
-  ///
-  /// See also [PhoneType].
-  /// Returns null if not available.
-  final PhoneType? type;
-
-  /// Create a [Phone] from native data.
-  Phone.fromNative(Map data)
-      : number = data['number'] as String?,
-        type = PhoneType.values[data['type'] as int];
 }

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -7,6 +7,7 @@ import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/barcode_type.dart';
 import 'package:mobile_scanner/src/enums/phone_type.dart';
 import 'package:mobile_scanner/src/objects/calendar_event.dart';
+import 'package:mobile_scanner/src/objects/contact_info.dart';
 import 'package:mobile_scanner/src/objects/driver_license.dart';
 import 'package:mobile_scanner/src/objects/email.dart';
 import 'package:mobile_scanner/src/objects/geo_point.dart';
@@ -119,62 +120,6 @@ class Barcode {
         sms = toSMS(data['sms'] as Map?),
         url = toUrl(data['url'] as Map?),
         wifi = toWiFi(data['wifi'] as Map?);
-}
-
-/// A person's or organization's business card. For example a VCARD.
-class ContactInfo {
-  /// Gets contact person's addresses.
-  ///
-  /// Returns an empty list if nothing found.
-  final List<Address> addresses;
-
-  /// Gets contact person's emails.
-  ///
-  /// Returns an empty list if nothing found.
-  final List<Email> emails;
-
-  /// Gets contact person's name.
-  ///
-  /// Returns null if not available.
-  final PersonName? name;
-
-  /// Gets contact person's organization.
-  ///
-  /// Returns null if not available.
-  final String? organization;
-
-  /// Gets contact person's phones.
-  ///
-  /// Returns an empty list if nothing found.
-  final List<Phone>? phones;
-
-  /// Gets contact person's title.
-  ///
-  /// Returns null if not available.
-  final String? title;
-
-  /// Gets contact person's urls.
-  ///
-  /// Returns an empty list if nothing found.
-  final List<String>? urls;
-
-  /// Create a [ContactInfo] from native data.
-  ContactInfo.fromNative(Map data)
-      : addresses = List.unmodifiable(
-          (data['addresses'] as List? ?? [])
-              .cast<Map>()
-              .map(Address.fromNative),
-        ),
-        emails = List.unmodifiable(
-          (data['emails'] as List? ?? []).cast<Map>().map(Email.fromNative),
-        ),
-        name = toName(data['name'] as Map?),
-        organization = data['organization'] as String?,
-        phones = List.unmodifiable(
-          (data['phones'] as List? ?? []).cast<Map>().map(Phone.fromNative),
-        ),
-        title = data['title'] as String?,
-        urls = List.unmodifiable((data['urls'] as List? ?? []).cast<String>());
 }
 
 /// An address.

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -141,54 +141,6 @@ class Address {
         type = AddressType.values[data['type'] as int];
 }
 
-/// A person's name, both formatted version and individual name components.
-class PersonName {
-  /// Gets first name.
-  ///
-  /// Returns null if not available.
-  final String? first;
-
-  /// Gets middle name.
-  ///
-  /// Returns null if not available.
-  final String? middle;
-
-  /// Gets last name.
-  ///
-  /// Returns null if not available.
-  final String? last;
-
-  /// Gets prefix of the name.
-  ///
-  /// Returns null if not available.
-  final String? prefix;
-
-  /// Gets suffix of the person's name.
-  ///
-  /// Returns null if not available.
-  final String? suffix;
-
-  /// Gets the properly formatted name.
-  ///
-  /// Returns null if not available.
-  final String? formattedName;
-
-  /// Designates a text string to be set as the kana name in the phonebook. Used for Japanese contacts.
-  ///
-  /// Returns null if not available.
-  final String? pronunciation;
-
-  /// Create a [PersonName] from native data.
-  PersonName.fromNative(Map data)
-      : first = data['first'] as String?,
-        middle = data['middle'] as String?,
-        last = data['last'] as String?,
-        prefix = data['prefix'] as String?,
-        suffix = data['suffix'] as String?,
-        formattedName = data['formattedName'] as String?,
-        pronunciation = data['pronunciation'] as String?;
-}
-
 /// Phone number info.
 class Phone {
   /// Gets phone number.

--- a/lib/src/objects/barcode_capture.dart
+++ b/lib/src/objects/barcode_capture.dart
@@ -1,27 +1,43 @@
 import 'dart:typed_data';
+import 'dart:ui';
 
 import 'package:mobile_scanner/src/objects/barcode.dart';
 
-/// The return object after a frame is scanned.
-///
-/// [barcodes] A list with barcodes. A scanned frame can contain multiple
-/// barcodes.
-/// [image] If enabled, an image of the scanned frame.
+/// This class represents a scanned barcode.
 class BarcodeCapture {
-  final List<Barcode> barcodes;
-  final dynamic raw;
+  /// Create a new [BarcodeCapture] instance.
+  BarcodeCapture({
+    this.barcodes = const <Barcode>[],
+    double? height,
+    this.image,
+    this.raw,
+    double? width,
+  }) : size =
+            width == null && height == null ? Size.zero : Size(width!, height!);
 
+  /// The list of scanned barcodes.
+  final List<Barcode> barcodes;
+
+  /// The bytes of the image that is embedded in the barcode.
+  ///
+  /// This null if [MobileScannerController.returnImage] is false.
   final Uint8List? image;
 
-  final double? width;
+  /// The raw data of the scanned barcode.
+  final dynamic raw; // TODO: this should be `Object?` instead of dynamic
 
-  final double? height;
+  /// The size of the scanned barcode.
+  final Size size;
 
-  BarcodeCapture({
-    required this.barcodes,
-    required this.raw,
-    this.image,
-    this.width,
-    this.height,
-  });
+  /// The width of the scanned barcode.
+  ///
+  /// Prefer using `size.width` instead,
+  /// as this getter will be removed in the future.
+  double get width => size.width;
+
+  /// The height of the scanned barcode.
+  ///
+  /// Prefer using `size.height` instead,
+  /// as this getter will be removed in the future.
+  double get height => size.height;
 }

--- a/lib/src/objects/calendar_event.dart
+++ b/lib/src/objects/calendar_event.dart
@@ -1,0 +1,47 @@
+/// A calendar event extracted from a QRCode.
+class CalendarEvent {
+  /// Create a new [CalendarEvent] instance.
+  const CalendarEvent({
+    this.description,
+    this.start,
+    this.end,
+    this.location,
+    this.organizer,
+    this.status,
+    this.summary,
+  });
+
+  /// Create a new [CalendarEvent] instance from a map.
+  factory CalendarEvent.fromNative(Map<Object?, Object?> data) {
+    return CalendarEvent(
+      description: data['description'] as String?,
+      start: DateTime.tryParse(data['start'] as String? ?? ''),
+      end: DateTime.tryParse(data['end'] as String? ?? ''),
+      location: data['location'] as String?,
+      organizer: data['organizer'] as String?,
+      status: data['status'] as String?,
+      summary: data['summary'] as String?,
+    );
+  }
+
+  /// The description of the calendar event.
+  final String? description;
+
+  /// The start time of the calendar event.
+  final DateTime? start;
+
+  /// The end time of the calendar event.
+  final DateTime? end;
+
+  /// The location of the calendar event.
+  final String? location;
+
+  /// The organizer of the calendar event.
+  final String? organizer;
+
+  /// The status of the calendar event.
+  final String? status;
+
+  /// The summary of the calendar event.
+  final String? summary;
+}

--- a/lib/src/objects/contact_info.dart
+++ b/lib/src/objects/contact_info.dart
@@ -1,5 +1,6 @@
 import 'package:mobile_scanner/src/objects/barcode.dart';
 import 'package:mobile_scanner/src/objects/email.dart';
+import 'package:mobile_scanner/src/objects/person_name.dart';
 
 /// A person's or organization's business card.
 /// For example a VCARD.

--- a/lib/src/objects/contact_info.dart
+++ b/lib/src/objects/contact_info.dart
@@ -1,3 +1,4 @@
+import 'package:mobile_scanner/src/objects/address.dart';
 import 'package:mobile_scanner/src/objects/barcode.dart';
 import 'package:mobile_scanner/src/objects/email.dart';
 import 'package:mobile_scanner/src/objects/person_name.dart';

--- a/lib/src/objects/contact_info.dart
+++ b/lib/src/objects/contact_info.dart
@@ -1,0 +1,71 @@
+import 'package:mobile_scanner/src/objects/barcode.dart';
+import 'package:mobile_scanner/src/objects/email.dart';
+
+/// A person's or organization's business card.
+/// For example a VCARD.
+class ContactInfo {
+  /// Create a new [ContactInfo] instance.
+  const ContactInfo({
+    this.addresses = const <Address>[],
+    this.emails = const <Email>[],
+    this.name,
+    this.organization,
+    this.phones = const <Phone>[],
+    this.title,
+    this.urls = const <String>[],
+  });
+
+  /// Create a new [ContactInfo] instance from a map.
+  factory ContactInfo.fromNative(Map<Object?, Object?> data) {
+    final List<Object?>? addresses = data['addresses'] as List<Object?>?;
+    final List<Object?>? emails = data['emails'] as List<Object?>?;
+    final List<Object?>? phones = data['phones'] as List<Object?>?;
+    final List<Object?>? urls = data['urls'] as List<Object?>?;
+    final Map<Object?, Object?>? name = data['name'] as Map<Object?, Object?>?;
+
+    return ContactInfo(
+      addresses: addresses == null
+          ? const <Address>[]
+          : List.unmodifiable(
+              addresses.cast<Map<Object?, Object?>>().map(Address.fromNative),
+            ),
+      emails: emails == null
+          ? const <Email>[]
+          : List.unmodifiable(
+              emails.cast<Map<Object?, Object?>>().map(Email.fromNative),
+            ),
+      name: name == null ? null : PersonName.fromNative(name),
+      organization: data['organization'] as String?,
+      phones: phones == null
+          ? const <Phone>[]
+          : List.unmodifiable(
+              phones.cast<Map<Object?, Object?>>().map(Phone.fromNative),
+            ),
+      title: data['title'] as String?,
+      urls: urls == null
+          ? const <String>[]
+          : List.unmodifiable(urls.cast<String>()),
+    );
+  }
+
+  /// The list of addresses for the person or organisation.
+  final List<Address> addresses;
+
+  /// The list of email addresses for the person or organisation.
+  final List<Email> emails;
+
+  /// The name of the contact person.
+  final PersonName? name;
+
+  /// The name of the organization.
+  final String? organization;
+
+  /// The available phone numbers for the contact person or organisation.
+  final List<Phone> phones;
+
+  /// The contact person's title.
+  final String? title;
+
+  /// The urls associated with the contact person or organisation.
+  final List<String> urls;
+}

--- a/lib/src/objects/contact_info.dart
+++ b/lib/src/objects/contact_info.dart
@@ -1,7 +1,7 @@
 import 'package:mobile_scanner/src/objects/address.dart';
-import 'package:mobile_scanner/src/objects/barcode.dart';
 import 'package:mobile_scanner/src/objects/email.dart';
 import 'package:mobile_scanner/src/objects/person_name.dart';
+import 'package:mobile_scanner/src/objects/phone.dart';
 
 /// A person's or organization's business card.
 /// For example a VCARD.

--- a/lib/src/objects/driver_license.dart
+++ b/lib/src/objects/driver_license.dart
@@ -1,0 +1,90 @@
+/// A driver license or ID card.
+class DriverLicense {
+  /// Create a new [DriverLicense].
+  const DriverLicense({
+    this.addressCity,
+    this.addressState,
+    this.addressStreet,
+    this.addressZip,
+    this.birthDate,
+    this.documentType,
+    this.expiryDate,
+    this.firstName,
+    this.gender,
+    this.issueDate,
+    this.issuingCountry,
+    this.lastName,
+    this.licenseNumber,
+    this.middleName,
+  });
+
+  /// Create a [DriverLicense] from a map.
+  factory DriverLicense.fromNative(Map<Object?, Object?> data) {
+    return DriverLicense(
+      addressCity: data['addressCity'] as String?,
+      addressState: data['addressState'] as String?,
+      addressStreet: data['addressStreet'] as String?,
+      addressZip: data['addressZip'] as String?,
+      birthDate: data['birthDate'] as String?,
+      documentType: data['documentType'] as String?,
+      expiryDate: data['expiryDate'] as String?,
+      firstName: data['firstName'] as String?,
+      gender: data['gender'] as String?,
+      issueDate: data['issueDate'] as String?,
+      issuingCountry: data['issuingCountry'] as String?,
+      lastName: data['lastName'] as String?,
+      licenseNumber: data['licenseNumber'] as String?,
+      middleName: data['middleName'] as String?,
+    );
+  }
+
+  /// The city of the holder's address.
+  final String? addressCity;
+
+  /// The state of the holder's address.
+  final String? addressState;
+
+  /// The street address of the holder's address.
+  final String? addressStreet;
+
+  /// The postal code of the holder's address.
+  final String? addressZip;
+
+  /// The holder's birth date.
+  final String? birthDate;
+
+  /// The type of the license.
+  ///
+  /// This is either "DL" for driver licenses or "ID" for ID cards.
+  final String? documentType;
+
+  /// The expiry date of the license.
+  final String? expiryDate;
+
+  /// The holder's first name.
+  final String? firstName;
+
+  /// The holder's gender.
+  ///
+  /// This is either '1' for male or '2' for female.
+  final String? gender;
+
+  /// The issue date of the license.
+  ///
+  /// The date format depends on the issuing country.
+  /// For example `MMDDYYYY` is used in the US,
+  /// and `YYYYMMDD` is used in Canada.
+  final String? issueDate;
+
+  /// The three-letter country code in which this license was issued.
+  final String? issuingCountry;
+
+  /// The holder's last name.
+  final String? lastName;
+
+  /// The identifying number for this license.
+  final String? licenseNumber;
+
+  /// The holder's middle name.
+  final String? middleName;
+}

--- a/lib/src/objects/email.dart
+++ b/lib/src/objects/email.dart
@@ -1,0 +1,34 @@
+import 'package:mobile_scanner/src/enums/email_type.dart';
+
+/// An email message from a 'MAILTO:' or similar QRCode type.
+class Email {
+  /// Construct a new [Email] instance.
+  const Email({
+    this.address,
+    this.body,
+    this.subject,
+    this.type = EmailType.unknown,
+  });
+
+  /// Construct an [Email] from the given [data].
+  factory Email.fromNative(Map<Object?, Object?> data) {
+    return Email(
+      address: data['address'] as String?,
+      body: data['body'] as String?,
+      subject: data['subject'] as String?,
+      type: EmailType.fromRawValue(data['type'] as int? ?? 0),
+    );
+  }
+
+  /// The email address.
+  final String? address;
+
+  /// The body of the email.
+  final String? body;
+
+  /// The subject of the email.
+  final String? subject;
+
+  /// The type of the email.
+  final EmailType type;
+}

--- a/lib/src/objects/geo_point.dart
+++ b/lib/src/objects/geo_point.dart
@@ -1,0 +1,31 @@
+/// GPS coordinates from a `GEO:` or similar QRCode type.
+class GeoPoint {
+  /// Construct a new [GeoPoint] instance.
+  const GeoPoint({
+    required this.latitude,
+    required this.longitude,
+  });
+
+  /// Construct a [GeoPoint] from the given [data].
+  ///
+  /// If the data does not contain valid GeoPoint coordinates,
+  /// then `0,0` is returned.
+  factory GeoPoint.fromNative(Map<Object?, Object?> data) {
+    final double? latitude = data['latitude'] as double?;
+    final double? longitude = data['longitude'] as double?;
+
+    // If either is not set, then this GeoPoint is invalid.
+    // Return the geographic center as fallback.
+    if (latitude == null || longitude == null) {
+      return const GeoPoint(latitude: 0.0, longitude: 0.0);
+    }
+
+    return GeoPoint(latitude: latitude, longitude: longitude);
+  }
+
+  /// The latitude of the coordinate.
+  final double latitude;
+
+  /// The longitude of the coordinate.
+  final double longitude;
+}

--- a/lib/src/objects/person_name.dart
+++ b/lib/src/objects/person_name.dart
@@ -1,0 +1,49 @@
+/// A person's name, divided into individual components.
+class PersonName {
+  /// Create a new [PersonName] instance.
+  const PersonName({
+    this.first,
+    this.middle,
+    this.last,
+    this.prefix,
+    this.suffix,
+    this.formattedName,
+    this.pronunciation,
+  });
+
+  /// Create a [PersonName] from a map.
+  factory PersonName.fromNative(Map<Object?, Object?> data) {
+    return PersonName(
+      first: data['first'] as String?,
+      middle: data['middle'] as String?,
+      last: data['last'] as String?,
+      prefix: data['prefix'] as String?,
+      suffix: data['suffix'] as String?,
+      formattedName: data['formattedName'] as String?,
+      pronunciation: data['pronunciation'] as String?,
+    );
+  }
+
+  /// The person's first name.
+  final String? first;
+
+  /// The person's middle name.
+  final String? middle;
+
+  /// The person's last name.
+  final String? last;
+
+  /// The prefix of the person's name.
+  final String? prefix;
+
+  /// The suffix of the person's name.
+  final String? suffix;
+
+  /// The person's name in a structured format.
+  final String? formattedName;
+
+  /// The pronunciation of the person's name.
+  ///
+  /// This is used for the "kana" name in Japanese phonebooks.
+  final String? pronunciation;
+}

--- a/lib/src/objects/phone.dart
+++ b/lib/src/objects/phone.dart
@@ -1,0 +1,24 @@
+import 'package:mobile_scanner/src/enums/phone_type.dart';
+
+/// Phone number information from a barcode.
+class Phone {
+  /// Construct a new [Phone] instance.
+  const Phone({
+    this.number,
+    this.type = PhoneType.unknown,
+  });
+
+  /// Create a [Phone] from the given [data].
+  factory Phone.fromNative(Map<Object?, Object?> data) {
+    return Phone(
+      number: data['number'] as String?,
+      type: PhoneType.fromRawValue(data['type'] as int? ?? 0),
+    );
+  }
+
+  /// The phone number value.
+  final String? number;
+
+  /// The type of the phone number.
+  final PhoneType type;
+}

--- a/lib/src/objects/sms.dart
+++ b/lib/src/objects/sms.dart
@@ -1,0 +1,22 @@
+/// An sms message from a `SMS:` or similar QRCode type.
+class SMS {
+  /// Construct a new [SMS] instance.
+  const SMS({
+    this.message,
+    required this.phoneNumber,
+  });
+
+  /// Construct a new [SMS] instance from the given [data].
+  factory SMS.fromNative(Map<Object?, Object?> data) {
+    return SMS(
+      message: data['message'] as String?,
+      phoneNumber: data['phoneNumber'] as String? ?? '',
+    );
+  }
+
+  /// The message contained in the sms.
+  final String? message;
+
+  /// The phone number which sent the sms.
+  final String phoneNumber;
+}

--- a/lib/src/objects/url_bookmark.dart
+++ b/lib/src/objects/url_bookmark.dart
@@ -1,0 +1,22 @@
+/// A URL and title from a `MEBKM:` or similar QRCode type.
+class UrlBookmark {
+  /// Construct a new [UrlBookmark] instance.
+  const UrlBookmark({
+    this.title,
+    required this.url,
+  });
+
+  /// Construct a new [UrlBookmark] instance from the given [data].
+  factory UrlBookmark.fromNative(Map<Object?, Object?> data) {
+    return UrlBookmark(
+      title: data['title'] as String?,
+      url: data['url'] as String? ?? '',
+    );
+  }
+
+  /// The title of the bookmark.
+  final String? title;
+
+  /// The url of the bookmark.
+  final String url;
+}

--- a/lib/src/objects/wifi.dart
+++ b/lib/src/objects/wifi.dart
@@ -1,0 +1,32 @@
+import 'package:mobile_scanner/src/enums/barcode_type.dart';
+import 'package:mobile_scanner/src/enums/encryption_type.dart';
+
+/// Wireless network information from [BarcodeType.wifi] barcodes.
+class WiFi {
+  /// Construct a new [WiFi] instance.
+  const WiFi({
+    this.encryptionType = EncryptionType.none,
+    this.ssid,
+    this.password,
+  });
+
+  /// Construct a new [WiFi] instance from the given [data].
+  factory WiFi.fromNative(Map<Object?, Object?> data) {
+    return WiFi(
+      encryptionType: EncryptionType.fromRawValue(
+        data['encryptionType'] as int? ?? 0,
+      ),
+      ssid: data['ssid'] as String?,
+      password: data['password'] as String?,
+    );
+  }
+
+  /// The encryption type of the wireless network.
+  final EncryptionType encryptionType;
+
+  /// The ssid of the wireless network.
+  final String? ssid;
+
+  /// The password of the wireless network.
+  final String? password;
+}


### PR DESCRIPTION
The classes in `src/objects/barcode.dart` have been moved to their own files.
The API for these classes stays the same unless otherwise noted below.
 
- The `type` attribute of the `Address`, `Email`, `Phone` is now non-null.
   - The enums now specify `unknown` as their value, instead of null.
- The `phoneNumber` of an SMS is now non-null.
   - This was an assumption that I made. The empty string is used in place of null.
- The `latitude` and `longitude` of a `GeoPoint` are now non-null.
   - This was an assumption that I made. A valid point should have both latitude and longitude anyway
   - If either is null, the `GeoPoint.fromNative` method returns `0,0` as fallback.
- The `url` of a `UrlBookmark` is now non-null.
   - This was an assumption that I made. The empty string is used in place of null.
- The `phones` and `urls` of `ContactInfo` are now non-null.
   - empty lists are used if the actual value was null.
- The `BarcodeCapture` class now exposes a `size`.
   - eventually we can deprecate the `width / height`, but keep the `size`
   - Size.zero is used as default if width or height is null
- The `width` and `height` of `BarcodeCapture` are now non-null.
  - These attributes are now getters, which expose the width/height of the `size`
- Cleaned up a Platform check in `barcode_scanner_window.dart`
  - Previously it did `Platform.isIOS` twice, now it only does it once
  - I also added a check for `kIsWeb` because `Platform.isIOS` throws on web
- The `corners` of `BarcodeCapture` are now non-null. If there are no corners, the list is empty.
- The `fromNative()` methods on the data classes now accept `Map<Object?, Object?>` instead of `Map<dynamic, dynamic>`
   - This change is by definition a **breaking change**, but to an internal-only API (consumers _should_ be using the regular constructor, if they ever want to create these classes)