### PR TITLE
fix: Fix ios torch crash

### DIFF
--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -286,12 +286,18 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
         device = nil
     }
 
-    /// Toggle the flashlight between on and off.
+    /// Set the torch mode.
+    ///
+    /// This method should be called on the main DispatchQueue.
     func toggleTorch(_ torch: AVCaptureDevice.TorchMode) throws {
-        if (device == nil || !device.hasTorch || !device.isTorchAvailable) {
+        guard let device = self.device else {
             return
         }
-
+        
+        if (!device.hasTorch || !device.isTorchAvailable || !device.isTorchModeSupported(torch)) {
+            return
+        }
+        
         if (device.torchMode != torch) {
             try device.lockForConfiguration()
             device.torchMode = torch

--- a/macos/Classes/MobileScannerPlugin.swift
+++ b/macos/Classes/MobileScannerPlugin.swift
@@ -61,6 +61,10 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
             start(call, result)
         case "torch":
             toggleTorch(call, result)
+        case "setScale":
+            setScale(call, result)
+        case "resetScale":
+            resetScale(call, result)
             //        case "analyze":
             //            switchAnalyzeMode(call, result)
         case "stop":
@@ -339,6 +343,18 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
             device.torchMode = torch
             device.unlockForConfiguration()
         }
+    }
+    
+    /// Reset the zoom scale.
+    private func resetScale(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        // The zoom scale is not yet supported on MacOS.
+        result(nil)
+    }
+    
+    /// Set the zoom scale.
+    private func setScale(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        // The zoom scale is not yet supported on MacOS.
+        result(nil)
     }
     
     private func toggleTorch(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {

--- a/macos/Classes/MobileScannerPlugin.swift
+++ b/macos/Classes/MobileScannerPlugin.swift
@@ -320,7 +320,11 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
 
     // TODO: this method should be removed when iOS and MacOS share their implementation.
     private func toggleTorchInternal(_ torch: AVCaptureDevice.TorchMode) throws {
-        if (device == nil || !device.hasTorch) {
+        guard let device = self.device else {
+            return
+        }
+        
+        if (!device.hasTorch || !device.isTorchModeSupported(torch)) {
             return
         }
         
@@ -337,7 +341,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         }
     }
     
-    func toggleTorch(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+    private func toggleTorch(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let requestedTorchMode: AVCaptureDevice.TorchMode = call.arguments as! Int == 1 ? .on : .off
 
         do {


### PR DESCRIPTION
This PR fixes a crash on iOS, due to missing switches to the main dispatch queue when setting up the zoom scale & torch on the background queue.

It also adds a check for determining if the torch mode is actually supported.

For consistency, the fixes have been ported to MacOS as well.

Lastly, this PR adds stub implementations for MacOS for the scale methods, so that these do not throw unimplemented errors. I didn't find any compatible API for actually implementing that.

Fixes #884 