### PR TITLE
fix: Fix platform messages threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bugs fixed:
 * Fixed the default values for the `format` and `type` arguments of the Barcode constructor.
   These now use `BarcodeFormat.unknown` and `BarcodeType.unknown`, rather than `BarcodeFormat.ean13` and `BarcodeType.text`.
   (thanks @navaronbracke !)
+* Fixed messages not being sent on the main thread for Android, iOS and MacOS. (thanks @navaronbracke !)
 
 ## 3.5.0
 New Features:

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -2,6 +2,8 @@ package dev.steenbakker.mobile_scanner
 
 import android.app.Activity
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.util.Size
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ExperimentalGetImage
@@ -30,11 +32,12 @@ class MobileScannerHandler(
                 "name" to "barcode",
                 "data" to barcodes
             ))
-            analyzerResult?.success(true)
-        } else {
-            analyzerResult?.success(false)
         }
-        analyzerResult = null
+
+        Handler(Looper.getMainLooper()).post {
+            analyzerResult?.success(barcodes != null)
+            analyzerResult = null
+        }
     }
 
     private var analyzerResult: MethodChannel.Result? = null
@@ -92,7 +95,6 @@ class MobileScannerHandler(
         if(listener != null) {
             activityPluginBinding.removeRequestPermissionsResultListener(listener)
         }
-
     }
 
     @ExperimentalGetImage
@@ -173,11 +175,13 @@ class MobileScannerHandler(
                 torchStateCallback,
                 zoomScaleStateCallback,
                 mobileScannerStartedCallback = {
-                    result.success(mapOf(
-                        "textureId" to it.id,
-                        "size" to mapOf("width" to it.width, "height" to it.height),
-                        "torchable" to it.hasFlashUnit
-                    ))
+                    Handler(Looper.getMainLooper()).post {
+                        result.success(mapOf(
+                            "textureId" to it.id,
+                            "size" to mapOf("width" to it.width, "height" to it.height),
+                            "torchable" to it.hasFlashUnit
+                        ))
+                    }
                 },
                 timeout.toLong(),
                 cameraResolution,

--- a/ios/Classes/BarcodeHandler.swift
+++ b/ios/Classes/BarcodeHandler.swift
@@ -9,9 +9,6 @@ import Flutter
 import Foundation
 
 public class BarcodeHandler: NSObject, FlutterStreamHandler {
-    
-    var event: [String: Any?] = [:]
-    
     private var eventSink: FlutterEventSink?
     private let eventChannel: FlutterEventChannel
     
@@ -23,8 +20,9 @@ public class BarcodeHandler: NSObject, FlutterStreamHandler {
     }
     
     func publishEvent(_ event: [String: Any?]) {
-        self.event = event
-        eventSink?(event)
+        DispatchQueue.main.async {
+            self.eventSink?(event)
+        }
     }
     
     public func onListen(withArguments arguments: Any?,

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -232,23 +232,19 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
                     device.activeFormat.formatDescription)
                 let hasTorch = device.hasTorch
                 
-                DispatchQueue.main.async {
-                    completion(
-                        MobileScannerStartParameters(
-                            width: Double(dimensions.height),
-                            height: Double(dimensions.width),
-                            hasTorch: hasTorch,
-                            textureId: self.textureId ?? 0
-                        )
+                completion(
+                    MobileScannerStartParameters(
+                        width: Double(dimensions.height),
+                        height: Double(dimensions.width),
+                        hasTorch: hasTorch,
+                        textureId: self.textureId ?? 0
                     )
-                }
+                )
                 
                 return
             }
             
-            DispatchQueue.main.async {
-                completion(MobileScannerStartParameters())
-            }
+            completion(MobileScannerStartParameters())
         }
     }
 

--- a/ios/Classes/MobileScannerPlugin.swift
+++ b/ios/Classes/MobileScannerPlugin.swift
@@ -121,7 +121,12 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
 
         do {
             try mobileScanner.start(barcodeScannerOptions: barcodeOptions, returnImage: returnImage, cameraPosition: position, torch: torch ? .on : .off, detectionSpeed: detectionSpeed) { parameters in
-                result(["textureId": parameters.textureId, "size": ["width": parameters.width, "height": parameters.height], "torchable": parameters.hasTorch])
+                DispatchQueue.main.async {
+                    result([
+                        "textureId": parameters.textureId,
+                        "size": ["width": parameters.width, "height": parameters.height],
+                        "torchable": parameters.hasTorch])
+                }
             }
         } catch MobileScannerError.alreadyStarted {
             result(FlutterError(code: "MobileScanner",

--- a/ios/Classes/MobileScannerPlugin.swift
+++ b/ios/Classes/MobileScannerPlugin.swift
@@ -252,16 +252,28 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         }
 
         mobileScanner.analyzeImage(image: uiImage!, position: AVCaptureDevice.Position.back, callback: { [self] barcodes, error in
-            if error == nil && barcodes != nil && !barcodes!.isEmpty {
+            if error != nil {
+                barcodeHandler.publishEvent(["name": "error", "message": error?.localizedDescription])
+                
+                DispatchQueue.main.async {
+                    result(false)
+                }
+                
+                return
+            }
+            
+            if (barcodes == nil || barcodes!.isEmpty) {
+                DispatchQueue.main.async {
+                    result(false)
+                }
+            } else {
                 let barcodesMap: [Any?] = barcodes!.compactMap { barcode in barcode.data }
                 let event: [String: Any?] = ["name": "barcode", "data": barcodesMap]
                 barcodeHandler.publishEvent(event)
-                result(true)
-            } else {
-                if error != nil {
-                    barcodeHandler.publishEvent(["name": "error", "message": error?.localizedDescription])
+                
+                DispatchQueue.main.async {
+                    result(true)
                 }
-                result(false)
             }
         })
     }

--- a/ios/Classes/MobileScannerPlugin.swift
+++ b/ios/Classes/MobileScannerPlugin.swift
@@ -163,12 +163,12 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
     private func toggleTorch(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         do {
             try mobileScanner.toggleTorch(call.arguments as? Int == 1 ? .on : .off)
+            result(nil)
         } catch {
             result(FlutterError(code: "MobileScanner",
                                 message: "Called toggleTorch() while stopped!",
                                 details: nil))
         }
-        result(nil)
     }
     
     /// Toggles the zoomScale
@@ -182,6 +182,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         }
         do {
             try mobileScanner.setScale(scale!)
+            result(nil)
         } catch MobileScannerError.zoomWhenStopped {
             result(FlutterError(code: "MobileScanner",
                                 message: "Called setScale() while stopped!",
@@ -195,13 +196,13 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
                                 message: "Error while zooming.",
                                 details: nil))
         }
-        result(nil)
     }
 
     /// Reset the zoomScale
     private func resetScale(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         do {
             try mobileScanner.resetScale()
+            result(nil)
         } catch MobileScannerError.zoomWhenStopped {
             result(FlutterError(code: "MobileScanner",
                                 message: "Called resetScale() while stopped!",
@@ -215,7 +216,6 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
                                 message: "Error while zooming.",
                                 details: nil))
         }
-        result(nil)
     }
 
     /// Toggles the torch

--- a/ios/Classes/MobileScannerUtilities.swift
+++ b/ios/Classes/MobileScannerUtilities.swift
@@ -1,14 +1,6 @@
 import AVFoundation
-import Flutter
 import Foundation
 import MLKitBarcodeScanning
-
-extension Error {
-    func throwNative(_ result: FlutterResult) {
-        let error = FlutterError(code: localizedDescription, message: nil, details: nil)
-        result(error)
-    }
-}
 
 extension CVBuffer {
     var image: UIImage {

--- a/macos/Classes/MobileScannerPlugin.swift
+++ b/macos/Classes/MobileScannerPlugin.swift
@@ -144,7 +144,9 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                                 }
                             }
                         } else {
-                            self?.sink?(FlutterError(code: "MobileScanner", message: error?.localizedDescription, details: nil))
+                            DispatchQueue.main.async {
+                                self?.sink?(FlutterError(code: "MobileScanner", message: error?.localizedDescription, details: nil))
+                            }
                         }
                     })
                     if(self?.symbologies.isEmpty == false){
@@ -153,7 +155,9 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                     }
                     try imageRequestHandler.perform([barcodeRequest])
                 } catch let e {
-                    self?.sink?(FlutterError(code: "MobileScanner", message: e.localizedDescription, details: nil))
+                    DispatchQueue.main.async {
+                        self?.sink?(FlutterError(code: "MobileScanner", message: e.localizedDescription, details: nil))
+                    }
                 }
             }
         }

--- a/macos/Classes/MobileScannerPlugin.swift
+++ b/macos/Classes/MobileScannerPlugin.swift
@@ -276,6 +276,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                 device.unlockForConfiguration()
             } catch {
                 result(FlutterError(code: error.localizedDescription, message: nil, details: nil))
+                return
             }
         }
         
@@ -288,6 +289,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
             captureSession.addInput(input)
         } catch {
             result(FlutterError(code: error.localizedDescription, message: nil, details: nil))
+            return
         }
         captureSession.sessionPreset = AVCaptureSession.Preset.photo
         // Add video output.


### PR DESCRIPTION
This PR fixes the missing switches to the main thread on Android, iOS and MacOS.

Changes in this PR:
- Added the two missing main looper switches for Android
- Removed the unused `event` property from the iOS `BarcodeHandler`
- Added a missing `DispatchQueue.main.async` switch to the iOS `BarcodeHandler`
- Moved the `DispatchQueue.main.async` from inside the iOS `MobileScanner.start()` method to the argument that is passed to the completion block. This makes it easier to read.
- Fixed some `result(nil)` calls that were called _after_ catch blocks on iOS. This would result in the result getting called twice.
- Added missing `DispatchQueue.main.async` switches to the iOS `analyzeImage` implementation
- Removed the unused `Error.throwNative` extension from the iOS implementation.
  - I chose to remove this, as it also used the `FlutterResult` facility, which this PR is working with. No semantic changes as it was unused.
- Fixed two missing returns for MacOS, which would allow a function to continue after `FlutterError` was called.
- Fixed two missing `DispatchQueue.main.async` switches for MacOS

Fixes #751 