### PR TITLE
fix: Adjust autoStart values for samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.1
+* This release fixes an issue with automatic starts in the examples.
+
 ## 5.1.0
 This updates reverts a few breaking changes made in v5.0.0 in order to keep things simple.
 

--- a/example/lib/barcode_scanner_controller.dart
+++ b/example/lib/barcode_scanner_controller.dart
@@ -16,12 +16,9 @@ class BarcodeScannerWithController extends StatefulWidget {
 class _BarcodeScannerWithControllerState
     extends State<BarcodeScannerWithController> with WidgetsBindingObserver {
   final MobileScannerController controller = MobileScannerController(
-    torchEnabled: true, useNewCameraSelector: true,
-    // formats: [BarcodeFormat.qrCode]
-    // facing: CameraFacing.front,
-    // detectionSpeed: DetectionSpeed.normal
-    // detectionTimeoutMs: 1000,
-    // returnImage: false,
+    autoStart: false,
+    torchEnabled: true,
+    useNewCameraSelector: true,
   );
 
   Barcode? _barcode;

--- a/example/lib/barcode_scanner_listview.dart
+++ b/example/lib/barcode_scanner_listview.dart
@@ -15,19 +15,7 @@ class BarcodeScannerListView extends StatefulWidget {
 class _BarcodeScannerListViewState extends State<BarcodeScannerListView> {
   final MobileScannerController controller = MobileScannerController(
     torchEnabled: true,
-    // formats: [BarcodeFormat.qrCode]
-    // facing: CameraFacing.front,
-    // detectionSpeed: DetectionSpeed.normal
-    // detectionTimeoutMs: 1000,
-    // returnImage: false,
   );
-
-  @override
-  void initState() {
-    super.initState();
-
-    controller.start();
-  }
 
   Widget _buildBarcodesListView() {
     return StreamBuilder<BarcodeCapture>(

--- a/example/lib/barcode_scanner_pageview.dart
+++ b/example/lib/barcode_scanner_pageview.dart
@@ -13,16 +13,9 @@ class BarcodeScannerPageView extends StatefulWidget {
 }
 
 class _BarcodeScannerPageViewState extends State<BarcodeScannerPageView> {
-  final MobileScannerController controller =
-      MobileScannerController(autoStart: false);
+  final MobileScannerController controller = MobileScannerController();
 
   final PageController pageController = PageController();
-
-  @override
-  void initState() {
-    super.initState();
-    unawaited(controller.start());
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/barcode_scanner_returning_image.dart
+++ b/example/lib/barcode_scanner_returning_image.dart
@@ -18,18 +18,8 @@ class _BarcodeScannerReturningImageState
     extends State<BarcodeScannerReturningImage> {
   final MobileScannerController controller = MobileScannerController(
     torchEnabled: true,
-    // formats: [BarcodeFormat.qrCode]
-    // facing: CameraFacing.front,
-    // detectionSpeed: DetectionSpeed.normal
-    // detectionTimeoutMs: 1000,
     returnImage: true,
   );
-
-  @override
-  void initState() {
-    super.initState();
-    controller.start();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/barcode_scanner_window.dart
+++ b/example/lib/barcode_scanner_window.dart
@@ -17,13 +17,6 @@ class _BarcodeScannerWithScanWindowState
     extends State<BarcodeScannerWithScanWindow> {
   final MobileScannerController controller = MobileScannerController();
 
-  @override
-  void initState() {
-    super.initState();
-
-    controller.start();
-  }
-
   Widget _buildBarcodeOverlay() {
     return ValueListenableBuilder(
       valueListenable: controller,

--- a/example/lib/barcode_scanner_zoom.dart
+++ b/example/lib/barcode_scanner_zoom.dart
@@ -22,12 +22,6 @@ class _BarcodeScannerWithZoomState extends State<BarcodeScannerWithZoom> {
 
   double _zoomFactor = 0.0;
 
-  @override
-  void initState() {
-    super.initState();
-    controller.start();
-  }
-
   Widget _buildZoomScaleSlider() {
     return ValueListenableBuilder(
       valueListenable: controller,

--- a/example/lib/mobile_scanner_overlay.dart
+++ b/example/lib/mobile_scanner_overlay.dart
@@ -16,12 +16,6 @@ class _BarcodeScannerWithOverlayState extends State<BarcodeScannerWithOverlay> {
   );
 
   @override
-  void initState() {
-    super.initState();
-    controller.start();
-  }
-
-  @override
   Widget build(BuildContext context) {
     final scanWindow = Rect.fromCenter(
       center: MediaQuery.sizeOf(context).center(Offset.zero),

--- a/ios/mobile_scanner.podspec
+++ b/ios/mobile_scanner.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'mobile_scanner'
-  s.version          = '5.0.2'
+  s.version          = '5.1.1'
   s.summary          = 'An universal scanner for Flutter based on MLKit.'
   s.description      = <<-DESC
 An universal scanner for Flutter based on MLKit.

--- a/macos/mobile_scanner.podspec
+++ b/macos/mobile_scanner.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'mobile_scanner'
-  s.version          = '5.0.2'
+  s.version          = '5.1.1'
   s.summary          = 'An universal scanner for Flutter based on MLKit.'
   s.description      = <<-DESC
 An universal scanner for Flutter based on MLKit.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal barcode and QR code scanner for Flutter based on MLKit. Uses CameraX on Android, AVFoundation on iOS and Apple Vision & AVFoundation on macOS.
-version: 5.1.0
+version: 5.1.1
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 screenshots:


### PR DESCRIPTION
When reintroducing the `autoStart` parameter, the samples were not accounted for. This PR adjusts the samples to automatically start, except for the lifecycle sample, which still manually starts. 

Fixes #1058 