### PR TITLE
fix: lower the Flutter constraint to allow earlier adoption of the beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## NEXT
+## 5.0.0-beta.2
+
+**BREAKING CHANGES:**
+
+* Flutter 3.16.0 is now required.
 
 Bugs fixed:
 * Fixed an issue where the scan window was not updated when its size was changed. (thanks @navaronbracke !)
@@ -7,7 +11,6 @@ Bugs fixed:
 
 **BREAKING CHANGES:**
 
-* Flutter 3.19.0 is now required.
 * The `width` and `height` of `BarcodeCapture` have been removed, in favor of `size`.
 * The `raw` attribute is now `Object?` instead of `dynamic`, so that it participates in type promotion.
 * The `MobileScannerArguments` class has been removed from the public API, as it is an internal type.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,8 +6,8 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 0.0.1
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  sdk: ">=3.2.0 <4.0.0"
+  flutter: ">=3.16.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal barcode and QR code scanner for Flutter based on MLKit. Uses CameraX on Android, AVFoundation on iOS and Apple Vision & AVFoundation on macOS.
-version: 5.0.0-beta.1
+version: 5.0.0-beta.2
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 screenshots:
@@ -16,8 +16,8 @@ screenshots:
   path: example/screenshots/overlay.png
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  sdk: ">=3.2.0 <4.0.0"
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:
@@ -25,7 +25,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   plugin_platform_interface: ^2.0.2  
-  web: ^0.5.0
+  web: ^0.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR lowers the barrier to entry for the new beta to Flutter 3.16.0

The main use of the previous constraint was to use `extension types`, but that can be done as an incremental release instead. Users that are already on Flutter 3.16.0 _do_ have access to (an earlier version of) package:web and dart:js_interop which does not yet utilise extension types.