### PR TITLE
feat: Bump version to 3.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.3
+Bugs fixed:
+* Fixed a bug with an implicit conversion to integer for the scan timeout for iOS. (thanks @EArminjon !)
+
 ## 3.5.2
 Improvements:
 * Updated to `play-services-mlkit-barcode-scanning` version 18.3.0

--- a/ios/mobile_scanner.podspec
+++ b/ios/mobile_scanner.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'mobile_scanner'
-  s.version          = '3.5.2'
+  s.version          = '3.5.3'
   s.summary          = 'An universal scanner for Flutter based on MLKit.'
   s.description      = <<-DESC
 An universal scanner for Flutter based on MLKit.

--- a/macos/mobile_scanner.podspec
+++ b/macos/mobile_scanner.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'mobile_scanner'
-  s.version          = '3.5.2'
+  s.version          = '3.5.3'
   s.summary          = 'An universal scanner for Flutter based on MLKit.'
   s.description      = <<-DESC
 An universal scanner for Flutter based on MLKit.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal barcode and QR code scanner for Flutter based on MLKit. Uses CameraX on Android, AVFoundation on iOS and Apple Vision & AVFoundation on macOS.
-version: 3.5.2
+version: 3.5.3
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 environment:


### PR DESCRIPTION
This PR bumps the version to 3.5.3, to include the iOS scan timeout conversion fix.