### PR TITLE
fix: bump zxing js from 0.19.1 to 0.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## NEXT
+Bugs fixed:
+* [web] Fixed a bug that prevented color inverted barcodes from being scanned.
+
+Improvements:
+* [web] Bump ZXingJS from version 0.19.1 to 0.21.3.
+
 ## 6.0.4
 Bugs fixed:
 * [Android] Fixed UI stutter when `returnImage` is true.

--- a/lib/src/web/zxing/zxing_barcode_reader.dart
+++ b/lib/src/web/zxing/zxing_barcode_reader.dart
@@ -52,7 +52,7 @@ final class ZXingBarcodeReader extends BarcodeReader {
   }
 
   @override
-  String get scriptUrl => 'https://unpkg.com/@zxing/library@0.19.1';
+  String get scriptUrl => 'https://unpkg.com/@zxing/library@0.21.3';
 
   JSMap? _createReaderHints(List<BarcodeFormat> formats) {
     if (formats.isEmpty || formats.contains(BarcodeFormat.all)) {


### PR DESCRIPTION
This PR bumps our default ZXing version to the latest available version.
I didn't go through the entire changelog (there might be other things we can add with this new version), but the fix for color inverted barcodes is in this dependency roll.

fixes https://github.com/juliansteenbakker/mobile_scanner/issues/1278