### PR TITLE
chore(deps): Bump GoogleMLKit/BarcodeScanning to 6.0.0

### DIFF
--- a/ios/mobile_scanner.podspec
+++ b/ios/mobile_scanner.podspec
@@ -15,7 +15,7 @@ An universal scanner for Flutter based on MLKit.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'GoogleMLKit/BarcodeScanning', '~> 5.0.0'
+  s.dependency 'GoogleMLKit/BarcodeScanning', '~> 6.0.0'
   s.platform = :ios, '12.0'
   s.static_framework = true
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
The 5.0.0 version has the iOS privacy manifests updated for the MLKit libs themselves, but they still pulled in old versions of transitive dependencies like GoogleToolboxForMac that didn't have the necessary manifests. The 6.0.0 version updated the transitive dependencies and now the privacy manifests should be all good.