### PR TITLE
docs: add description for all examples to examples README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,5 +165,5 @@ Future<void> dispose() async {
 
 To display the camera preview, pass the controller to a `MobileScanner` widget.
 
-See the examples for runnable examples of various usages,
+See the [examples](example/README.md) for runnable examples of various usages,
 such as the basic usage, applying a scan window, or retrieving images from the barcodes.

--- a/example/README.md
+++ b/example/README.md
@@ -2,15 +2,66 @@
 
 Demonstrates how to use the mobile_scanner plugin.
 
-## Getting Started
+## Run Examples
 
-This project is a starting point for a Flutter application.
+1. `git clone https://github.com/juliansteenbakker/mobile_scanner.git`
+2. `cd mobile_scanner/examples/lib`
+3. `flutter pub get`
+4. `flutter run`
 
-A few resources to get you started if this is your first Flutter project:
+## Examples Overview
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+### With Controller
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+Scanner widget with control buttons overlay. Shows first detected barcode.
+(See ListView example for detecting and displaying multiple barcodes at the same time.)
+
+* Displays Flashlight, SwitchCamera and Start/Stop buttons.
+* Uses `MobileScannerController` to start/stop, toggle flashlight, switch camera.
+* Displays Gallery button to use images as source for analysis.
+* Handles changes in AppLifecycleState.
+
+### With ListView
+
+Scanner widget with control buttons overlay. Shows all barcodes detected at the same time in a ListView.
+
+* Displays Flashlight, SwitchCamera and Start/Stop buttons.
+* Uses `MobileScannerController` to start/stop, toggle flashlight, switch camera.
+* Displays Gallery button to use images as source for analysis.
+
+### With Zoom Slider
+
+Scanner widget with control buttons and zoom slider overlay. Shows first detected barcode.
+
+* Displays Flashlight, SwitchCamera and Start/Stop buttons and zoom slider.
+* Uses `MobileScannerController` to start/stop, toggle flashlight, switch camera, set zoom scale.
+* Displays Gallery button to use images as source for analysis.
+
+### With Controller (returning image)
+
+Scanner widget with control buttons overlay. Shows the first detected barcode and the captured image.
+
+* Displays Flashlight, SwitchCamera and Start/Stop buttons.
+* Uses `MobileScannerController` to start/stop, toggle flashlight, switch camera.
+* Displays captured image that contains the detected barcode.
+
+### With Page View
+
+Scanner widget in one of many pages that can be swiped horizontally. Starts and stops scanner depending on page visibility.
+
+* Shows first detected barcode.
+
+### With Scan Window
+
+Scanner widget with scan window overlay. Barcodes are only detected inside the scan window.
+
+* Draws scan window - a half-transparent overlay with a cut out middle part.
+* Draws bounding box around (first) detected barcode. (not working on every device)
+
+### With Overlay
+
+Scanner widget with scan window overlay. Barcodes are only detected inside the scan window.
+
+* Draws scan window - a half-transparent overlay with a cut out middle part that has a border with rounded corners.
+* Displays Flashlight, SwitchCamera buttons.
+* Uses `MobileScannerController` to toggle flashlight, switch camera.


### PR DESCRIPTION
Currently, it is a time-consuming task to figure out the best options to implement mobile_scanner in a custom app because because there is not general documentation for the examples found in the examples folder.

This PR adds an overview with a short description for all examples.