### PR TITLE
fix: fix barcode scanner leak on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+* Fixed a leak of the barcode scanner on Android.
+
 ## 5.1.1
 * This release fixes an issue with automatic starts in the examples.
 

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -472,4 +472,11 @@ class MobileScanner(
         camera?.cameraControl?.setZoomRatio(1f)
     }
 
+    /**
+     * Dispose of this scanner instance.
+     */
+    fun dispose() {
+        scanner?.close()
+        scanner = null
+    }
 }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -13,6 +13,7 @@ import android.os.Looper
 import android.util.Size
 import android.view.Surface
 import android.view.WindowManager
+import androidx.annotation.VisibleForTesting
 import androidx.camera.core.Camera
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ExperimentalGetImage
@@ -41,7 +42,7 @@ class MobileScanner(
     private val activity: Activity,
     private val textureRegistry: TextureRegistry,
     private val mobileScannerCallback: MobileScannerCallback,
-    private val mobileScannerErrorCallback: MobileScannerErrorCallback
+    private val mobileScannerErrorCallback: MobileScannerErrorCallback,
 ) {
 
     /// Internal variables
@@ -159,6 +160,15 @@ class MobileScanner(
         return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
     }
 
+    /**
+     * Create a barcode scanner from the given options.
+     *
+     * Can be overridden in tests.
+     */
+    @VisibleForTesting
+    fun createBarcodeScanner(options: BarcodeScannerOptions?) : BarcodeScanner {
+        return if (options == null) BarcodeScanning.getClient() else BarcodeScanning.getClient(options)
+    }
 
     // scales the scanWindow to the provided inputImage and checks if that scaled
     // scanWindow contains the barcode
@@ -238,11 +248,7 @@ class MobileScanner(
         }
 
         lastScanned = null
-        scanner = if (barcodeScannerOptions != null) {
-            BarcodeScanning.getClient(barcodeScannerOptions)
-        } else {
-            BarcodeScanning.getClient()
-        }
+        scanner = createBarcodeScanner(barcodeScannerOptions)
 
         val cameraProviderFuture = ProcessCameraProvider.getInstance(activity)
         val executor = ContextCompat.getMainExecutor(activity)

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -170,16 +170,6 @@ class MobileScanner(
         return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
     }
 
-    /**
-     * Create a barcode scanner from the given options.
-     *
-     * Can be overridden in tests.
-     */
-    @VisibleForTesting
-    fun createBarcodeScanner(options: BarcodeScannerOptions?) : BarcodeScanner {
-        return if (options == null) BarcodeScanning.getClient() else BarcodeScanning.getClient(options)
-    }
-
     // scales the scanWindow to the provided inputImage and checks if that scaled
     // scanWindow contains the barcode
     private fun isBarcodeInScanWindow(
@@ -512,7 +502,10 @@ class MobileScanner(
      * Dispose of this scanner instance.
      */
     fun dispose() {
-        scanner?.close()
-        scanner = null
+        if (isStopped()) {
+            return
+        }
+
+        stop() // Defer to the stop method, which disposes all resources anyway.
     }
 }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -92,6 +92,7 @@ class MobileScannerHandler(
     fun dispose(activityPluginBinding: ActivityPluginBinding) {
         methodChannel?.setMethodCallHandler(null)
         methodChannel = null
+        mobileScanner?.dispose()
         mobileScanner = null
 
         val listener: RequestPermissionsResultListener? = permissions.getPermissionListener()

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -243,7 +243,13 @@ class MobileScannerHandler(
         analyzerResult = result
         val uri = Uri.fromFile(File(call.arguments.toString()))
 
-        mobileScanner!!.analyzeImage(uri, analyzeImageSuccessCallback, analyzeImageErrorCallback)
+        // TODO: parse options from the method call
+        // See https://github.com/juliansteenbakker/mobile_scanner/issues/1069
+        mobileScanner!!.analyzeImage(
+            uri,
+            null,
+            analyzeImageSuccessCallback,
+            analyzeImageErrorCallback)
     }
 
     private fun toggleTorch(result: MethodChannel.Result) {


### PR DESCRIPTION
This PR adds the following changes:
- Fixes a possible leak on Android relating to keeping an orphaned barcode scanner around (the one that is created when the scanner variable is declared, but not yet used)
- Fixed another possible leak where not all camera observers were released
- Reflows some part of the Android code to use early returns
- Updates `analyzeImage()` to take configurable barcode scanner options & use a short lived scanner
- Adds a way to mock the barcode scanner for testing (will be used for the NaN error fix)

For future readers, iOS does not have an equivalent release method for the scanner in the MLKit library.
It's possible that uses an autorelease pool or destructor.

Fixes https://github.com/juliansteenbakker/mobile_scanner/issues/988
Part of https://github.com/juliansteenbakker/mobile_scanner/issues/1069
Part of https://github.com/juliansteenbakker/mobile_scanner/issues/1134