### PR TITLE
fix: remove redundant release

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -478,8 +478,6 @@ class MobileScanner(
             it.zoomState.removeObservers(owner)
             it.cameraState.removeObservers(owner)
         }
-        textureEntry?.release()
-        textureEntry = null
 
         // Unbind the camera use cases, the preview is a use case.
         // The camera will be closed when the last use case is unbound.


### PR DESCRIPTION
This PR is a follow up to https://github.com/navaronbracke/mobile_scanner/commit/dead58edf18a6c4e8417fcc46885f690a00b6335

The second release is redundant since we already do it a few lines above.
