### PR TITLE
fix: error with returning image on android

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -107,14 +107,16 @@ class MobileScanner(
                         val stream = ByteArrayOutputStream()
                         bmResult.compress(Bitmap.CompressFormat.PNG, 100, stream)
                         val byteArray = stream.toByteArray()
+                        val bmWidth = bmResult.width
+                        val bmHeight = bmResult.height
                         bmResult.recycle()
 
 
                         mobileScannerCallback(
                             barcodeMap,
                             byteArray,
-                            bmResult.width,
-                            bmResult.height
+                            bmWidget,
+                            bmHeight
                         )
 
                     } else {

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -115,7 +115,7 @@ class MobileScanner(
                         mobileScannerCallback(
                             barcodeMap,
                             byteArray,
-                            bmWidget,
+                            bmWidth,
                             bmHeight
                         )
 


### PR DESCRIPTION
When using a MobileScannerController with returnImage set to true, my android app would throw several messages about trying to call getWidth or getHeight on a recycled bitmap, this change fixes the issue and allows the app to continue and capture the image