### PR TITLE
fix: add payload data as raw bytes in the new iOS/MacOS implementation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 Improvements:
 * [Android] Added support for Impeller.
+* [Apple] Added support for `rawBytes` from the Vision API observations.
 
 ## 7.0.0-beta.5
 

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -891,6 +891,13 @@ extension VNBarcodeObservation {
         // Calculate the width and height of the barcode based on adjusted coordinates
         let width = distanceBetween(adjustedTopLeft, adjustedTopRight) * CGFloat(imageWidth)
         let height = distanceBetween(adjustedTopLeft, adjustedBottomLeft) * CGFloat(imageHeight)
+        var rawBytes: FlutterStandardTypedData? = nil
+        
+        if #available(iOS 17.0, macOS 14.0, *) {
+            if let payloadData = payloadData {
+                rawBytes = FlutterStandardTypedData(bytes: payloadData)
+            }
+        }
 
         let data = [
             // Clockwise, starting from the top-left corner.
@@ -901,6 +908,7 @@ extension VNBarcodeObservation {
                 ["x": bottomLeftX, "y": bottomLeftY],
             ],
             "format": symbology.toInt ?? -1,
+            "rawBytes": rawBytes,
             "rawValue": payloadStringValue ?? "",
             "displayValue": payloadStringValue ?? "",
             "size": [


### PR DESCRIPTION
This PR restores support for `Barcode.rawBytes` in the Vision implementation.
This appears to be the only field that wasn't ported over, excluding the various decoded datatypes (which are MLKIt specific and might be added later)

Fixes #1315