### PR TITLE
fix: iOS Timeout is broken because of Double miss conversion - additional

### DIFF
--- a/ios/Classes/MobileScannerPlugin.swift
+++ b/ios/Classes/MobileScannerPlugin.swift
@@ -103,7 +103,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         let returnImage: Bool = (call.arguments as! Dictionary<String, Any?>)["returnImage"] as? Bool ?? false
         let speed: Int = (call.arguments as! Dictionary<String, Any?>)["speed"] as? Int ?? 0
         let timeoutMs: Int = (call.arguments as! Dictionary<String, Any?>)["timeout"] as? Int ?? 0
-        self.mobileScanner.timeoutSeconds = timeoutMs / Double(1000)
+        self.mobileScanner.timeoutSeconds = Double(timeoutMs) / Double(1000)
 
         let formatList = formats.map { format in return BarcodeFormat(rawValue: format)}
         var barcodeOptions: BarcodeScannerOptions? = nil


### PR DESCRIPTION
I apology, I didn't test enough and the latest change no longer compile. Here is the fix. 
As timeout is an Int, division seems to not accept `Int / Double` but it accept obviously `Double / Double`. 

This will fix :
https://github.com/juliansteenbakker/mobile_scanner/issues/873

Sorry again for this fail.
