### PR TITLE
fix: fix android jank ui when returnImage is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 6.0.4
 Bugs fixed:
-* Fixed android ui jank when `returnImage` is true.
+* [Android] Fixed UI jank when `returnImage` is true.
 
 ## 6.0.3
 New features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.4
+Bugs fixed:
+* Fixed android ui jank when `returnImage` is true.
+
 ## 6.0.3
 New features:
 * Adds pause function to pause the camera but keep textures in place.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,7 +79,8 @@ dependencies {
 
     implementation 'androidx.camera:camera-lifecycle:1.3.4'
     implementation 'androidx.camera:camera-camera2:1.3.4'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
-    testImplementation 'org.mockito:mockito-core:5.12.0'    
+    testImplementation 'org.mockito:mockito-core:5.12.0'
 }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import java.io.ByteArrayOutputStream
 import kotlin.math.roundToInt
+
 class MobileScanner(
     private val activity: Activity,
     private val textureRegistry: TextureRegistry,
@@ -149,8 +150,10 @@ class MobileScanner(
                     val byteArray = stream.toByteArray()
                     val bmWidth = bmResult.width
                     val bmHeight = bmResult.height
+
                     bmResult.recycle()
                     imageProxy.close()
+
                     mobileScannerCallback(
                         barcodeMap,
                         byteArray,

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -35,9 +35,12 @@ import dev.steenbakker.mobile_scanner.objects.DetectionSpeed
 import dev.steenbakker.mobile_scanner.objects.MobileScannerStartParameters
 import dev.steenbakker.mobile_scanner.utils.YuvToRgbConverter
 import io.flutter.view.TextureRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import java.io.ByteArrayOutputStream
 import kotlin.math.roundToInt
-
 class MobileScanner(
     private val activity: Activity,
     private val textureRegistry: TextureRegistry,
@@ -97,6 +100,7 @@ class MobileScanner(
 
                     if (newScannedBarcodes == lastScanned) {
                         // New scanned is duplicate, returning
+                        imageProxy.close()
                         return@addOnSuccessListener
                     }
                     if (newScannedBarcodes.isNotEmpty()) {
@@ -118,10 +122,12 @@ class MobileScanner(
                 }
 
                 if (barcodeMap.isEmpty()) {
+                    imageProxy.close()
                     return@addOnSuccessListener
                 }
 
                 if (!returnImage) {
+                    imageProxy.close()
                     mobileScannerCallback(
                         barcodeMap,
                         null,
@@ -130,31 +136,34 @@ class MobileScanner(
                     return@addOnSuccessListener
                 }
 
-                val bitmap = Bitmap.createBitmap(mediaImage.width, mediaImage.height, Bitmap.Config.ARGB_8888)
-                val imageFormat = YuvToRgbConverter(activity.applicationContext)
+                CoroutineScope(Dispatchers.IO).launch {
+                    val bitmap = Bitmap.createBitmap(mediaImage.width, mediaImage.height, Bitmap.Config.ARGB_8888)
+                    val imageFormat = YuvToRgbConverter(activity.applicationContext)
 
-                imageFormat.yuvToRgb(mediaImage, bitmap)
+                    imageFormat.yuvToRgb(mediaImage, bitmap)
 
-                val bmResult = rotateBitmap(bitmap, camera?.cameraInfo?.sensorRotationDegrees?.toFloat() ?: 90f)
+                    val bmResult = rotateBitmap(bitmap, camera?.cameraInfo?.sensorRotationDegrees?.toFloat() ?: 90f)
 
-                val stream = ByteArrayOutputStream()
-                bmResult.compress(Bitmap.CompressFormat.PNG, 100, stream)
-                val byteArray = stream.toByteArray()
-                val bmWidth = bmResult.width
-                val bmHeight = bmResult.height
-                bmResult.recycle()
+                    val stream = ByteArrayOutputStream()
+                    bmResult.compress(Bitmap.CompressFormat.PNG, 100, stream)
+                    val byteArray = stream.toByteArray()
+                    val bmWidth = bmResult.width
+                    val bmHeight = bmResult.height
+                    bmResult.recycle()
+                    imageProxy.close()
+                    mobileScannerCallback(
+                        barcodeMap,
+                        byteArray,
+                        bmWidth,
+                        bmHeight
+                    )
+                }
 
-                mobileScannerCallback(
-                    barcodeMap,
-                    byteArray,
-                    bmWidth,
-                    bmHeight
-                )
             }.addOnFailureListener { e ->
                 mobileScannerErrorCallback(
                     e.localizedMessage ?: e.toString()
                 )
-            }.addOnCompleteListener { imageProxy.close() }
+            }
         }
 
         if (detectionSpeed == DetectionSpeed.NORMAL) {


### PR DESCRIPTION
### ✨ What's the context?

When returnImage is set to true,  android device experiences UI Jank when QR code is detected.

https://github.com/user-attachments/assets/a7f63de7-17e0-4b41-b557-66d283256231


### 🛠 Changes being made

- Used Coroutine for image processing task.
