### PR TITLE
feat: add macos privacy manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [MacOS] Added the corners and size information to barcode results.
 * [MacOS] Added support for `analyzeImage`.
+* [MacOS] Added a Privacy Manifest.
 * [web] Added the size information to barcode results.
 * Added support for barcode formats to image analysis.
 

--- a/macos/mobile_scanner.podspec
+++ b/macos/mobile_scanner.podspec
@@ -18,4 +18,5 @@ An universal scanner for Flutter based on MLKit.
   s.platform = :osx, '10.14'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
+  s.resource_bundles = {'mobile_scanner_macos_privacy' => ['mobile_scanner/Sources/mobile_scanner/Resources/PrivacyInfo.xcprivacy']}
 end

--- a/macos/mobile_scanner/Package.swift
+++ b/macos/mobile_scanner/Package.swift
@@ -17,8 +17,7 @@ let package = Package(
             name: "mobile_scanner",
             dependencies: [],
             resources: [
-                // To add other resources, see the instructions at
-                // https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package
+                .process("Resources"),
             ]
         )
     ]

--- a/macos/mobile_scanner/Sources/mobile_scanner/Resources/PrivacyInfo.xcprivacy
+++ b/macos/mobile_scanner/Sources/mobile_scanner/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- The key NSPrivacyAccessedAPITypes is not required for MacOS -->
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds the privacy manifest for MacOS. Built the example app to verify that the privacy manifest is included in the archive.

Fixes #1178 