### PR TITLE
Fix Namespace not specified. Specify a namespace in the module's buil…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace = "dev.steenbakker.mobile_scanner"
     if (project.android.hasProperty("namespace")) {
         namespace 'dev.steenbakker.mobile_scanner'
     }


### PR DESCRIPTION
**FIX**:Namespace not specified. Specify a namespace in the module's build's file

D:\path to project \android>**_gradlew clean_**

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':mobile_scanner'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 1s
4 actionable tasks: 4 up-to-date