### PR TITLE
Fix android permission

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerPermissions.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerPermissions.kt
@@ -70,6 +70,7 @@ class MobileScannerPermissions {
                 object: ResultCallback {
                     override fun onResult(errorCode: String?, errorDescription: String?) {
                         ongoing = false
+                        listener = null
                         callback.onResult(errorCode, errorDescription)
                     }
                 }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerPermissions.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerPermissions.kt
@@ -45,7 +45,7 @@ class MobileScannerPermissions {
         return if (hasPermission) {
             1
         } else {
-            0
+            2
         }
     }
 

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -189,8 +189,9 @@ class MobileScannerController {
       final MobileScannerState state;
 
       try {
-        state = MobileScannerState
-            .values[await _methodChannel.invokeMethod('state') as int? ?? 0];
+        state = MobileScannerState.fromRawValue(
+          await _methodChannel.invokeMethod('state') as int? ?? 0,
+        );
       } on PlatformException catch (error) {
         isStarting = false;
 


### PR DESCRIPTION
This PR fixes a bug for Android permissions.

- Android does not have an undetermined permission state
- The check for the permission state wrongly returned `undetermined` for a denied state
- There was also a bug with the permission listener not being unset after it finished

Fixes #860 