### PR TITLE
fix: scanner overlay example

### DIFF
--- a/example/lib/barcode_scanner_window.dart
+++ b/example/lib/barcode_scanner_window.dart
@@ -131,15 +131,15 @@ class ScannerOverlay extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    // TODO: use `Offset.zero & size` instead of Rect.largest
     // we need to pass the size to the custom paint widget
-    final backgroundPath = Path()..addRect(Rect.largest);
+    final backgroundPath = Path()
+      ..addRect(Rect.fromLTWH(0, 0, size.width, size.height));
     final cutoutPath = Path()..addRect(scanWindow);
 
     final backgroundPaint = Paint()
       ..color = Colors.black.withOpacity(0.5)
       ..style = PaintingStyle.fill
-      ..blendMode = BlendMode.dstOut;
+      ..blendMode = BlendMode.dstOver;
 
     final backgroundWithCutout = Path.combine(
       PathOperation.difference,

--- a/example/lib/mobile_scanner_overlay.dart
+++ b/example/lib/mobile_scanner_overlay.dart
@@ -102,9 +102,9 @@ class ScannerOverlay extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    // TODO: use `Offset.zero & size` instead of Rect.largest
     // we need to pass the size to the custom paint widget
-    final backgroundPath = Path()..addRect(Rect.largest);
+    final backgroundPath = Path()
+      ..addRect(Rect.fromLTWH(0, 0, size.width, size.height));
 
     final cutoutPath = Path()
       ..addRRect(
@@ -120,7 +120,7 @@ class ScannerOverlay extends CustomPainter {
     final backgroundPaint = Paint()
       ..color = Colors.black.withOpacity(0.5)
       ..style = PaintingStyle.fill
-      ..blendMode = BlendMode.dstOut;
+      ..blendMode = BlendMode.dstOver;
 
     final backgroundWithCutout = Path.combine(
       PathOperation.difference,


### PR DESCRIPTION
Fixes https://github.com/juliansteenbakker/mobile_scanner/issues/1185

I also updated the other usage of Rect.largest in `BarcodeScannerWithScanWindow`, even though it wasn't visually broken previously.  I figured it was better to keep them consistent, though.

|Before | After|
|------|-------|
| <img width="245" alt="image" src="https://github.com/user-attachments/assets/87ae7886-96c3-45b6-8cb5-44e5a9fc9268">  |   <img width="240" alt="image" src="https://github.com/user-attachments/assets/af0d61bf-6857-4d6f-867a-e2429c9e9d1b">   |
|  <img width="231" alt="image" src="https://github.com/user-attachments/assets/eeb1a65e-bcab-4201-8d89-031f99a1a48d">  | <img width="247" alt="image" src="https://github.com/user-attachments/assets/0eb6b1fd-c849-43e9-89bf-69b4b74763a7"> |