### PR TITLE
feat: change platform os detect pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 5.0.1
 
 Improvements:
-* Change platform OS detection pattern. According to the official Dart documentation, the `dart:io.Platform` object should only be used directly when it's critical to detect the actual current platform, without allowing overrides (for example, when calling native system APIs). With this change, we can override the platform in test code.
+* Adjusted the platform checks to use the defaultTargetPlatform API, so that tests can use the correct platform overrides.
 
 ## 5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.1
+
+Improvements:
+* Change platform OS detection pattern. According to the official Dart documentation, the `dart:io.Platform` object should only be used directly when it's critical to detect the actual current platform, without allowing overrides (for example, when calling native system APIs). With this change, we can override the platform in test code.
+
 ## 5.0.0
 
 This major release contains all the changes from the 5.0.0 beta releases, along with the following changes:

--- a/example/lib/barcode_scanner_window.dart
+++ b/example/lib/barcode_scanner_window.dart
@@ -204,7 +204,7 @@ class BarcodeOverlay extends CustomPainter {
     final double ratioWidth;
     final double ratioHeight;
 
-    if (!kIsWeb && Platform.isIOS) {
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) {
       ratioWidth = barcodeSize.width / adjustedSize.destination.width;
       ratioHeight = barcodeSize.height / adjustedSize.destination.height;
     } else {

--- a/example/lib/barcode_scanner_window.dart
+++ b/example/lib/barcode_scanner_window.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
-import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
@@ -54,7 +54,7 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
     final List<Map<Object?, Object?>> barcodes =
         data.cast<Map<Object?, Object?>>();
 
-    if (Platform.isMacOS) {
+    if (defaultTargetPlatform == TargetPlatform.macOS) {
       return BarcodeCapture(
         raw: event,
         barcodes: barcodes
@@ -70,7 +70,8 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
       );
     }
 
-    if (Platform.isAndroid || Platform.isIOS) {
+    if (defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS) {
       final double? width = event['width'] as double?;
       final double? height = event['height'] as double?;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal barcode and QR code scanner for Flutter based on MLKit. Uses CameraX on Android, AVFoundation on iOS and Apple Vision & AVFoundation on macOS.
-version: 5.0.0
+version: 5.0.1
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 screenshots:


### PR DESCRIPTION
current code in `lib/src/method_channel/mobile_scanner_method_channel.dart` cannot change the platform in the test code when need to change the platform. according to this thread, maybe we should change the platform os detect pattern into `defaultTargetPlatform `. 
ref:https://stackoverflow.com/questions/55233853/flutter-widget-tests-with-platform-branching