### PR TITLE
chore(deps): bump GoogleMLKit/BarcodeScanning from 4.0.0 to 5.0.0

### DIFF
--- a/ios/mobile_scanner.podspec
+++ b/ios/mobile_scanner.podspec
@@ -15,7 +15,7 @@ An universal scanner for Flutter based on MLKit.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'GoogleMLKit/BarcodeScanning', '~> 4.0.0'
+  s.dependency 'GoogleMLKit/BarcodeScanning', '~> 5.0.0'
   s.platform = :ios, '11.0'
   s.static_framework = true
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
This package depends on `GoogleMLKit/BarcodeScanning`.

Currently, it relies on version v4.0.0 of `GoogleMLKit/BarcodeScanning`.
The latest version is v5.0.0, which includes support for the Apple Privacy Manifest, prompting the need for an update of the dependent package.

This PR updates the dependency from v4.0.0 to v5.0.0.