### PR TITLE
fix: fix a cast from a bad conversion

### DIFF
--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -62,8 +62,13 @@ class Barcode {
       corners: corners == null
           ? const <Offset>[]
           : List.unmodifiable(
-              corners.cast<Map<String, double>>().map((Map<String, double> e) {
-                return Offset(e['x']!, e['y']!);
+              corners
+                  .cast<Map<Object?, Object?>>()
+                  .map((Map<Object?, Object?> e) {
+                final double x = e['x']! as double;
+                final double y = e['y']! as double;
+
+                return Offset(x, y);
               }),
             ),
       displayValue: data['displayValue'] as String?,


### PR DESCRIPTION
Apparently when moving the classes in #818 I missed a usage of a cast to a Map that broke.
(the `Map<String, double>` is the culprit)

This PR fixes that bug. As this bug was not yet in a released version, this PR has no version bump.