### PR TITLE
fix: fix updateScanWindow() not completing on Android and MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+Bugs fixed:
+* Fixed the `updateScanWindow()` function not completing on Android and MacOS. (thanks @navaronbracke !)
+
 ## 3.5.1
 Improvements:
 * The `type` of an `Address` is now non-null.

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -123,7 +123,7 @@ class MobileScannerHandler(
             "analyzeImage" -> analyzeImage(call, result)
             "setScale" -> setScale(call, result)
             "resetScale" -> resetScale(result)
-            "updateScanWindow" -> updateScanWindow(call)
+            "updateScanWindow" -> updateScanWindow(call, result)
             else -> result.notImplemented()
         }
     }
@@ -263,7 +263,9 @@ class MobileScannerHandler(
         }
     }
 
-    private fun updateScanWindow(call: MethodCall) {
+    private fun updateScanWindow(call: MethodCall, result: MethodChannel.Result) {
         mobileScanner!!.scanWindow = call.argument<List<Float>?>("rect")
+
+        result.success(null)
     }
 }

--- a/macos/Classes/MobileScannerPlugin.swift
+++ b/macos/Classes/MobileScannerPlugin.swift
@@ -66,7 +66,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         case "stop":
             stop(result)
         case "updateScanWindow":
-            updateScanWindow(call)
+            updateScanWindow(call, result)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -187,11 +187,12 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         }
     }
 
-    func updateScanWindow(_ call: FlutterMethodCall) {
+    func updateScanWindow(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let argReader = MapArgumentReader(call.arguments as? [String: Any])
         let scanWindowData: Array? = argReader.floatArray(key: "rect")
 
         if (scanWindowData == nil) {
+            result(nil)
             return
         }
 
@@ -202,6 +203,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         let height = scanWindowData![3] - minY
 
         scanWindow = CGRect(x: minX, y: minY, width: width, height: height)
+        result(nil)
     }
     
     func isBarCodeInScanWindow(_ scanWindow: CGRect, _ barcode: VNBarcodeObservation, _ inputImage: CGImage) -> Bool {


### PR DESCRIPTION
This PR fixes a bug where Android & MacOS were discarding the incoming MethodCall.Result for the `updateScanWindow()` function.

I checked the implementations for other such cases, and all other methods take the result as parameter. So `updateScanWindow()` was the only one that did not.

Fixes #730 