### PR TITLE
fix: Handle no cameras on Android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,4 +2,5 @@
   package="dev.steenbakker.mobile_scanner">
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
 </manifest>

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerExceptions.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerExceptions.kt
@@ -3,7 +3,6 @@ package dev.steenbakker.mobile_scanner
 class NoCamera : Exception()
 class AlreadyStarted : Exception()
 class AlreadyStopped : Exception()
-class TorchError : Exception()
 class CameraError : Exception()
 class TorchWhenStopped : Exception()
 class ZoomWhenStopped : Exception()

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -238,7 +238,7 @@ class MobileScannerHandler(
         try {
             mobileScanner!!.toggleTorch(call.arguments == 1)
             result.success(null)
-        } catch (e: AlreadyStopped) {
+        } catch (e: TorchWhenStopped) {
             result.error("MobileScanner", "Called toggleTorch() while stopped!", null)
         }
     }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -165,58 +165,60 @@ class MobileScannerHandler(
 
         val detectionSpeed: DetectionSpeed = DetectionSpeed.values().first { it.intValue == speed}
 
-        try {
-            mobileScanner!!.start(
-                barcodeScannerOptions,
-                returnImage, 
-                position,
-                torch,
-                detectionSpeed,
-                torchStateCallback,
-                zoomScaleStateCallback,
-                mobileScannerStartedCallback = {
-                    Handler(Looper.getMainLooper()).post {
-                        result.success(mapOf(
-                            "textureId" to it.id,
-                            "size" to mapOf("width" to it.width, "height" to it.height),
-                            "torchable" to it.hasFlashUnit
-                        ))
+        mobileScanner!!.start(
+            barcodeScannerOptions,
+            returnImage,
+            position,
+            torch,
+            detectionSpeed,
+            torchStateCallback,
+            zoomScaleStateCallback,
+            mobileScannerStartedCallback = {
+                Handler(Looper.getMainLooper()).post {
+                    result.success(mapOf(
+                        "textureId" to it.id,
+                        "size" to mapOf("width" to it.width, "height" to it.height),
+                        "torchable" to it.hasFlashUnit
+                    ))
+                }
+            },
+            mobileScannerErrorCallback = {
+                Handler(Looper.getMainLooper()).post {
+                    when (it) {
+                        is AlreadyStarted -> {
+                            result.error(
+                                "MobileScanner",
+                                "Called start() while already started",
+                                null
+                            )
+                        }
+                        is CameraError -> {
+                            result.error(
+                                "MobileScanner",
+                                "Error occurred when setting up camera!",
+                                null
+                            )
+                        }
+                        is NoCamera -> {
+                            result.error(
+                                "MobileScanner",
+                                "No camera found or failed to open camera!",
+                                null
+                            )
+                        }
+                        else -> {
+                            result.error(
+                                "MobileScanner",
+                                "Unknown error occurred.",
+                                null
+                            )
+                        }
                     }
-                },
-                timeout.toLong(),
-                cameraResolution,
-            )
-        } catch (e: AlreadyStarted) {
-            result.error(
-                "MobileScanner",
-                "Called start() while already started",
-                null
-            )
-        } catch (e: NoCamera) {
-            result.error(
-                "MobileScanner",
-                "No camera found or failed to open camera!",
-                null
-            )
-        } catch (e: TorchError) {
-            result.error(
-                "MobileScanner",
-                "Error occurred when setting torch!",
-                null
-            )
-        } catch (e: CameraError) {
-            result.error(
-                "MobileScanner",
-                "Error occurred when setting up camera!",
-                null
-            )
-        } catch (e: Exception) {
-            result.error(
-                "MobileScanner",
-                "Unknown error occurred..",
-                null
-            )
-        }
+                }
+            },
+            timeout.toLong(),
+            cameraResolution,
+        )
     }
 
     private fun stop(result: MethodChannel.Result) {

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -305,7 +305,7 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
     /// Set the zoom factor of the camera
     func setScale(_ scale: CGFloat) throws {
         if (device == nil) {
-            throw MobileScannerError.torchWhenStopped
+            throw MobileScannerError.zoomWhenStopped
         }
         
         do {

--- a/ios/Classes/MobileScannerPlugin.swift
+++ b/ios/Classes/MobileScannerPlugin.swift
@@ -95,7 +95,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    /// Parses all parameters and starts the mobileScanner
+    /// Start the mobileScanner.
     private func start(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let torch: Bool = (call.arguments as! Dictionary<String, Any?>)["torch"] as? Bool ?? false
         let facing: Int = (call.arguments as! Dictionary<String, Any?>)["facing"] as? Int ?? 1
@@ -151,7 +151,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    /// Stops the mobileScanner and closes the texture
+    /// Stops the mobileScanner and closes the texture.
     private func stop(_ result: @escaping FlutterResult) {
         do {
             try mobileScanner.stop()
@@ -159,7 +159,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         result(nil)
     }
 
-    /// Toggles the torch
+    /// Toggles the torch.
     private func toggleTorch(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         do {
             try mobileScanner.toggleTorch(call.arguments as? Int == 1 ? .on : .off)
@@ -171,7 +171,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         }
     }
     
-    /// Toggles the zoomScale
+    /// Sets the zoomScale.
     private func setScale(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let scale = call.arguments as? CGFloat
         if (scale == nil) {
@@ -198,7 +198,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    /// Reset the zoomScale
+    /// Reset the zoomScale.
     private func resetScale(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         do {
             try mobileScanner.resetScale()
@@ -218,7 +218,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    /// Toggles the torch
+    /// Updates the scan window rectangle.
     func updateScanWindow(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let scanWindowData: Array? = (call.arguments as? [String: Any])?["rect"] as? [CGFloat]
         MobileScannerPlugin.scanWindow = scanWindowData
@@ -240,7 +240,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         return CGRect(x: minX, y: minY, width: width, height: height)
     }
     
-    /// Analyzes a single image
+    /// Analyzes a single image.
     private func analyzeImage(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let uiImage = UIImage(contentsOfFile: call.arguments as? String ?? "")
         


### PR DESCRIPTION
This PR fixes some camera issues on Android by updating how we work with the camera:

- Only do safe access of the camera/cameraProvider using `?.`, instead of `!!.` which forced it.
- Added the feature flag to the manifest to denote that the camera is optional (since we now handle "no camera" properly)
- Updated the error handling for the camera provider to emit errors through a callback
   - This was not working, because the errors are thrown in the camera's executor.
- Removed the unused `TorchError` class
- Updated the toggle torch code to only do this when the device has a flash unit
- Fixes two typos that checked for the wrong error type

Fixes #762 
Fixes #719