### PR TITLE
fix: check canAddInput for AVCaptureSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 Improvements:
 * [Android] Added support for Impeller.
 
+Bugs fixed:
+* [Apple] Fixed a bug that caused a crash when the capture session could not add the video input.
+
 ## 7.0.0-beta.5
 
 Improvements:

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerErrorCodes.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerErrorCodes.swift
@@ -18,6 +18,8 @@ struct MobileScannerErrorCodes {
     // The error code 'CAMERA_ERROR' does not have an error message,
     // because it uses the error message from the underlying error.
     static let CAMERA_ERROR = "MOBILE_SCANNER_CAMERA_ERROR"
+    // This error message is used when the active AVCaptureSession cannot add the camera video input.
+    static let CAMERA_ERROR_CAPTURE_SESSION_INPUT_OCCUPIED_MESSAGE = "The camera video input could not be initialized."
     static let GENERIC_ERROR = "MOBILE_SCANNER_GENERIC_ERROR"
     static let GENERIC_ERROR_MESSAGE = "An unknown error occurred."
     // This message is used with the 'GENERIC_ERROR' error code.

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -358,6 +358,15 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         // Add device input
         do {
             let input = try AVCaptureDeviceInput(device: device)
+            
+            if (!(captureSession!.canAddInput(input))) {
+                result(FlutterError(
+                    code: MobileScannerErrorCodes.CAMERA_ERROR,
+                    message: MobileScannerErrorCodes.CAMERA_ERROR_CAPTURE_SESSION_INPUT_OCCUPIED_MESSAGE,
+                    details: nil))
+                return
+            }
+            
             captureSession!.addInput(input)
         } catch {
             result(FlutterError(

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -243,7 +243,7 @@
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
 			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
 			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
@@ -738,7 +738,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};


### PR DESCRIPTION
Per the docs of `addInput` : 

```
It’s only valid to call this method if canAddInput returns true.
```

https://developer.apple.com/documentation/avfoundation/avcapturesession/addinput(_:)

Fixes https://github.com/juliansteenbakker/mobile_scanner/issues/1297