### PR TITLE
chore: fix typo

### DIFF
--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerErrorCodes.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerErrorCodes.swift
@@ -10,7 +10,7 @@ import Foundation
 struct MobileScannerErrorCodes {
     static let ALREADY_STARTED_ERROR = "MOBILE_SCANNER_ALREADY_STARTED_ERROR"
     static let ALREADY_STARTED_ERROR_MESSAGE = "The scanner was already started."
-    static let ANALYZE_IMAGE_IOS_SIMULATOR_NOT_SUPPORTED_ERROR_MESSAGE = "Analyzing an image from a file is not supported on the iOS Simulator.";
+    static let ANALYZE_IMAGE_IOS_SIMULATOR_NOT_SUPPORTED_ERROR_MESSAGE = "Analyzing an image from a file is not supported on the iOS Simulator."
     static let ANALYZE_IMAGE_NO_VALID_IMAGE_ERROR_MESSAGE = "The provided file is not an image."
     // The error code 'BARCODE_ERROR' does not have an error message,
     // because it uses the error message from the undelying error.


### PR DESCRIPTION
This PR fixes a dangling semicolon, that is not needed in Swift.

I missed this one in #1275 