### PR TITLE
chore: fix analysis on master

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: subosito/flutter-action@v2.12.0
         with:
           cache: true
-          flutter-version: '3.22'
+          flutter-version: '3.24'
           channel: 'stable'
       - name: Version
         run: flutter doctor -v

--- a/example/lib/barcode_scanner_controller.dart
+++ b/example/lib/barcode_scanner_controller.dart
@@ -99,7 +99,7 @@ class _BarcodeScannerWithControllerState
             child: Container(
               alignment: Alignment.bottomCenter,
               height: 100,
-              color: Colors.black.withOpacity(0.4),
+              color: const Color.fromRGBO(0, 0, 0, 0.4),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [

--- a/example/lib/barcode_scanner_listview.dart
+++ b/example/lib/barcode_scanner_listview.dart
@@ -68,7 +68,7 @@ class _BarcodeScannerListViewState extends State<BarcodeScannerListView> {
             child: Container(
               alignment: Alignment.bottomCenter,
               height: 100,
-              color: Colors.black.withOpacity(0.4),
+              color: const Color.fromRGBO(0, 0, 0, 0.4),
               child: Column(
                 children: [
                   Expanded(

--- a/example/lib/barcode_scanner_pageview.dart
+++ b/example/lib/barcode_scanner_pageview.dart
@@ -78,7 +78,7 @@ class _BarcodeScannerPage extends StatelessWidget {
           child: Container(
             alignment: Alignment.bottomCenter,
             height: 100,
-            color: Colors.black.withOpacity(0.4),
+            color: const Color.fromRGBO(0, 0, 0, 0.4),
             child: Center(
               child: ScannedBarcodeLabel(barcodes: controller.barcodes),
             ),

--- a/example/lib/barcode_scanner_returning_image.dart
+++ b/example/lib/barcode_scanner_returning_image.dart
@@ -97,7 +97,7 @@ class _BarcodeScannerReturningImageState
                       child: Container(
                         alignment: Alignment.bottomCenter,
                         height: 100,
-                        color: Colors.black.withOpacity(0.4),
+                        color: const Color.fromRGBO(0, 0, 0, 0.4),
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: [

--- a/example/lib/barcode_scanner_simple.dart
+++ b/example/lib/barcode_scanner_simple.dart
@@ -50,7 +50,7 @@ class _BarcodeScannerSimpleState extends State<BarcodeScannerSimple> {
             child: Container(
               alignment: Alignment.bottomCenter,
               height: 100,
-              color: Colors.black.withOpacity(0.4),
+              color: const Color.fromRGBO(0, 0, 0, 0.4),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [

--- a/example/lib/barcode_scanner_window.dart
+++ b/example/lib/barcode_scanner_window.dart
@@ -108,7 +108,7 @@ class _BarcodeScannerWithScanWindowState
               alignment: Alignment.center,
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               height: 100,
-              color: Colors.black.withOpacity(0.4),
+              color: const Color.fromRGBO(0, 0, 0, 0.4),
               child: ScannedBarcodeLabel(barcodes: controller.barcodes),
             ),
           ),
@@ -137,7 +137,7 @@ class ScannerOverlay extends CustomPainter {
     final cutoutPath = Path()..addRect(scanWindow);
 
     final backgroundPaint = Paint()
-      ..color = Colors.black.withOpacity(0.5)
+      ..color = const Color.fromRGBO(0, 0, 0, 0.5)
       ..style = PaintingStyle.fill
       ..blendMode = BlendMode.dstOver;
 
@@ -214,7 +214,7 @@ class BarcodeOverlay extends CustomPainter {
     final cutoutPath = Path()..addPolygon(adjustedOffset, true);
 
     final backgroundPaint = Paint()
-      ..color = Colors.red.withOpacity(0.3)
+      ..color = const Color(0x4DF44336)
       ..style = PaintingStyle.fill
       ..blendMode = BlendMode.dstOut;
 

--- a/example/lib/barcode_scanner_zoom.dart
+++ b/example/lib/barcode_scanner_zoom.dart
@@ -86,7 +86,7 @@ class _BarcodeScannerWithZoomState extends State<BarcodeScannerWithZoom> {
             child: Container(
               alignment: Alignment.bottomCenter,
               height: 100,
-              color: Colors.black.withOpacity(0.4),
+              color: const Color.fromRGBO(0, 0, 0, 0.4),
               child: Column(
                 children: [
                   if (!kIsWeb) _buildZoomScaleSlider(),

--- a/example/lib/mobile_scanner_overlay.dart
+++ b/example/lib/mobile_scanner_overlay.dart
@@ -118,7 +118,7 @@ class ScannerOverlay extends CustomPainter {
       );
 
     final backgroundPaint = Paint()
-      ..color = Colors.black.withOpacity(0.5)
+      ..color = const Color.fromRGBO(0, 0, 0, 0.5)
       ..style = PaintingStyle.fill
       ..blendMode = BlendMode.dstOver;
 

--- a/example/lib/scanner_error_widget.dart
+++ b/example/lib/scanner_error_widget.dart
@@ -19,7 +19,6 @@ class ScannerErrorWidget extends StatelessWidget {
         errorMessage = 'Scanning is unsupported on this device';
       default:
         errorMessage = 'Generic Error';
-        break;
     }
 
     return ColoredBox(


### PR DESCRIPTION
This PR fixes the current lint warnings/errors on tip-of-tree for `master`:

- `withOpacity` is deprecated, replaced by `fromRGBO`, except for one usage of `Colors.red`, which is replaced by a hexadecimal version of said color, with the opacity applied
- an unreachable `break` statement was reported by the new version of the Dart analyzer (the respective lint now detects this case).
- `onPopWithResult` is not available for the current min sdk version, so that was adjusted from Flutter 3.22 to 3.24