### PR TITLE
feat: Android Impeller support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
+## NEXT
+
+* This release requires Flutter 3.27.0 or higher.
+
+Improvements:
+* [Android] Added support for Impeller.
+
 ## 7.0.0-beta.4
 
 **BREAKING CHANGES:**
-
-* This release requires Flutter 3.27.0 or higher.
 
 * The `updateScanWindow` method is now private. Instead, update the scan window in the `MobileScanner` widget directly.
 * The deprecated `EncryptionType.none` constant has been removed. Use `EncryptionType.unknown` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 **BREAKING CHANGES:**
 
+* This release requires Flutter 3.27.0 or higher.
+
 * The `updateScanWindow` method is now private. Instead, update the scan window in the `MobileScanner` widget directly.
 * The deprecated `EncryptionType.none` constant has been removed. Use `EncryptionType.unknown` instead.
 * The `errorBuilder` and `placeholderBuilder` of the `MobileScanner` widget no longer take a Widget argument, as it was unused.

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/BarcodeHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/BarcodeHandler.kt
@@ -30,6 +30,10 @@ class BarcodeHandler(binaryMessenger: BinaryMessenger) : EventChannel.StreamHand
         }
     }
 
+    fun dispose() {
+        eventChannel.setStreamHandler(null)
+    }
+
     override fun onListen(event: Any?, eventSink: EventChannel.EventSink?) {
         this.eventSink = eventSink
     }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/DeviceOrientationListener.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/DeviceOrientationListener.kt
@@ -1,0 +1,106 @@
+package dev.steenbakker.mobile_scanner
+
+import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.res.Configuration
+import android.os.Build
+import android.view.Display
+import android.view.Surface
+import android.view.WindowManager
+import io.flutter.embedding.engine.systemchannels.PlatformChannel
+
+/**
+ * This class will listen to device orientation changes.
+ *
+ * When a new orientation is received, the registered listener will be invoked.
+ */
+class DeviceOrientationListener(
+    private val activity: Activity,
+    val listener: (PlatformChannel.DeviceOrientation) -> Unit
+): BroadcastReceiver() {
+
+    companion object {
+        // The intent filter for listening to orientation changes.
+        private val orientationIntentFilter = IntentFilter(Intent.ACTION_CONFIGURATION_CHANGED)
+    }
+
+    // The last received orientation. This is used to prevent duplicate events.
+    private var lastOrientation: PlatformChannel.DeviceOrientation? = null
+    // Whether the device orientation is currently being observed.
+    private var listening = false
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        val orientation: PlatformChannel.DeviceOrientation = getUIOrientation()
+        if (orientation != lastOrientation) {
+            listener(orientation)
+        }
+
+        lastOrientation = orientation
+    }
+
+    @Suppress("deprecation")
+    private fun getDisplay(): Display {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activity.display!!
+        } else {
+            (activity.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
+        }
+    }
+
+    /**
+     * Gets the current user interface orientation.
+     */
+    fun getUIOrientation(): PlatformChannel.DeviceOrientation {
+        val rotation: Int = getDisplay().rotation
+        val orientation: Int = activity.resources.configuration.orientation
+
+        return when(orientation) {
+            Configuration.ORIENTATION_PORTRAIT -> {
+                if (rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_90) {
+                    PlatformChannel.DeviceOrientation.PORTRAIT_UP
+                } else {
+                    PlatformChannel.DeviceOrientation.PORTRAIT_DOWN
+                }
+            }
+            Configuration.ORIENTATION_LANDSCAPE -> {
+                if (rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_90) {
+                    PlatformChannel.DeviceOrientation.LANDSCAPE_LEFT
+                } else {
+                    PlatformChannel.DeviceOrientation.LANDSCAPE_RIGHT
+                }
+            }
+            Configuration.ORIENTATION_UNDEFINED -> PlatformChannel.DeviceOrientation.PORTRAIT_UP
+            else -> PlatformChannel.DeviceOrientation.PORTRAIT_UP
+        }
+    }
+
+    /**
+     * Start listening to device orientation changes.
+     */
+    fun start() {
+        if (listening) {
+            return
+        }
+
+        listening = true
+        activity.registerReceiver(this, orientationIntentFilter)
+
+        // Trigger the orientation listener with the current value.
+        onReceive(activity, null)
+    }
+
+    /**
+     * Stop listening to device orientation changes.
+     */
+    fun stop() {
+        if (!listening) {
+            return
+        }
+
+        activity.unregisterReceiver(this)
+        listening = false
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -46,8 +46,8 @@ class MobileScanner(
     private val textureRegistry: TextureRegistry,
     private val mobileScannerCallback: MobileScannerCallback,
     private val mobileScannerErrorCallback: MobileScannerErrorCallback,
-    private val barcodeScannerFactory: (options: BarcodeScannerOptions?) -> BarcodeScanner = ::defaultBarcodeScannerFactory,
     private val deviceOrientationListener: DeviceOrientationListener,
+    private val barcodeScannerFactory: (options: BarcodeScannerOptions?) -> BarcodeScanner = ::defaultBarcodeScannerFactory,
 ) {
 
     /// Internal variables

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -299,13 +299,16 @@ class MobileScanner(
 //            if (isPaused) {
 //                resumeCamera()
 //                mobileScannerStartedCallback(
-//                    MobileScannerStartParameters(
-//                        if (portrait) width else height,
-//                        if (portrait) height else width,
-//                        currentTorchState,
-//                        surfaceProducer!!.id(),
-//                        numberOfCameras ?: 0
-//                    )
+//                  MobileScannerStartParameters(
+//                    if (portrait) width else height,
+//                    if (portrait) height else width,
+//                    deviceOrientationListener.getUIOrientation().serialize(),
+//                    sensorRotationDegrees,
+//                    surfaceProducer!!.handlesCropAndRotation(),
+//                    currentTorchState,
+//                    surfaceProducer!!.id(),
+//                    numberOfCameras ?: 0
+//                  )
 //                )
 //                return
 //            }
@@ -415,7 +418,8 @@ class MobileScanner(
             val resolution = analysis.resolutionInfo!!.resolution
             val width = resolution.width.toDouble()
             val height = resolution.height.toDouble()
-            val portrait = (camera?.cameraInfo?.sensorRotationDegrees ?: 0) % 180 == 0
+            val sensorRotationDegrees = camera?.cameraInfo?.sensorRotationDegrees ?: 0
+            val portrait = sensorRotationDegrees % 180 == 0
 
             // Start with 'unavailable' torch state.
             var currentTorchState: Int = -1
@@ -434,6 +438,9 @@ class MobileScanner(
                 MobileScannerStartParameters(
                     if (portrait) width else height,
                     if (portrait) height else width,
+                    deviceOrientationListener.getUIOrientation().serialize(),
+                    sensorRotationDegrees,
+                    surfaceProducer!!.handlesCropAndRotation(),
                     currentTorchState,
                     surfaceProducer!!.id(),
                     numberOfCameras ?: 0

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -34,6 +34,7 @@ import dev.steenbakker.mobile_scanner.objects.DetectionSpeed
 import dev.steenbakker.mobile_scanner.objects.MobileScannerErrorCodes
 import dev.steenbakker.mobile_scanner.objects.MobileScannerStartParameters
 import dev.steenbakker.mobile_scanner.utils.YuvToRgbConverter
+import dev.steenbakker.mobile_scanner.utils.serialize
 import io.flutter.view.TextureRegistry
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -46,6 +47,7 @@ class MobileScanner(
     private val mobileScannerCallback: MobileScannerCallback,
     private val mobileScannerErrorCallback: MobileScannerErrorCallback,
     private val barcodeScannerFactory: (options: BarcodeScannerOptions?) -> BarcodeScanner = ::defaultBarcodeScannerFactory,
+    private val deviceOrientationListener: DeviceOrientationListener,
 ) {
 
     /// Internal variables
@@ -426,6 +428,8 @@ class MobileScanner(
                 currentTorchState = it.torchState.value ?: -1
             }
 
+            deviceOrientationListener.start()
+
             mobileScannerStartedCallback(
                 MobileScannerStartParameters(
                     if (portrait) width else height,
@@ -449,6 +453,7 @@ class MobileScanner(
             throw AlreadyStopped()
         }
 
+        deviceOrientationListener.stop()
         pauseCamera()
     }
 
@@ -460,6 +465,7 @@ class MobileScanner(
             throw AlreadyStopped()
         }
 
+        deviceOrientationListener.stop()
         releaseCamera()
     }
 

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -168,6 +168,9 @@ class MobileScannerHandler(
                     result.success(mapOf(
                         "textureId" to it.id,
                         "size" to mapOf("width" to it.width, "height" to it.height),
+                        "naturalDeviceOrientation" to it.naturalDeviceOrientation,
+                        "isPreviewPreTransformed" to it.isPreviewPreTransformed,
+                        "sensorOrientation" to it.sensorOrientation,
                         "currentTorchState" to it.currentTorchState,
                         "numberOfCameras" to it.numberOfCameras
                     ))

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -16,6 +16,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.plugin.common.EventChannel
 import io.flutter.view.TextureRegistry
 import java.io.File
 
@@ -65,6 +66,7 @@ class MobileScannerHandler(
     }
 
     private var methodChannel: MethodChannel? = null
+    private var deviceOrientationChannel: EventChannel? = null
 
     private var mobileScanner: MobileScanner? = null
 
@@ -81,12 +83,20 @@ class MobileScannerHandler(
         methodChannel = MethodChannel(binaryMessenger,
             "dev.steenbakker.mobile_scanner/scanner/method")
         methodChannel!!.setMethodCallHandler(this)
-        mobileScanner = MobileScanner(activity, textureRegistry, callback, errorCallback)
+
+        deviceOrientationChannel = EventChannel(binaryMessenger,
+            "dev.steenbakker.mobile_scanner/scanner/deviceOrientation")
+        deviceOrientationChannel!!.setStreamHandler(deviceOrientationListener)
+
+        mobileScanner = MobileScanner(
+            activity, textureRegistry, callback, errorCallback, deviceOrientationListener)
     }
 
     fun dispose(activityPluginBinding: ActivityPluginBinding) {
         methodChannel?.setMethodCallHandler(null)
         methodChannel = null
+        deviceOrientationChannel?.setStreamHandler(null)
+        deviceOrientationChannel = null
         barcodeHandler.dispose()
         mobileScanner?.dispose()
         mobileScanner = null

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -84,6 +84,8 @@ class MobileScannerHandler(
             "dev.steenbakker.mobile_scanner/scanner/method")
         methodChannel!!.setMethodCallHandler(this)
 
+        val deviceOrientationListener = DeviceOrientationListener(activity)
+
         deviceOrientationChannel = EventChannel(binaryMessenger,
             "dev.steenbakker.mobile_scanner/scanner/deviceOrientation")
         deviceOrientationChannel!!.setStreamHandler(deviceOrientationListener)

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -87,6 +87,7 @@ class MobileScannerHandler(
     fun dispose(activityPluginBinding: ActivityPluginBinding) {
         methodChannel?.setMethodCallHandler(null)
         methodChannel = null
+        barcodeHandler.dispose()
         mobileScanner?.dispose()
         mobileScanner = null
 

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/objects/MobileScannerStartParameters.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/objects/MobileScannerStartParameters.kt
@@ -3,6 +3,9 @@ package dev.steenbakker.mobile_scanner.objects
 class MobileScannerStartParameters(
     val width: Double = 0.0,
     val height: Double,
+    val naturalDeviceOrientation: String,
+    val sensorOrientation: Int,
+    val isPreviewPreTransformed: Boolean,
     val currentTorchState: Int,
     val id: Long,
     val numberOfCameras: Int

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/utils/DeviceOrientationExtension.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/utils/DeviceOrientationExtension.kt
@@ -1,0 +1,16 @@
+package dev.steenbakker.mobile_scanner.utils
+
+import io.flutter.embedding.engine.systemchannels.PlatformChannel
+
+/**
+ * This function serializes a device orientation to a string,
+ * for sending back over a method or event channel.
+ */
+fun PlatformChannel.DeviceOrientation.serialize(): String {
+    return when(this) {
+        PlatformChannel.DeviceOrientation.PORTRAIT_UP -> "PORTRAIT_UP"
+        PlatformChannel.DeviceOrientation.PORTRAIT_DOWN -> "PORTRAIT_DOWN"
+        PlatformChannel.DeviceOrientation.LANDSCAPE_LEFT -> "LANDSCAPE_LEFT"
+        PlatformChannel.DeviceOrientation.LANDSCAPE_RIGHT -> "LANDSCAPE_RIGHT"
+    }
+}

--- a/example/lib/barcode_scanner_controller.dart
+++ b/example/lib/barcode_scanner_controller.dart
@@ -18,7 +18,6 @@ class _BarcodeScannerWithControllerState
     extends State<BarcodeScannerWithController> with WidgetsBindingObserver {
   final MobileScannerController controller = MobileScannerController(
     autoStart: false,
-    torchEnabled: true,
   );
 
   @override

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 0.0.1
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.6.0 <4.0.0"
   flutter: ">=3.27.0"
 
 # Dependencies specify other packages that your package needs in order to work.

--- a/lib/src/method_channel/android_surface_producer_delegate.dart
+++ b/lib/src/method_channel/android_surface_producer_delegate.dart
@@ -34,30 +34,10 @@ class AndroidSurfaceProducerDelegate {
           'naturalDeviceOrientation': final String naturalDeviceOrientation,
           'sensorOrientation': final int sensorOrientation
         }) {
-      final DeviceOrientation? currentOrientation =
-          deviceOrientation.tryParseDeviceOrientation();
-      final DeviceOrientation? naturalOrientation =
-          naturalDeviceOrientation.tryParseDeviceOrientation();
-
-      if (currentOrientation == null) {
-        throw const MobileScannerException(
-          errorCode: MobileScannerErrorCode.genericError,
-          errorDetails: MobileScannerErrorDetails(
-            message:
-                'The start method did not return a valid current device orientation.',
-          ),
-        );
-      }
-
-      if (naturalOrientation == null) {
-        throw const MobileScannerException(
-          errorCode: MobileScannerErrorCode.genericError,
-          errorDetails: MobileScannerErrorDetails(
-            message:
-                'The start method did not return a valid natural device orientation.',
-          ),
-        );
-      }
+      final DeviceOrientation currentOrientation =
+          deviceOrientation.parseDeviceOrientation();
+      final DeviceOrientation naturalOrientation =
+          naturalDeviceOrientation.parseDeviceOrientation();
 
       return AndroidSurfaceProducerDelegate(
         cameraIsFrontFacing: cameraDirection == CameraFacing.front,

--- a/lib/src/method_channel/android_surface_producer_delegate.dart
+++ b/lib/src/method_channel/android_surface_producer_delegate.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// This class will manage the orientation corrections for textures
+/// that are provided by the SurfaceProducer API on Android.
+class AndroidSurfaceProducerDelegate {
+  /// Construct a new [AndroidSurfaceProducerDelegate].
+  AndroidSurfaceProducerDelegate({
+    required this.cameraIsFrontFacing,
+    required this.currentDeviceOrientation,
+    required this.isPreviewPreTransformed,
+    required this.naturalOrientation,
+    required this.sensorOrientation,
+  });
+
+  /// The rotation degrees corresponding to each device orientation.
+  static const Map<DeviceOrientation, int> _degreesForDeviceOrientation =
+      <DeviceOrientation, int>{
+    DeviceOrientation.portraitUp: 0,
+    DeviceOrientation.landscapeRight: 90,
+    DeviceOrientation.portraitDown: 180,
+    DeviceOrientation.landscapeLeft: 270,
+  };
+
+  /// The subscription that listens to device orientation changes.
+  StreamSubscription<Object?>? _deviceOrientationSubscription;
+
+  /// Whether the current camera is a front facing camera.
+  ///
+  /// This is used to determine whether the orientation correction
+  /// should apply an additional correction for front facing cameras.
+  final bool cameraIsFrontFacing;
+
+  /// The current orientation of the device.
+  ///
+  /// When the orientation changes this field is updated by notifications from
+  /// the [_deviceOrientationSubscription].
+  DeviceOrientation currentDeviceOrientation;
+
+  /// Whether the camera preview is pre-transformed,
+  /// and thus does not need an orientation correction.
+  final bool isPreviewPreTransformed;
+
+  /// The initial orientation of the device, when the camera was started.
+  ///
+  /// The camera preview will use this orientation as the natural orientation
+  /// to correct its rotation with respect to, if necessary.
+  final DeviceOrientation naturalOrientation;
+
+  /// The sensor orientation of the current camera, in degrees.
+  final int sensorOrientation;
+
+  /// Apply a rotation correction to the given [texture] widget.
+  Widget applyRotationCorrection(Widget texture) {
+    int naturalDeviceOrientationDegrees =
+        _degreesForDeviceOrientation[naturalOrientation]!;
+
+    if (isPreviewPreTransformed) {
+      // If the camera preview is backed by a SurfaceTexture, the transformation
+      // needed to correctly rotate the preview has already been applied.
+      //
+      // However, the camera preview rotation may need to be corrected if the
+      // device is naturally landscape-oriented.
+      if (naturalOrientation == DeviceOrientation.landscapeLeft ||
+          naturalOrientation == DeviceOrientation.landscapeRight) {
+        final int quarterTurns = (-naturalDeviceOrientationDegrees + 360) ~/ 4;
+
+        return RotatedBox(
+          quarterTurns: quarterTurns,
+          child: texture,
+        );
+      }
+
+      return texture;
+    }
+
+    // If the camera preview is not backed by a SurfaceTexture,
+    // the camera preview rotation needs to be manually applied,
+    // while also taking into account devices that are naturally landscape-oriented.
+    final int signForCameraDirection = cameraIsFrontFacing ? 1 : -1;
+
+    // For front-facing cameras, the preview is rotated counterclockwise,
+    // so determine the rotation needed to correct the camera preview with
+    // respect to the natural orientation of the device, based on the inverse of
+    // of the natural orientation.
+    if (signForCameraDirection == 1 &&
+        (currentDeviceOrientation == DeviceOrientation.landscapeLeft ||
+            currentDeviceOrientation == DeviceOrientation.landscapeRight)) {
+      naturalDeviceOrientationDegrees += 180;
+    }
+
+    // See https://developer.android.com/media/camera/camera2/camera-preview#orientation_calculation
+    final double rotation = (sensorOrientation +
+            naturalDeviceOrientationDegrees * signForCameraDirection +
+            360) %
+        360;
+
+    int quarterTurnsToCorrectPreview = rotation ~/ 90;
+
+    // Correct the camera preview rotation for devices that are naturally landscape-oriented.
+    if (naturalOrientation == DeviceOrientation.landscapeLeft ||
+        naturalOrientation == DeviceOrientation.landscapeRight) {
+      quarterTurnsToCorrectPreview +=
+          (-naturalDeviceOrientationDegrees + 360) ~/ 4;
+    }
+
+    return RotatedBox(
+      quarterTurns: quarterTurnsToCorrectPreview,
+      child: texture,
+    );
+  }
+
+  /// Start listening to device orientation changes,
+  /// which are provided by the given [stream].
+  void startListeningToDeviceOrientation(Stream<DeviceOrientation> stream) {
+    _deviceOrientationSubscription ??=
+        stream.listen((DeviceOrientation newOrientation) {
+      currentDeviceOrientation = newOrientation;
+    });
+  }
+
+  /// Dispose of this delegate.
+  void dispose() {
+    _deviceOrientationSubscription?.cancel();
+    _deviceOrientationSubscription = null;
+  }
+}

--- a/lib/src/method_channel/android_surface_producer_delegate.dart
+++ b/lib/src/method_channel/android_surface_producer_delegate.dart
@@ -60,6 +60,10 @@ class AndroidSurfaceProducerDelegate {
     DeviceOrientation.landscapeLeft: 270,
   };
 
+  // TODO: remove this flag once the rotation correction functions correctly on Impeller.
+  // See https://github.com/juliansteenbakker/mobile_scanner/pull/1283#discussion_r1927798329
+  static const bool _rotationCorrectionEnabled = false;
+
   /// The subscription that listens to device orientation changes.
   StreamSubscription<Object?>? _deviceOrientationSubscription;
 
@@ -90,6 +94,10 @@ class AndroidSurfaceProducerDelegate {
 
   /// Apply a rotation correction to the given [texture] widget.
   Widget applyRotationCorrection(Widget texture) {
+    if (!_rotationCorrectionEnabled) {
+      return texture;
+    }
+
     int naturalDeviceOrientationDegrees =
         _degreesForDeviceOrientation[naturalOrientation]!;
 
@@ -151,6 +159,10 @@ class AndroidSurfaceProducerDelegate {
   /// Start listening to device orientation changes,
   /// which are provided by the given [stream].
   void startListeningToDeviceOrientation(Stream<DeviceOrientation> stream) {
+    if (!_rotationCorrectionEnabled) {
+      return;
+    }
+
     _deviceOrientationSubscription ??=
         stream.listen((DeviceOrientation newOrientation) {
       currentDeviceOrientation = newOrientation;

--- a/lib/src/method_channel/android_surface_producer_delegate.dart
+++ b/lib/src/method_channel/android_surface_producer_delegate.dart
@@ -13,7 +13,6 @@ class AndroidSurfaceProducerDelegate {
   /// Construct a new [AndroidSurfaceProducerDelegate].
   AndroidSurfaceProducerDelegate({
     required this.cameraIsFrontFacing,
-    required this.currentDeviceOrientation,
     required this.isPreviewPreTransformed,
     required this.naturalOrientation,
     required this.sensorOrientation,
@@ -29,19 +28,15 @@ class AndroidSurfaceProducerDelegate {
   ) {
     if (config
         case {
-          'currentDeviceOrientation': final String deviceOrientation,
           'isPreviewPreTransformed': final bool isPreviewPreTransformed,
           'naturalDeviceOrientation': final String naturalDeviceOrientation,
           'sensorOrientation': final int sensorOrientation
         }) {
-      final DeviceOrientation currentOrientation =
-          deviceOrientation.parseDeviceOrientation();
       final DeviceOrientation naturalOrientation =
           naturalDeviceOrientation.parseDeviceOrientation();
 
       return AndroidSurfaceProducerDelegate(
         cameraIsFrontFacing: cameraDirection == CameraFacing.front,
-        currentDeviceOrientation: currentOrientation,
         isPreviewPreTransformed: isPreviewPreTransformed,
         naturalOrientation: naturalOrientation,
         sensorOrientation: sensorOrientation,
@@ -78,7 +73,7 @@ class AndroidSurfaceProducerDelegate {
   ///
   /// When the orientation changes this field is updated by notifications from
   /// the [_deviceOrientationSubscription].
-  DeviceOrientation currentDeviceOrientation;
+  DeviceOrientation? currentDeviceOrientation;
 
   /// Whether the camera preview is pre-transformed,
   /// and thus does not need an orientation correction.

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -27,7 +27,8 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
 
   /// The name of the error event that is sent when an operation is not supported.
   @visibleForTesting
-  static const String kUnsupportdOperationErrorEventName = 'MOBILE_SCANNER_UNSUPPORTED_OPERATION';
+  static const String kUnsupportdOperationErrorEventName =
+      'MOBILE_SCANNER_UNSUPPORTED_OPERATION';
 
   /// The method channel used to interact with the native platform.
   @visibleForTesting
@@ -45,7 +46,8 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
 
   /// Get the event stream of barcode events that come from the [eventChannel].
   Stream<Map<Object?, Object?>> get eventsStream {
-    _eventsStream ??= eventChannel.receiveBroadcastStream().cast<Map<Object?, Object?>>();
+    _eventsStream ??=
+        eventChannel.receiveBroadcastStream().cast<Map<Object?, Object?>>();
 
     return _eventsStream!;
   }
@@ -69,12 +71,14 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
       return null;
     }
 
-    final List<Map<Object?, Object?>> barcodes = data.cast<Map<Object?, Object?>>();
+    final List<Map<Object?, Object?>> barcodes =
+        data.cast<Map<Object?, Object?>>();
 
     if (defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS ||
         defaultTargetPlatform == TargetPlatform.macOS) {
-      final Map<Object?, Object?>? imageData = event['image'] as Map<Object?, Object?>?;
+      final Map<Object?, Object?>? imageData =
+          event['image'] as Map<Object?, Object?>?;
       final Uint8List? image = imageData?['bytes'] as Uint8List?;
       final double? width = imageData?['width'] as double?;
       final double? height = imageData?['height'] as double?;
@@ -100,7 +104,8 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
   /// If the error is not a [PlatformException],
   /// with [kBarcodeErrorEventName] as [PlatformException.code], the error is rethrown as-is.
   Never _parseBarcodeError(Object error, StackTrace stackTrace) {
-    if (error case PlatformException(:final String code, :final String? message) when code == kBarcodeErrorEventName) {
+    if (error case PlatformException(:final String code, :final String? message)
+        when code == kBarcodeErrorEventName) {
       throw MobileScannerBarcodeException(message);
     }
 
@@ -112,7 +117,8 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
   /// Throws a [MobileScannerException] if the permission is not granted.
   Future<void> _requestCameraPermission() async {
     try {
-      final MobileScannerAuthorizationState authorizationState = MobileScannerAuthorizationState.fromRawValue(
+      final MobileScannerAuthorizationState authorizationState =
+          MobileScannerAuthorizationState.fromRawValue(
         await methodChannel.invokeMethod<int>('state') ?? 0,
       );
 
@@ -124,7 +130,8 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
         // So if the permission was denied, request it again.
         case MobileScannerAuthorizationState.denied:
         case MobileScannerAuthorizationState.undetermined:
-          final bool permissionGranted = await methodChannel.invokeMethod<bool>('request') ?? false;
+          final bool permissionGranted =
+              await methodChannel.invokeMethod<bool>('request') ?? false;
 
           if (!permissionGranted) {
             throw const MobileScannerException(
@@ -175,7 +182,8 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
     List<BarcodeFormat> formats = const <BarcodeFormat>[],
   }) async {
     try {
-      final Map<Object?, Object?>? result = await methodChannel.invokeMapMethod<Object?, Object?>(
+      final Map<Object?, Object?>? result =
+          await methodChannel.invokeMapMethod<Object?, Object?>(
         'analyzeImage',
         {
           'filePath': path,
@@ -211,7 +219,8 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
 
     final Widget texture = Texture(textureId: _textureId!);
 
-    if (_surfaceProducerDelegate case final AndroidSurfaceProducerDelegate delegate) {
+    if (_surfaceProducerDelegate
+        case final AndroidSurfaceProducerDelegate delegate) {
       return delegate.applyRotationCorrection(texture);
     }
 
@@ -282,7 +291,8 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
     _textureId = textureId;
 
     if (defaultTargetPlatform == TargetPlatform.android) {
-      _surfaceProducerDelegate = AndroidSurfaceProducerDelegate.fromConfiguration(
+      _surfaceProducerDelegate =
+          AndroidSurfaceProducerDelegate.fromConfiguration(
         startResult,
         startOptions.cameraDirection,
       );
@@ -295,7 +305,8 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
 
     final Size size;
 
-    if (startResult['size'] case {'width': final double width, 'height': final double height}) {
+    if (startResult['size']
+        case {'width': final double width, 'height': final double height}) {
       size = Size(width, height);
     } else {
       size = Size.zero;

--- a/lib/src/utils/parse_device_orientation_extension.dart
+++ b/lib/src/utils/parse_device_orientation_extension.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/services.dart';
+
+/// This extension defines a utility function for parsing a [DeviceOrientation]
+/// from a [String].
+extension ParseDeviceOrientation on String {
+  /// Parse `this` into a [DeviceOrientation].
+  ///
+  /// Returns the parsed device orientation,
+  /// or null if `this` is not a valid device orientation.
+  DeviceOrientation? tryParseDeviceOrientation() {
+    return switch (this) {
+      'PORTRAIT_UP' => DeviceOrientation.portraitUp,
+      'PORTRAIT_DOWN' => DeviceOrientation.portraitDown,
+      'LANDSCAPE_LEFT' => DeviceOrientation.landscapeLeft,
+      'LANDSCAPE_RIGHT' => DeviceOrientation.landscapeRight,
+      _ => null,
+    };
+  }
+}

--- a/lib/src/utils/parse_device_orientation_extension.dart
+++ b/lib/src/utils/parse_device_orientation_extension.dart
@@ -5,15 +5,19 @@ import 'package:flutter/services.dart';
 extension ParseDeviceOrientation on String {
   /// Parse `this` into a [DeviceOrientation].
   ///
-  /// Returns the parsed device orientation,
-  /// or null if `this` is not a valid device orientation.
-  DeviceOrientation? tryParseDeviceOrientation() {
+  /// Returns the parsed device orientation.
+  /// Throws an [ArgumentError] if `this` is an invalid device orientation.
+  DeviceOrientation parseDeviceOrientation() {
     return switch (this) {
       'PORTRAIT_UP' => DeviceOrientation.portraitUp,
       'PORTRAIT_DOWN' => DeviceOrientation.portraitDown,
       'LANDSCAPE_LEFT' => DeviceOrientation.landscapeLeft,
       'LANDSCAPE_RIGHT' => DeviceOrientation.landscapeRight,
-      _ => null,
+      _ => throw ArgumentError.value(
+          this,
+          'deviceOrientation',
+          'Received an invalid device orientation',
+        ),
     };
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,8 +16,8 @@ screenshots:
   path: example/screenshots/overlay.png
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  sdk: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.0"
 
 dependencies:
   collection: ">=1.15.0 <2.0.0"

--- a/test/parse_device_orientation_test.dart
+++ b/test/parse_device_orientation_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/utils/parse_device_orientation_extension.dart';
+
+void main() {
+  group('parseDeviceOrientation', () {
+    test('can parse valid device orientation string', () {
+      expect(
+        'PORTRAIT_UP'.parseDeviceOrientation(),
+        DeviceOrientation.portraitUp,
+      );
+      expect(
+        'PORTRAIT_DOWN'.parseDeviceOrientation(),
+        DeviceOrientation.portraitDown,
+      );
+      expect(
+        'LANDSCAPE_LEFT'.parseDeviceOrientation(),
+        DeviceOrientation.landscapeLeft,
+      );
+      expect(
+        'LANDSCAPE_RIGHT'.parseDeviceOrientation(),
+        DeviceOrientation.landscapeRight,
+      );
+    });
+
+    test('throws ArgumentError when parsing invalid device orientation string',
+        () {
+      expect(
+        () => ''.parseDeviceOrientation(),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            'Received an invalid device orientation',
+          ),
+        ),
+      );
+
+      expect(
+        () => 'foo'.parseDeviceOrientation(),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            'Received an invalid device orientation',
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
This PR adds support for Impeller on Android.

Supercedes #1277 (retargets those changes onto the new develop branch)

TODO:
- [x] replace `SurfaceTexture` with `SurfaceProducer`
- [x] suppress deprecation for the to-be-deprecated `onSurfaceDestroyed` (I need to add the annotation)
- [x] add rotation correction, inspired by the change in camera_android_camerax
- [x] provide the rotation correction with the needed input arguments (also inspired by the change in camera_android_camerax)
   - [x] provide `isPreviewPreTransformed` (either from the surface producer or by checking the SDK level)
   - [x] provide the device's natural orientation (i.e. landscape for tablets)
   - [x] provide the sensor orientation in degrees
   - [x] set up a device orientation EventSink on the Android side, to relay changes in the device orientation
   - [x] listen to changes in the device orientation on the Dart side, so that we can correct the orientation of the preview
 - [ ] investigate additional rotation being applied due to Impeller. See https://github.com/juliansteenbakker/mobile_scanner/pull/1283#discussion_r1927798329

Part of #867 