### PR TITLE
feat: read inverted datamatrix (improve #1071)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,6 +80,9 @@ dependencies {
     implementation 'androidx.camera:camera-lifecycle:1.3.3'
     implementation 'androidx.camera:camera-camera2:1.3.3'
 
+    // opencv
+    implementation 'com.quickbirdstudios:opencv:3.4.15'
+
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.mockito:mockito-core:5.12.0'    
 }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -497,13 +497,29 @@ class MobileScanner(
     /**
      * Invert the input image.
      */
-    fun invertInputImage(image: InputImage): InputImage {
-        val bitmap = ImageConvertUtils.getInstance().getUpRightBitmap(image);
-        val tmp = Mat(bitmap.getWidth(), bitmap.getHeight(), CvType.CV_8UC1);
-        Utils.bitmapToMat(bitmap, tmp);
-        Core.bitwise_not(tmp, tmp);
-        Utils.matToBitmap(tmp, bitmap);
-        val newImage = InputImage.fromBitmap(bitmap, 0);
-        return newImage
+    private fun invertInputImage(image: InputImage): InputImage {
+        val bitmap = ImageConvertUtils.getInstance().getUpRightBitmap(image)
+
+        val mat = Mat()
+        Utils.bitmapToMat(bitmap, mat)
+
+        val channels = ArrayList<Mat>(4)
+        Core.split(mat, channels)
+
+        // Invert only RGB channels
+        for (i in 0..2) {
+            Core.bitwise_not(channels[i], channels[i])
+        }
+
+        // Merge channels back
+        Core.merge(channels, mat)
+
+        Utils.matToBitmap(mat, bitmap)
+        mat.release()
+        for (channel in channels) {
+            channel.release()
+        }
+
+        return InputImage.fromBitmap(bitmap, 0)
     }
 }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -36,7 +36,12 @@ import dev.steenbakker.mobile_scanner.utils.YuvToRgbConverter
 import io.flutter.view.TextureRegistry
 import java.io.ByteArrayOutputStream
 import kotlin.math.roundToInt
-
+import com.google.mlkit.vision.common.internal.ImageConvertUtils
+import org.opencv.core.Mat
+import org.opencv.core.CvType
+import org.opencv.core.Core
+import org.opencv.android.Utils
+import org.opencv.android.OpenCVLoader
 
 class MobileScanner(
     private val activity: Activity,
@@ -57,6 +62,8 @@ class MobileScanner(
 
     /// Configurable variables
     var scanWindow: List<Float>? = null
+    var intervalInvertImage: Boolean = false
+    var invertImage: Boolean = false
     private var detectionSpeed: DetectionSpeed = DetectionSpeed.NO_DUPLICATES
     private var detectionTimeout: Long = 250
     private var returnImage = false
@@ -67,7 +74,16 @@ class MobileScanner(
     @ExperimentalGetImage
     val captureOutput = ImageAnalysis.Analyzer { imageProxy -> // YUV_420_888 format
         val mediaImage = imageProxy.image ?: return@Analyzer
-        val inputImage = InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees)
+        var inputImage = InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees)
+
+        // Invert
+        if (intervalInvertImage) {
+            invertImage = !invertImage
+        }
+
+        if (invertImage) {
+            inputImage = invertInputImage(inputImage)
+        }
 
         if (detectionSpeed == DetectionSpeed.NORMAL && scannerTimeout) {
             imageProxy.close()
@@ -218,6 +234,7 @@ class MobileScanner(
     fun start(
         barcodeScannerOptions: BarcodeScannerOptions?,
         returnImage: Boolean,
+        intervalInvertImage: Boolean,
         cameraPosition: CameraSelector,
         torch: Boolean,
         detectionSpeed: DetectionSpeed,
@@ -229,9 +246,13 @@ class MobileScanner(
         cameraResolution: Size?,
         newCameraResolutionSelector: Boolean
     ) {
+
+        OpenCVLoader.initDebug()
+            
         this.detectionSpeed = detectionSpeed
         this.detectionTimeout = detectionTimeout
         this.returnImage = returnImage
+        this.intervalInvertImage = intervalInvertImage
 
         if (camera?.cameraInfo != null && preview != null && textureEntry != null) {
             mobileScannerErrorCallback(AlreadyStarted())
@@ -473,5 +494,16 @@ class MobileScanner(
         if (camera == null) throw ZoomWhenStopped()
         camera?.cameraControl?.setZoomRatio(1f)
     }
-
+    /**
+     * Invert the input image.
+     */
+    fun invertInputImage(image: InputImage): InputImage {
+        val bitmap = ImageConvertUtils.getInstance().getUpRightBitmap(image);
+        val tmp = Mat(bitmap.getWidth(), bitmap.getHeight(), CvType.CV_8UC1);
+        Utils.bitmapToMat(bitmap, tmp);
+        Core.bitwise_not(tmp, tmp);
+        Utils.matToBitmap(tmp, bitmap);
+        val newImage = InputImage.fromBitmap(bitmap, 0);
+        return newImage
+    }
 }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -128,6 +128,7 @@ class MobileScannerHandler(
             "setScale" -> setScale(call, result)
             "resetScale" -> resetScale(result)
             "updateScanWindow" -> updateScanWindow(call, result)
+            "setIntervalInvertImage" -> setIntervalInvertImage(call, result)
             else -> result.notImplemented()
         }
     }
@@ -138,6 +139,7 @@ class MobileScannerHandler(
         val facing: Int = call.argument<Int>("facing") ?: 0
         val formats: List<Int>? = call.argument<List<Int>>("formats")
         val returnImage: Boolean = call.argument<Boolean>("returnImage") ?: false
+        val intervalInvertImage: Boolean = call.argument<Boolean>("intervalInvertImage") ?: false
         val speed: Int = call.argument<Int>("speed") ?: 1
         val timeout: Int = call.argument<Int>("timeout") ?: 250
         val cameraResolutionValues: List<Int>? = call.argument<List<Int>>("cameraResolution")
@@ -174,6 +176,7 @@ class MobileScannerHandler(
         mobileScanner!!.start(
             barcodeScannerOptions,
             returnImage,
+            intervalInvertImage,
             position,
             torch,
             detectionSpeed,
@@ -273,6 +276,15 @@ class MobileScannerHandler(
     private fun updateScanWindow(call: MethodCall, result: MethodChannel.Result) {
         mobileScanner?.scanWindow = call.argument<List<Float>?>("rect")
 
+        result.success(null)
+    }
+
+    private fun setIntervalInvertImage(call: MethodCall, result: MethodChannel.Result) {
+        val intervalInvertImage = call.argument<Boolean?>("intervalInvertImage")
+        
+        if (intervalInvertImage != null)
+            mobileScanner?.intervalInvertImage = intervalInvertImage
+        
         result.success(null)
     }
 }

--- a/ios/Classes/MobileScannerPlugin.swift
+++ b/ios/Classes/MobileScannerPlugin.swift
@@ -84,6 +84,8 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
             toggleTorch(result)
         case "analyzeImage":
             analyzeImage(call, result)
+        case "setIntervalInvertImage":
+            setIntervalInvertImage(call, result)
         case "setScale":
             setScale(call, result)
         case "resetScale":
@@ -101,6 +103,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         let facing: Int = (call.arguments as! Dictionary<String, Any?>)["facing"] as? Int ?? 1
         let formats: Array<Int> = (call.arguments as! Dictionary<String, Any?>)["formats"] as? Array ?? []
         let returnImage: Bool = (call.arguments as! Dictionary<String, Any?>)["returnImage"] as? Bool ?? false
+        let intervalInvertImage: Bool = (call.arguments as! Dictionary<String, Any?>)["intervalInvertImage"] as? Bool ?? false
         let speed: Int = (call.arguments as! Dictionary<String, Any?>)["speed"] as? Int ?? 0
         let timeoutMs: Int = (call.arguments as! Dictionary<String, Any?>)["timeout"] as? Int ?? 0
         self.mobileScanner.timeoutSeconds = Double(timeoutMs) / Double(1000)
@@ -120,7 +123,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         let detectionSpeed: DetectionSpeed = DetectionSpeed(rawValue: speed)!
 
         do {
-            try mobileScanner.start(barcodeScannerOptions: barcodeOptions, returnImage: returnImage, cameraPosition: position, torch: torch, detectionSpeed: detectionSpeed) { parameters in
+            try mobileScanner.start(barcodeScannerOptions: barcodeOptions, returnImage: returnImage, intervalInvertImage: intervalInvertImage, cameraPosition: position, torch: torch, detectionSpeed: detectionSpeed) { parameters in
                 DispatchQueue.main.async {
                     result([
                         "textureId": parameters.textureId,
@@ -162,6 +165,20 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
         result(nil)
     }
     
+    
+    /// Sets interval inverting
+    private func setIntervalInvertImage(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        let intervalInvertImage = call.arguments as? Bool
+        if (intervalInvertImage == nil) {
+            result(FlutterError(code: "MobileScanner",
+                                message: "You must provide a invert (bool) when calling setIntervalInvertImage",
+                                details: nil))
+            return
+        }
+        mobileScanner.setIntervalInvertImage(invert!)
+        result(nil)
+    }
+
     /// Sets the zoomScale.
     private func setScale(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let scale = call.arguments as? CGFloat

--- a/ios/Classes/MobileScannerPlugin.swift
+++ b/ios/Classes/MobileScannerPlugin.swift
@@ -175,7 +175,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin {
                                 details: nil))
             return
         }
-        mobileScanner.setIntervalInvertImage(invert!)
+        mobileScanner.setIntervalInvertImage(intervalInvertImage!)
         result(nil)
     }
 

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -296,6 +296,14 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
   }
 
   @override
+  Future<void> setIntervalInvertImage(bool intervalInvertImage) async {
+    await methodChannel.invokeMethod<void>(
+      'setIntervalInvertImage',
+      {'intervalInvertImage': intervalInvertImage},
+    );
+  }
+
+  @override
   Future<void> dispose() async {
     await stop();
   }

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -25,6 +25,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
     this.formats = const <BarcodeFormat>[],
     this.returnImage = false,
     this.torchEnabled = false,
+    this.intervalInvertImage = false,
     this.useNewCameraSelector = false,
   })  : detectionTimeoutMs =
             detectionSpeed == DetectionSpeed.normal ? detectionTimeoutMs : 0,
@@ -87,6 +88,13 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   ///
   /// Defaults to false.
   final bool torchEnabled;
+
+  /// Whether the image should be inverted on a 1 to 1 interval.
+  /// So images are normal - inverted - normal - inverted
+  /// and we can read both kind of images.
+  ///
+  /// Defaults to false.
+  final bool intervalInvertImage;
 
   /// Use the new resolution selector.
   ///
@@ -268,6 +276,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
       formats: formats,
       returnImage: returnImage,
       torchEnabled: torchEnabled,
+      intervalInvertImage: intervalInvertImage,
     );
 
     try {

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -90,7 +90,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   final bool torchEnabled;
 
   /// Whether the image should be inverted on a 1 to 1 interval.
-  /// So images are normal - inverted - normal - inverted
+  /// So images are normal - inverted - normal - inverted...
   /// and we can read both kind of images.
   ///
   /// Defaults to false.

--- a/lib/src/mobile_scanner_platform_interface.dart
+++ b/lib/src/mobile_scanner_platform_interface.dart
@@ -104,6 +104,11 @@ abstract class MobileScannerPlatform extends PlatformInterface {
     throw UnimplementedError('updateScanWindow() has not been implemented.');
   }
 
+  /// Set inverting image colors (for negative Data Matrixes) on intervals.
+  Future<void> setIntervalInvertImage(bool intervalInvertImage) {
+    throw UnimplementedError('setIntervalInvertImage() has not been implemented.');
+  }
+
   /// Dispose of this [MobileScannerPlatform] instance.
   Future<void> dispose() {
     throw UnimplementedError('dispose() has not been implemented.');

--- a/lib/src/objects/start_options.dart
+++ b/lib/src/objects/start_options.dart
@@ -14,6 +14,7 @@ class StartOptions {
     required this.formats,
     required this.returnImage,
     required this.torchEnabled,
+    required this.intervalInvertImage,
   });
 
   /// The direction for the camera.
@@ -37,6 +38,9 @@ class StartOptions {
   /// Whether the torch should be turned on when the scanner starts.
   final bool torchEnabled;
 
+  /// Whether the image should be inverted on intervals.
+  final bool intervalInvertImage;
+
   Map<String, Object?> toMap() {
     return <String, Object?>{
       if (cameraResolution != null)
@@ -51,6 +55,7 @@ class StartOptions {
       'speed': detectionSpeed.rawValue,
       'timeout': detectionTimeoutMs,
       'torch': torchEnabled,
+      'intervalInvertImage': intervalInvertImage,
     };
   }
 }


### PR DESCRIPTION
Quoting petri-lipponen-movesense:
> Here's a quick stab at adding support for reading inverted data matrixes that the MLKit does not support. The iOS implementation is a bit clumsy (I'm not an iOS coder), but Android one is quite straight forward. Tested and works in Android & iOS. Feel free to modify, include or leave be as you will.
> 
> Future idea: add "tryInverted" which duplicates each frame and tries normal and inverted both.

And based on a old solution I had to do for an old client, sometimes codes could come either normal or inverted, so we had to scan both situations.

In my PR, which is almost [exact as petri-lipponen-movesense's](https://github.com/juliansteenbakker/mobile_scanner/pull/1071), I just modify the bool to add to invert the image into intervals.
This means that every image in the stream will change from inverted to normal.
In this case, we could either scan any of these two codes:

<img width="534" alt="image" src="https://github.com/user-attachments/assets/03f27e17-a09a-45f5-b900-1900b8527fdd">
