### PR TITLE
fix: Remove redundant breaking change notice for Map<Object?, Object?> change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,4 @@
 ## NEXT
-Breaking changes:
-* The internal `fromNative()` methods now accept a `Map<Object?, Object?>` instead of `Map<dynamic, dynamic>`.
-
 Improvements:
 * The `type` of an `Address` is now non-null.
 * The `type` of an `Email` is now non-null.


### PR DESCRIPTION
The analyzer accepts `Map` and `Map<Object?, Object?>` without restrictions. Thus this is actually not a breaking change.

Example program:

```
void main() {
  final Map m = {};

  final Map<Object?, Object?> m2 = <Object?, Object?>{};

  final Map<Object?, Object?> m3 = {};
  
  foo(m); // LinkedHashMap<dynamic, dynamic>
  foo(m2); // LinkedHashMap<Object?, Object?>
  foo(m3); // LinkedHashMap<Object?, Object?>
}

void foo(Map<Object?, Object?> input) {
  print(input.runtimeType);
}
```