### PR TITLE
fix: turn off camerax info logs

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -55,5 +55,8 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           cache: true
+          # TODO: move the code to the new tall style once Flutter 3.29 is the new minimum.
+          # https://github.com/juliansteenbakker/mobile_scanner/issues/1326
+          flutter-version: '3.27'
       - name: Format
         run: dart format --set-exit-if-changed .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+Improvements:
+* [Android] Turn off logging for CameraX, except for the `Log.ERROR` logging level.
+
 ## 7.0.0-beta.6
 
 **BREAKING CHANGES:**


### PR DESCRIPTION
This PR turns off the CameraX logging for the `Log.DEBUG`, `Log.INFO` and `Log.WARN` logging.
Per the docs of CameraX:

```
For apps that want to reduce the logs produced by CameraX, set it to Log. ERROR to avoid all logs except for error.
```

We could technically also allow `Log.WARN`, but I'm not sure if that is going to help much.

Fixes #1255 