### PR TITLE
fix: report analyze image as unsupported on iOS Simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Bugs fixed:
 * [Apple] Fixed a bug that caused the corner points to not be returned in clockwise orientation.
 * [Apple] Fixed an issue where `analyzeImage` would not throw an error if no valid image is provided as argument.
 * [Apple] Fixed an issue where `analyzeImage` would not return if no barcodes are found in the image.
+* [Apple] Fixed an issue where the iOS Simulator did not report that analyzing images from a file is unsupported. 
 * [Android] Fixed an issue where `analyzeImage` would not return if no valid image is provided as argument.
 
 Improvements:

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/objects/MobileScannerErrorCodes.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/objects/MobileScannerErrorCodes.kt
@@ -22,5 +22,6 @@ class MobileScannerErrorCodes {
         const val NO_CAMERA_ERROR_MESSAGE = "No cameras available."
         const val SET_SCALE_WHEN_STOPPED_ERROR = "MOBILE_SCANNER_SET_SCALE_WHEN_STOPPED_ERROR"
         const val SET_SCALE_WHEN_STOPPED_ERROR_MESSAGE = "The zoom scale cannot be changed when the camera is stopped."
+        const val UNSUPPORTED_OPERATION_ERROR = "MOBILE_SCANNER_UNSUPPORTED_OPERATION" // Reserved for future use.
     }
 }

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerErrorCodes.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerErrorCodes.swift
@@ -10,6 +10,7 @@ import Foundation
 struct MobileScannerErrorCodes {
     static let ALREADY_STARTED_ERROR = "MOBILE_SCANNER_ALREADY_STARTED_ERROR"
     static let ALREADY_STARTED_ERROR_MESSAGE = "The scanner was already started."
+    static let ANALYZE_IMAGE_IOS_SIMULATOR_NOT_SUPPORTED_ERROR_MESSAGE = "Analyzing an image from a file is not supported on the iOS Simulator.";
     static let ANALYZE_IMAGE_NO_VALID_IMAGE_ERROR_MESSAGE = "The provided file is not an image."
     // The error code 'BARCODE_ERROR' does not have an error message,
     // because it uses the error message from the undelying error.
@@ -25,4 +26,5 @@ struct MobileScannerErrorCodes {
     static let NO_CAMERA_ERROR_MESSAGE = "No cameras available."
     static let SET_SCALE_WHEN_STOPPED_ERROR = "MOBILE_SCANNER_SET_SCALE_WHEN_STOPPED_ERROR"
     static let SET_SCALE_WHEN_STOPPED_ERROR_MESSAGE = "The zoom scale cannot be changed when the camera is stopped."
+    static let UNSUPPORTED_OPERATION_ERROR = "MOBILE_SCANNER_UNSUPPORTED_OPERATION"
 }

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -48,17 +48,17 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
     var standardZoomFactor: CGFloat = 1
     
     public static func register(with registrar: FlutterPluginRegistrar) {
-        #if os(iOS)
+#if os(iOS)
         let textures = registrar.textures()
-        #else
+#else
         let textures = registrar.textures
-        #endif
+#endif
         
-        #if os(iOS)
+#if os(iOS)
         let messenger = registrar.messenger()
-        #else
+#else
         let messenger = registrar.messenger
-        #endif
+#endif
         
         let instance = MobileScannerPlugin(textures)
         let method = FlutterMethodChannel(name:
@@ -332,7 +332,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         
         // Check the zoom factor at switching from ultra wide camera to wide camera.
         standardZoomFactor = 1
-        #if os(iOS)
+#if os(iOS)
         if #available(iOS 13.0, *) {
             for (index, actualDevice) in device.constituentDevices.enumerated() {
                 if (actualDevice.deviceType != .builtInUltraWideCamera) {
@@ -343,7 +343,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                 }
             }
         }
-        #endif
+#endif
         
         // Add device input
         do {
@@ -512,7 +512,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         }
         
         do {
-            #if os(iOS)
+#if os(iOS)
                 try device.lockForConfiguration()
                 let maxZoomFactor = device.activeFormat.videoMaxZoomFactor
                 
@@ -528,7 +528,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                 device.videoZoomFactor = actualScale
 
                 device.unlockForConfiguration()
-            #endif
+#endif
         } catch {
             throw MobileScannerError.zoomError(error)
         }
@@ -542,11 +542,11 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         }
 
         do {
-            #if os(iOS)
+#if os(iOS)
                 try device.lockForConfiguration()
                 device.videoZoomFactor = standardZoomFactor
                 device.unlockForConfiguration()
-            #endif
+#endif
         } catch {
             throw MobileScannerError.zoomError(error)
         }

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -632,6 +632,8 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
     func analyzeImage(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         // The iOS Simulator cannot use some of the GPU features that are required for the Vision API.
         // Thus analyzing images is not supported on the iOS Simulator.
+        //
+        // See https://forums.developer.apple.com/forums/thread/696714
 #if os(iOS) && targetEnvironment(simulator)
         result(FlutterError(
             code: MobileScannerErrorCodes.UNSUPPORTED_OPERATION_ERROR,

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -630,6 +630,17 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
     }
     
     func analyzeImage(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        // The iOS Simulator cannot use some of the GPU features that are required for the Vision API.
+        // Thus analyzing images is not supported on the iOS Simulator.
+#if os(iOS) && targetEnvironment(simulator)
+        result(FlutterError(
+            code: MobileScannerErrorCodes.UNSUPPORTED_OPERATION_ERROR,
+            message: MobileScannerErrorCodes.ANALYZE_IMAGE_IOS_SIMULATOR_NOT_SUPPORTED_ERROR_MESSAGE,
+            details: nil
+        ))
+        return
+#endif
+        
         let argReader = MapArgumentReader(call.arguments as? [String: Any])
         let symbologies:[VNBarcodeSymbology] = argReader.toSymbology()
         

--- a/lib/src/enums/mobile_scanner_error_code.dart
+++ b/lib/src/enums/mobile_scanner_error_code.dart
@@ -43,6 +43,8 @@ enum MobileScannerErrorCode {
       'MOBILE_SCANNER_NO_CAMERA_ERROR' => MobileScannerErrorCode.unsupported,
       'MOBILE_SCANNER_CAMERA_PERMISSION_DENIED' =>
         MobileScannerErrorCode.permissionDenied,
+      'MOBILE_SCANNER_UNSUPPORTED_OPERATION' =>
+        MobileScannerErrorCode.unsupported,
       _ => MobileScannerErrorCode.genericError,
     };
   }

--- a/lib/src/enums/mobile_scanner_error_code.dart
+++ b/lib/src/enums/mobile_scanner_error_code.dart
@@ -43,8 +43,6 @@ enum MobileScannerErrorCode {
       'MOBILE_SCANNER_NO_CAMERA_ERROR' => MobileScannerErrorCode.unsupported,
       'MOBILE_SCANNER_CAMERA_PERMISSION_DENIED' =>
         MobileScannerErrorCode.permissionDenied,
-      'MOBILE_SCANNER_UNSUPPORTED_OPERATION' =>
-        MobileScannerErrorCode.unsupported,
       _ => MobileScannerErrorCode.genericError,
     };
   }

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -24,6 +24,11 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
   @visibleForTesting
   static const String kBarcodeErrorEventName = 'MOBILE_SCANNER_BARCODE_ERROR';
 
+  /// The name of the error event that is sent when an operation is not supported.
+  @visibleForTesting
+  static const String kUnsupportdOperationErrorEventName =
+      'MOBILE_SCANNER_UNSUPPORTED_OPERATION';
+
   /// The method channel used to interact with the native platform.
   @visibleForTesting
   final methodChannel = const MethodChannel(
@@ -190,6 +195,15 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
       // Handle any errors from analyze image requests.
       if (error.code == kBarcodeErrorEventName) {
         throw MobileScannerBarcodeException(error.message);
+      }
+
+      if (error.code == kUnsupportdOperationErrorEventName) {
+        throw MobileScannerException(
+          errorCode: MobileScannerErrorCode.fromPlatformException(error),
+          errorDetails: MobileScannerErrorDetails(
+            message: error.message,
+          ),
+        );
       }
 
       return null;

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -198,12 +198,7 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
       }
 
       if (error.code == kUnsupportdOperationErrorEventName) {
-        throw MobileScannerException(
-          errorCode: MobileScannerErrorCode.fromPlatformException(error),
-          errorDetails: MobileScannerErrorDetails(
-            message: error.message,
-          ),
-        );
+        throw UnsupportedError(error.message ?? 'Unsupported operation.');
       }
 
       return null;

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -182,12 +182,16 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   /// The [formats] specify the barcode formats that should be detected in the image.
   /// If the [formats] are omitted or empty, all formats are detected.
   ///
-  /// This is only supported on Android, iOS and MacOS.
+  /// This is only supported on Android, physical iOS devices and MacOS.
+  /// This is not supported on the iOS Simulator, due to restrictions on the Simulator.
   ///
   /// Returns the [BarcodeCapture] that was found in the image.
   ///
   /// If an error occurred during the analysis of the image,
   /// a [MobileScannerBarcodeException] error is thrown.
+  ///
+  /// If analyzing images from a file is not supported,
+  /// a [MobileScannerException] is thrown, with [MobileScannerErrorCode.unsupported] as error code.
   Future<BarcodeCapture?> analyzeImage(
     String path, {
     List<BarcodeFormat> formats = const <BarcodeFormat>[],

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -190,8 +190,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   /// If an error occurred during the analysis of the image,
   /// a [MobileScannerBarcodeException] error is thrown.
   ///
-  /// If analyzing images from a file is not supported,
-  /// a [MobileScannerException] is thrown, with [MobileScannerErrorCode.unsupported] as error code.
+  /// If analyzing images from a file is not supported, an [UnsupportedError] is thrown.
   Future<BarcodeCapture?> analyzeImage(
     String path, {
     List<BarcodeFormat> formats = const <BarcodeFormat>[],


### PR DESCRIPTION
It seems that the iOS Simulator does not support the neural engine features that are required to run the Vision API,
hence why it fails to create the underlying detection model.

Fixes https://github.com/juliansteenbakker/mobile_scanner/issues/1269