### PR TITLE
chore: Bump version to 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 5.2.0
 * This release requires Flutter 3.22.0 and Dart 3.4.
 
 * [Android] Fixed a leak of the barcode scanner.

--- a/ios/mobile_scanner.podspec
+++ b/ios/mobile_scanner.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'mobile_scanner'
-  s.version          = '5.1.1'
+  s.version          = '5.2.0'
   s.summary          = 'An universal scanner for Flutter based on MLKit.'
   s.description      = <<-DESC
 An universal scanner for Flutter based on MLKit.

--- a/macos/mobile_scanner.podspec
+++ b/macos/mobile_scanner.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'mobile_scanner'
-  s.version          = '5.1.1'
+  s.version          = '5.2.0'
   s.summary          = 'An universal scanner for Flutter based on MLKit.'
   s.description      = <<-DESC
 An universal scanner for Flutter based on MLKit.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal barcode and QR code scanner for Flutter based on MLKit. Uses CameraX on Android, AVFoundation on iOS and Apple Vision & AVFoundation on macOS.
-version: 5.1.1
+version: 5.2.0
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 screenshots:


### PR DESCRIPTION
This PR bumps the version of `mobile_scanner` to 5.2.0

I used this version number, to not break users that have not migrated to Flutter 3.22.0

This version includes the bump for package:web and some bugfixes.

For the next version, I plan to fix the NV21 format bug and finish the Impeller migration on Android.