### PR TITLE
fix: iOS Timeout is broken because of Double miss conversion

### DIFF
--- a/ios/Classes/MobileScannerPlugin.swift
+++ b/ios/Classes/MobileScannerPlugin.swift
@@ -103,7 +103,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         let returnImage: Bool = (call.arguments as! Dictionary<String, Any?>)["returnImage"] as? Bool ?? false
         let speed: Int = (call.arguments as! Dictionary<String, Any?>)["speed"] as? Int ?? 0
         let timeoutMs: Int = (call.arguments as! Dictionary<String, Any?>)["timeout"] as? Int ?? 0
-        self.mobileScanner.timeoutSeconds = Double(timeoutMs / 1000)
+        self.mobileScanner.timeoutSeconds = timeoutMs / Double(1000)
 
         let formatList = formats.map { format in return BarcodeFormat(rawValue: format)}
         var barcodeOptions: BarcodeScannerOptions? = nil


### PR DESCRIPTION
A Double conversion is broken leading to an Int round result. 
(You can quickly check that here : https://online.swiftplayground.run/)

```swift
// Default conversion will use int
print(500 / 1000) // 0 
// Wrong conversion to Double
print(Double(500 / 1000)) // 0.0 
// Good conversion to Double
print(500 / Double(1000)) // 0.5
```

Important bug :).