### PR TITLE
feat: read inverted datamatrix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,6 +80,9 @@ dependencies {
     implementation 'androidx.camera:camera-lifecycle:1.3.3'
     implementation 'androidx.camera:camera-camera2:1.3.3'
 
+    // opencv
+    implementation 'com.quickbirdstudios:opencv:3.4.15'
+
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.mockito:mockito-core:5.12.0'    
 }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -128,6 +128,7 @@ class MobileScannerHandler(
             "setScale" -> setScale(call, result)
             "resetScale" -> resetScale(result)
             "updateScanWindow" -> updateScanWindow(call, result)
+            "setInvertImage" -> setInvertImage(call, result)
             else -> result.notImplemented()
         }
     }
@@ -138,6 +139,7 @@ class MobileScannerHandler(
         val facing: Int = call.argument<Int>("facing") ?: 0
         val formats: List<Int>? = call.argument<List<Int>>("formats")
         val returnImage: Boolean = call.argument<Boolean>("returnImage") ?: false
+        val invertImage: Boolean = call.argument<Boolean>("invertImage") ?: false
         val speed: Int = call.argument<Int>("speed") ?: 1
         val timeout: Int = call.argument<Int>("timeout") ?: 250
         val cameraResolutionValues: List<Int>? = call.argument<List<Int>>("cameraResolution")
@@ -174,6 +176,7 @@ class MobileScannerHandler(
         mobileScanner!!.start(
             barcodeScannerOptions,
             returnImage,
+            invertImage,
             position,
             torch,
             detectionSpeed,
@@ -273,6 +276,15 @@ class MobileScannerHandler(
     private fun updateScanWindow(call: MethodCall, result: MethodChannel.Result) {
         mobileScanner?.scanWindow = call.argument<List<Float>?>("rect")
 
+        result.success(null)
+    }
+
+    private fun setInvertImage(call: MethodCall, result: MethodChannel.Result) {
+        val invert = call.argument<Boolean?>("invertImage")
+        
+        if (invert != null)
+            mobileScanner?.invertImage = invert
+        
         result.success(null)
     }
 }

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -144,9 +144,10 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
             nextScanTime = currentTime + timeoutSeconds
             imagesCurrentlyBeingProcessed = true
             
-            let ciImage
+            let ciImage : CIImage
             if (invertImage) {
                 image = self.invertImage(image: latestBuffer.image)
+                ciImage = CIImage(image: image)
             }
             else
             {

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -28,6 +28,9 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
     /// Return image buffer with the Barcode event
     var returnImage: Bool = false
 
+    /// Analyze inverted image (useful for scanning white barcodes on black background)
+    var invertImage: Bool = false
+
     /// Default position of camera
     var videoPosition: AVCaptureDevice.Position = AVCaptureDevice.Position.back
 
@@ -149,6 +152,10 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
                 defaultOrientation: .portrait,
                 position: videoPosition
             )
+
+            if (invertImage) {
+                image = self.invertImage(image: image)
+            }
 
             scanner.process(image) { [self] barcodes, error in
                 imagesCurrentlyBeingProcessed = false
@@ -390,6 +397,10 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
         }
     }
     
+    func setInvertImage(_ invertImage: Bool) {
+        self.invertImage = invertImage
+    }
+
     /// Set the zoom factor of the camera
     func setScale(_ scale: CGFloat) throws {
         if (device == nil) {
@@ -440,8 +451,18 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
             defaultOrientation: .portrait,
             position: position
         )
-
+        if (invertImage) {
+            image = self.invertImage(image: image)
+        }
         scanner.process(image, completion: callback)
+    }
+
+    func invertImage(image: UIImage) -> UIImage {
+        let ciImage = CIImage(image: image)
+        let filter = CIFilter(name: "CIColorInvert")
+        filter?.setValue(ciImage, forKey: kCIInputImageKey)
+        let outputImage = filter?.outputImage
+        return UIImage(ciImage: outputImage!, orientation: image.imageOrientation, scale: image.scale)
     }
 
     var barcodesString: Array<String?>?

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -449,12 +449,12 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
     }
 
     /// Analyze a single image
-    func analyzeImage(imageIn: UIImage, position: AVCaptureDevice.Position, callback: @escaping BarcodeScanningCallback) {
-        var image = imageIn
+    func analyzeImage(image: UIImage, position: AVCaptureDevice.Position, callback: @escaping BarcodeScanningCallback) {
+        var uiimage = image
         if (invertImage) {
-            image = self.invertImage(image: image)
+            uiimage = self.invertImage(image: uiimage)
         }
-        var visImage = VisionImage(image: image)
+        var visImage = VisionImage(image: uiimage)
         visImage.orientation = imageOrientation(
             deviceOrientation: UIDevice.current.orientation,
             defaultOrientation: .portrait,

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -146,7 +146,7 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
             
             let ciImage = latestBuffer.image
 
-            let image = VisionImage(image: ciImage)
+            var image = VisionImage(image: ciImage)
             image.orientation = imageOrientation(
                 deviceOrientation: UIDevice.current.orientation,
                 defaultOrientation: .portrait,

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -144,7 +144,14 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
             nextScanTime = currentTime + timeoutSeconds
             imagesCurrentlyBeingProcessed = true
             
-            let ciImage = latestBuffer.image
+            let ciImage
+            if (invertImage) {
+                image = self.invertImage(image: latestBuffer.image)
+            }
+            else
+            {
+                ciImage = latestBuffer.image
+            }
 
             var image = VisionImage(image: ciImage)
             image.orientation = imageOrientation(
@@ -153,9 +160,6 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
                 position: videoPosition
             )
 
-            if (invertImage) {
-                image = self.invertImage(image: image)
-            }
 
             scanner.process(image) { [self] barcodes, error in
                 imagesCurrentlyBeingProcessed = false

--- a/ios/Classes/MobileScanner.swift
+++ b/ios/Classes/MobileScanner.swift
@@ -146,8 +146,8 @@ public class MobileScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
             
             let ciImage : CIImage
             if (invertImage) {
-                image = self.invertImage(image: latestBuffer.image)
-                ciImage = CIImage(image: image)
+                let temp_image = self.invertImage(image: latestBuffer.image)
+                ciImage = CIImage(image: temp_image)
             }
             else
             {

--- a/ios/Classes/MobileScannerPlugin.swift
+++ b/ios/Classes/MobileScannerPlugin.swift
@@ -123,7 +123,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         let detectionSpeed: DetectionSpeed = DetectionSpeed(rawValue: speed)!
 
         do {
-            try mobileScanner.start(barcodeScannerOptions: barcodeOptions, returnImage: returnImage, cameraPosition: position, torch: torch, detectionSpeed: detectionSpeed) { parameters in
+            try mobileScanner.start(barcodeScannerOptions: barcodeOptions, returnImage: returnImage, invertImage: invertImage, cameraPosition: position, torch: torch, detectionSpeed: detectionSpeed) { parameters in
                 DispatchQueue.main.async {
                     result([
                         "textureId": parameters.textureId,

--- a/ios/Classes/MobileScannerPlugin.swift
+++ b/ios/Classes/MobileScannerPlugin.swift
@@ -84,6 +84,8 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
             toggleTorch(result)
         case "analyzeImage":
             analyzeImage(call, result)
+        case "setInvertImage":
+            setInvertImage(call, result)
         case "setScale":
             setScale(call, result)
         case "resetScale":
@@ -101,6 +103,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         let facing: Int = (call.arguments as! Dictionary<String, Any?>)["facing"] as? Int ?? 1
         let formats: Array<Int> = (call.arguments as! Dictionary<String, Any?>)["formats"] as? Array ?? []
         let returnImage: Bool = (call.arguments as! Dictionary<String, Any?>)["returnImage"] as? Bool ?? false
+        let invertImage: Bool = (call.arguments as! Dictionary<String, Any?>)["invertImage"] as? Bool ?? false
         let speed: Int = (call.arguments as! Dictionary<String, Any?>)["speed"] as? Int ?? 0
         let timeoutMs: Int = (call.arguments as! Dictionary<String, Any?>)["timeout"] as? Int ?? 0
         self.mobileScanner.timeoutSeconds = Double(timeoutMs) / Double(1000)
@@ -162,6 +165,26 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         result(nil)
     }
     
+    
+    /// Sets the zoomScale.
+    private func setInvertImage(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        let invert = call.arguments as? Bool
+        if (invert == nil) {
+            result(FlutterError(code: "MobileScanner",
+                                message: "You must provide a invert (bool) when calling setInvertImage",
+                                details: nil))
+            return
+        }
+        do {
+            try mobileScanner.setInvertImage(scale!)
+            result(nil)
+        } catch MobileScannerError.zoomWhenStopped {
+            result(FlutterError(code: "MobileScanner",
+                                message: "Called setInvertImage() while stopped!",
+                                details: nil))
+        }
+    }
+
     /// Sets the zoomScale.
     private func setScale(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let scale = call.arguments as? CGFloat

--- a/ios/Classes/MobileScannerPlugin.swift
+++ b/ios/Classes/MobileScannerPlugin.swift
@@ -175,14 +175,8 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
                                 details: nil))
             return
         }
-        do {
-            try mobileScanner.setInvertImage(scale!)
-            result(nil)
-        } catch MobileScannerError.zoomWhenStopped {
-            result(FlutterError(code: "MobileScanner",
-                                message: "Called setInvertImage() while stopped!",
-                                details: nil))
-        }
+        mobileScanner.setInvertImage(invert!)
+        result(nil)
     }
 
     /// Sets the zoomScale.

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -296,6 +296,14 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
   }
 
   @override
+  Future<void> setInvertImage(bool invertImage) async {
+    await methodChannel.invokeMethod<void>(
+      'setInvertImage',
+      {'invertImage': invertImage},
+    );
+  }
+
+  @override
   Future<void> dispose() async {
     await stop();
   }

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -25,6 +25,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
     this.formats = const <BarcodeFormat>[],
     this.returnImage = false,
     this.torchEnabled = false,
+    this.invertImage = false,
     this.useNewCameraSelector = false,
   })  : detectionTimeoutMs =
             detectionSpeed == DetectionSpeed.normal ? detectionTimeoutMs : 0,
@@ -87,6 +88,11 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   ///
   /// Defaults to false.
   final bool torchEnabled;
+
+  /// Whether the image should be inverted before scanning.
+  ///
+  /// Defaults to false.
+  final bool invertImage;
 
   /// Use the new resolution selector.
   ///
@@ -268,6 +274,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
       formats: formats,
       returnImage: returnImage,
       torchEnabled: torchEnabled,
+      invertImage: invertImage,
     );
 
     try {

--- a/lib/src/mobile_scanner_platform_interface.dart
+++ b/lib/src/mobile_scanner_platform_interface.dart
@@ -104,6 +104,11 @@ abstract class MobileScannerPlatform extends PlatformInterface {
     throw UnimplementedError('updateScanWindow() has not been implemented.');
   }
 
+  /// Set inverting image colors (for negative Data Matrixes).
+  Future<void> setInvertImage(bool invert) {
+    throw UnimplementedError('setInvertImage() has not been implemented.');
+  }
+
   /// Dispose of this [MobileScannerPlatform] instance.
   Future<void> dispose() {
     throw UnimplementedError('dispose() has not been implemented.');

--- a/lib/src/objects/start_options.dart
+++ b/lib/src/objects/start_options.dart
@@ -14,6 +14,7 @@ class StartOptions {
     required this.formats,
     required this.returnImage,
     required this.torchEnabled,
+    required this.invertImage,
   });
 
   /// The direction for the camera.
@@ -37,6 +38,9 @@ class StartOptions {
   /// Whether the torch should be turned on when the scanner starts.
   final bool torchEnabled;
 
+  /// Whether the image should be inverted.
+  final bool invertImage;
+
   Map<String, Object?> toMap() {
     return <String, Object?>{
       if (cameraResolution != null)
@@ -51,6 +55,7 @@ class StartOptions {
       'speed': detectionSpeed.rawValue,
       'timeout': detectionTimeoutMs,
       'torch': torchEnabled,
+      'invertImage': invertImage,
     };
   }
 }


### PR DESCRIPTION
Here's a quick stab at adding support for reading inverted data matrixes that the MLKit does not support. The iOS implementation is a bit clumsy (I'm not an iOS coder), but Android one is quite straight forward. Tested and works in Android & iOS. Feel free to modify, include or leave be as you will.

Future idea: add "tryInverted" which duplicates each frame and tries normal and inverted both.