### PR TITLE
docs: Add note about compileSDK requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Bugs fixed:
 
 ## 3.5.0
 
-**NOTE: Since this release plugin requires your project to have compileSDK 34 (Android 14)**
+**NOTE: From this version onwards, `mobile_scanner` requires Android projects to have a `compileSdk` of 34 (Android 14) or higher**
 
 New Features:
 * Added the option to switch between bundled and unbundled MLKit for Android. (thanks @woolfred !)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,11 @@ BREAKING CHANGES:
 
 ## 3.5.7
 
-NOTE: This version requires your project to have compileSDK 34 on Android
-
 Improvements:
 * Updated js dependency together with other dependencies.
 * Reverted compileSdk version to 33 on Android. This update will be released under version 4.0.0.
 
 ## 3.5.6
-
-NOTE: This version requires your project to have compileSDK 34 on Android
 
 Bugs fixed:
 * [web] Fixed a crash with the ZXing barcode format (thanks @hazzo!)
@@ -29,21 +25,15 @@ Improvements:
 
 ## 3.5.5
 
-NOTE: This version requires your project to have compileSDK 34 on Android
-
 Bugs fixed:
 * Fixed a bug where the scanner would get stuck after denying permissions on Android. (thanks @navaronbracke !)
 
 ## 3.5.4
 
-NOTE: This version requires your project to have compileSDK 34 on Android
-
 Bugs fixed:
 * Fixed a bug with an implicit conversion to integer for the scan timeout for iOS. (thanks @EArminjon !)
 
 ## 3.5.2
-
-NOTE: This version requires your project to have compileSDK 34 on Android
 
 Improvements:
 * Updated to `play-services-mlkit-barcode-scanning` version 18.3.0
@@ -56,8 +46,6 @@ Bugs fixed:
 * Fixed a synchronization issue for the torch state. (thanks @navaronbracke !)
 
 ## 3.5.1
-
-NOTE: This version requires your project to have compileSDK 34 on Android
 
 Improvements:
 * The `type` of an `Address` is now non-null.
@@ -79,7 +67,7 @@ Bugs fixed:
 
 ## 3.5.0
 
-NOTE: This version requires your project to have compileSDK 34 on Android
+**NOTE: Since this release plugin requires your project to have compileSDK 34 (Android 14)**
 
 New Features:
 * Added the option to switch between bundled and unbundled MLKit for Android. (thanks @woolfred !)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ BREAKING CHANGES:
 * [Android] Java version has been upgraded to version 17.
 
 ## 3.5.7
+
+NOTE: This version requires your project to have compileSDK 34 on Android
+
 Improvements:
 * Updated js dependency together with other dependencies.
 * Reverted compileSdk version to 33 on Android. This update will be released under version 4.0.0.
 
 ## 3.5.6
+
+NOTE: This version requires your project to have compileSDK 34 on Android
+
 Bugs fixed:
 * [web] Fixed a crash with the ZXing barcode format (thanks @hazzo!)
 * [web] Fixed stream controller not being closed on web.
@@ -22,14 +28,23 @@ Improvements:
 * [Android] Migrated to ResolutionSelector with ResolutionStrategy. You can opt in into the new selector by setting [useNewCameraSelector] in the [MobileScannerController] to true.
 
 ## 3.5.5
+
+NOTE: This version requires your project to have compileSDK 34 on Android
+
 Bugs fixed:
 * Fixed a bug where the scanner would get stuck after denying permissions on Android. (thanks @navaronbracke !)
 
 ## 3.5.4
+
+NOTE: This version requires your project to have compileSDK 34 on Android
+
 Bugs fixed:
 * Fixed a bug with an implicit conversion to integer for the scan timeout for iOS. (thanks @EArminjon !)
 
 ## 3.5.2
+
+NOTE: This version requires your project to have compileSDK 34 on Android
+
 Improvements:
 * Updated to `play-services-mlkit-barcode-scanning` version 18.3.0
 
@@ -41,6 +56,9 @@ Bugs fixed:
 * Fixed a synchronization issue for the torch state. (thanks @navaronbracke !)
 
 ## 3.5.1
+
+NOTE: This version requires your project to have compileSDK 34 on Android
+
 Improvements:
 * The `type` of an `Address` is now non-null.
 * The `type` of an `Email` is now non-null.
@@ -60,6 +78,9 @@ Bugs fixed:
 * Fixed messages not being sent on the main thread for Android, iOS and MacOS. (thanks @navaronbracke !)
 
 ## 3.5.0
+
+NOTE: This version requires your project to have compileSDK 34 on Android
+
 New Features:
 * Added the option to switch between bundled and unbundled MLKit for Android. (thanks @woolfred !)
 * Added the option to specify the camera resolution for Android. (thanks @EArminjon !)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,11 @@ BREAKING CHANGES:
 * [Android] Java version has been upgraded to version 17.
 
 ## 3.5.7
-
 Improvements:
 * Updated js dependency together with other dependencies.
 * Reverted compileSdk version to 33 on Android. This update will be released under version 4.0.0.
 
 ## 3.5.6
-
 Bugs fixed:
 * [web] Fixed a crash with the ZXing barcode format (thanks @hazzo!)
 * [web] Fixed stream controller not being closed on web.
@@ -24,17 +22,14 @@ Improvements:
 * [Android] Migrated to ResolutionSelector with ResolutionStrategy. You can opt in into the new selector by setting [useNewCameraSelector] in the [MobileScannerController] to true.
 
 ## 3.5.5
-
 Bugs fixed:
 * Fixed a bug where the scanner would get stuck after denying permissions on Android. (thanks @navaronbracke !)
 
 ## 3.5.4
-
 Bugs fixed:
 * Fixed a bug with an implicit conversion to integer for the scan timeout for iOS. (thanks @EArminjon !)
 
 ## 3.5.2
-
 Improvements:
 * Updated to `play-services-mlkit-barcode-scanning` version 18.3.0
 
@@ -46,7 +41,6 @@ Bugs fixed:
 * Fixed a synchronization issue for the torch state. (thanks @navaronbracke !)
 
 ## 3.5.1
-
 Improvements:
 * The `type` of an `Address` is now non-null.
 * The `type` of an `Email` is now non-null.


### PR DESCRIPTION
Added a note to mark which versions would require Android projects to have compileSDK 34.

The reason for this change is because since `3.5.0` the plugin uses dependencies that require compileSDK to be set to 34 as I have already explained in https://github.com/juliansteenbakker/mobile_scanner/issues/922#issuecomment-1912090475

With this change, hopefully, there will be less confused people as versions before 4.0.0 don't mention such requirement, so, potentially, there might be more issues like #922 