### PR TITLE
fix: Constrain torch unavailable example icon

### DIFF
--- a/example/lib/scanner_button_widgets.dart
+++ b/example/lib/scanner_button_widgets.dart
@@ -167,14 +167,12 @@ class ToggleFlashlightButton extends StatelessWidget {
               },
             );
           case TorchState.unavailable:
-            return const SizedBox(
-              width: 48.0,
-              child: Center(
-                child: Icon(
-                  Icons.no_flash,
-                  size: 32.0,
-                  color: Colors.grey,
-                ),
+            return const SizedBox.square(
+              dimension: 48.0,
+              child: Icon(
+                Icons.no_flash,
+                size: 32.0,
+                color: Colors.grey,
               ),
             );
         }


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/juliansteenbakker/mobile_scanner/pull/1186, which caused the icon to center vertically unconstrained.

I also removed the `Center` widget, because it does not appear to have any effect inside a `SizedBox`.  But I'm happy to re-add if it's necessary.