### PR TITLE
fix: connecting the useNewCameraSelector option

### DIFF
--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -268,6 +268,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
       formats: formats,
       returnImage: returnImage,
       torchEnabled: torchEnabled,
+      useNewCameraSelector: useNewCameraSelector,
     );
 
     try {

--- a/lib/src/objects/start_options.dart
+++ b/lib/src/objects/start_options.dart
@@ -14,6 +14,7 @@ class StartOptions {
     required this.formats,
     required this.returnImage,
     required this.torchEnabled,
+    required this.useNewCameraSelector,
   });
 
   /// The direction for the camera.
@@ -37,6 +38,10 @@ class StartOptions {
   /// Whether the torch should be turned on when the scanner starts.
   final bool torchEnabled;
 
+  /// Only supported on Android.
+  /// Whether the new resolution selector should be used.
+  final bool useNewCameraSelector;
+
   Map<String, Object?> toMap() {
     return <String, Object?>{
       if (cameraResolution != null)
@@ -51,6 +56,7 @@ class StartOptions {
       'speed': detectionSpeed.rawValue,
       'timeout': detectionTimeoutMs,
       'torch': torchEnabled,
+      'useNewCameraSelector': useNewCameraSelector,
     };
   }
 }

--- a/lib/src/objects/start_options.dart
+++ b/lib/src/objects/start_options.dart
@@ -38,8 +38,9 @@ class StartOptions {
   /// Whether the torch should be turned on when the scanner starts.
   final bool torchEnabled;
 
-  /// Only supported on Android.
   /// Whether the new resolution selector should be used.
+  ///
+  /// This option is only supported on Android. Other platforms will ignore this option.
   final bool useNewCameraSelector;
 
   Map<String, Object?> toMap() {


### PR DESCRIPTION
useNewCameraSelector is not being sent to the android backend. This forwards it with the other start options.