### PR TITLE
fix: with the "noDuplicates", the same code is no longer detected after stopping and restarting the scanner

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -70,7 +70,7 @@ class MobileScanner(
         scanner.process(inputImage)
             .addOnSuccessListener { barcodes ->
                 if (detectionSpeed == DetectionSpeed.NO_DUPLICATES) {
-                    val newScannedBarcodes = barcodes.map { barcode -> barcode.rawValue }
+                    val newScannedBarcodes = barcodes.mapNotNull({ barcode -> barcode.rawValue }).sorted()
                     if (newScannedBarcodes == lastScanned) {
                         // New scanned is duplicate, returning
                         return@addOnSuccessListener
@@ -224,6 +224,7 @@ class MobileScanner(
             throw AlreadyStarted()
         }
 
+        lastScanned = null
         scanner = if (barcodeScannerOptions != null) {
             BarcodeScanning.getClient(barcodeScannerOptions)
         } else {

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -117,12 +117,13 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
                 imagesCurrentlyBeingProcessed = false
                 
                 if (detectionSpeed == DetectionSpeed.noDuplicates) {
-                    let newScannedBarcodes = barcodes?.map { barcode in
+                    let newScannedBarcodes = barcodes?.compactMap({ barcode in
                         return barcode.rawValue
-                    }
+                    }).sorted()
+                    
                     if (error == nil && barcodesString != nil && newScannedBarcodes != nil && barcodesString!.elementsEqual(newScannedBarcodes!)) {
                         return
-                    } else {
+                    } else if (newScannedBarcodes?.isEmpty == false) {
                         barcodesString = newScannedBarcodes
                     }
                 }
@@ -139,6 +140,7 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
             throw MobileScannerError.alreadyStarted
         }
 
+        barcodesString = nil
         scanner = barcodeScannerOptions != nil ? BarcodeScanner.barcodeScanner(options: barcodeScannerOptions!) : BarcodeScanner.barcodeScanner()
         captureSession = AVCaptureSession()
         textureId = registry?.register(self)


### PR DESCRIPTION
This PR proposes a fix for the issue reported here #750, which I also encountered.

To summarize, we reset the variable that holds the list of recently scanned codes every time the mobile scanner controller is restarted. I also sorted the list to avoid false comparisons of lists with the same codes but in a different order.

Additionally, on iOS, I had a code that was being spammed even though the "noDuplicates" speed was enabled. Upon reviewing the code, I noticed that this occurred when an empty code list was returned by the scanner, which happens as soon as there are no more codes in the camera's field of view. So I added a check to ignore empty lists. In fact, this check was already present in the Android code.