### PR TITLE
fix: return type 'int' doesn't allow null for zxingBarcodeFormat method

### DIFF
--- a/lib/src/web/zxing.dart
+++ b/lib/src/web/zxing.dart
@@ -133,7 +133,7 @@ extension ZXingBarcodeFormat on BarcodeFormat {
         return 15;
       case BarcodeFormat.unknown:
       case BarcodeFormat.all:
-      case default:
+      default:
         return -1;
     }
   }

--- a/lib/src/web/zxing.dart
+++ b/lib/src/web/zxing.dart
@@ -133,6 +133,7 @@ extension ZXingBarcodeFormat on BarcodeFormat {
         return 15;
       case BarcodeFormat.unknown:
       case BarcodeFormat.all:
+      case default:
         return -1;
     }
   }


### PR DESCRIPTION
fixes #912 