### PR TITLE
fix: widget-disposed-during-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 5.0.2
 
 Bugs fixed:
-* Catch an exception that could appear if MobileScannerController is disposed during start(). [#1036](https://github.com/juliansteenbakker/mobile_scanner/pull/1036) (thanks @EArminjon !)
+* Fixed a crash when the controller is disposed while it is still starting. [#1036](https://github.com/juliansteenbakker/mobile_scanner/pull/1036) (thanks @EArminjon !)
 
 ## 5.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.2
+
+Bugs fixed:
+* Catch an exception that could appear if MobileScannerController is disposed during start(). [#1036](https://github.com/juliansteenbakker/mobile_scanner/pull/1036) (thanks @EArminjon !)
+
 ## 5.0.1
 
 Improvements:

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -274,16 +274,18 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
         options,
       );
 
-      value = value.copyWith(
-        availableCameras: viewAttributes.numberOfCameras,
-        cameraDirection: effectiveDirection,
-        isInitialized: true,
-        isRunning: true,
-        size: viewAttributes.size,
-        // If the device has a flashlight, let the platform update the torch state.
-        // If it does not have one, provide the unavailable state directly.
-        torchState: viewAttributes.hasTorch ? null : TorchState.unavailable,
-      );
+      if (!_isDisposed) {
+        value = value.copyWith(
+          availableCameras: viewAttributes.numberOfCameras,
+          cameraDirection: effectiveDirection,
+          isInitialized: true,
+          isRunning: true,
+          size: viewAttributes.size,
+          // If the device has a flashlight, let the platform update the torch state.
+          // If it does not have one, provide the unavailable state directly.
+          torchState: viewAttributes.hasTorch ? null : TorchState.unavailable,
+        );
+      }
     } on MobileScannerException catch (error) {
       // The initialization finished with an error.
       // To avoid stale values, reset the output size,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal barcode and QR code scanner for Flutter based on MLKit. Uses CameraX on Android, AVFoundation on iOS and Apple Vision & AVFoundation on macOS.
-version: 5.0.1
+version: 5.0.2
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 screenshots:
@@ -24,7 +24,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  plugin_platform_interface: ^2.0.2  
+  plugin_platform_interface: ^2.0.2
   web: ^0.5.1
 
 dev_dependencies:


### PR DESCRIPTION
If mobile_scanner widget is disposed while start the following exception appear : 

```
flutter: Once you have called dispose() on a MobileScannerController, it can no longer be used.
flutter: #0      ChangeNotifier.debugAssertNotDisposed.<anonymous closure> (package:flutter/src/foundation/change_notifier.dart:179:9)
flutter: #1      ChangeNotifier.debugAssertNotDisposed (package:flutter/src/foundation/change_notifier.dart:186:6)
flutter: #2      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:412:27)
flutter: #3      ValueNotifier.value= (package:flutter/src/foundation/change_notifier.dart:555:5)
flutter: #4      MobileScannerController.start (package:mobile_scanner/src/mobile_scanner_controller.dart:277:7)
```