### PR TITLE
fix: clean up example button widgets

### DIFF
--- a/example/lib/scanner_button_widgets.dart
+++ b/example/lib/scanner_button_widgets.dart
@@ -112,6 +112,7 @@ class SwitchCameraButton extends StatelessWidget {
         }
 
         return IconButton(
+          color: Colors.white,
           iconSize: 32.0,
           icon: icon,
           onPressed: () async {
@@ -166,10 +167,13 @@ class ToggleFlashlightButton extends StatelessWidget {
               },
             );
           case TorchState.unavailable:
-            return const Icon(
-              Icons.no_flash,
-              color: Colors.grey,
-            );
+            return const SizedBox(
+                width: 48.0,
+                child: Icon(
+                  Icons.no_flash,
+                  size: 32.0,
+                  color: Colors.grey,
+                ));
         }
       },
     );

--- a/example/lib/scanner_button_widgets.dart
+++ b/example/lib/scanner_button_widgets.dart
@@ -168,12 +168,15 @@ class ToggleFlashlightButton extends StatelessWidget {
             );
           case TorchState.unavailable:
             return const SizedBox(
-                width: 48.0,
+              width: 48.0,
+              child: Center(
                 child: Icon(
                   Icons.no_flash,
                   size: 32.0,
                   color: Colors.grey,
-                ));
+                ),
+              ),
+            );
         }
       },
     );


### PR DESCRIPTION
I noticed when experimenting with the overlay example, that the camera switching button had no color defined (and was invisible when I tried it in my app initially), and that the flash-unavailable icon did not take as much space as the flash icon button (and was a different size).  This attempts to fix those issues.

Before:

https://github.com/user-attachments/assets/090825e0-337a-4029-80b2-d3a0d14bd5f1

After:

https://github.com/user-attachments/assets/414fdff9-95e9-4968-a354-d7294533e689

