### PR TITLE
fix: missing methods on enums

### DIFF
--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,3 +1,9 @@
 -keep class com.google.mlkit.* { *; }
 -keep class com.google.android.libraries.barhopper.** { *; }
 -keep class com.google.photos.* { *; }
+
+-keepclassmembers class * extends java.lang.Enum {
+    <fields>;
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}


### PR DESCRIPTION
Some enums in android camerax API are missing after minification. Adding a general rule to keep enum fields and APIs around. Fixes #614 in my testing.