### PR TITLE
feat: handle more facing directions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Improvements:
 * [Android] Turn off logging for CameraX, except for the `Log.ERROR` logging level.
+* Added `CameraFacing.external` and `CameraFacing.unknown` enum values.
 
 ## 7.0.0-beta.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## NEXT
 
+**BREAKING CHANGES:**
+
+* The initial state of the `MobileScannerState` camera facing direction is changed to `CameraFacing.unknown`.
+
 Improvements:
 * [Android] Turn off logging for CameraX, except for the `Log.ERROR` logging level.
 * Added `CameraFacing.external` and `CameraFacing.unknown` enum values.

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -22,6 +22,7 @@ import androidx.camera.core.Camera
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.CameraXConfig
 import androidx.camera.core.ExperimentalGetImage
+import androidx.camera.core.ExperimentalLensFacing
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
 import androidx.camera.core.Preview
@@ -278,6 +279,17 @@ class MobileScanner(
         }
     }
 
+    @ExperimentalLensFacing
+    private fun getCameraLensFacing(camera: Camera?): Int? {
+        return when(camera?.cameraInfo?.lensFacing) {
+            CameraSelector.LENS_FACING_BACK -> 1
+            CameraSelector.LENS_FACING_FRONT -> 0
+            CameraSelector.LENS_FACING_EXTERNAL -> 2
+            CameraSelector.LENS_FACING_UNKNOWN -> null
+            else -> null
+        }
+    }
+
     private fun rotateBitmap(bitmap: Bitmap, degrees: Float): Bitmap {
         val matrix = Matrix()
         matrix.postRotate(degrees)
@@ -318,6 +330,7 @@ class MobileScanner(
     /**
      * Start barcode scanning by initializing the camera and barcode scanner.
      */
+    @ExperimentalLensFacing
     @ExperimentalGetImage
     fun start(
         barcodeScannerOptions: BarcodeScannerOptions?,
@@ -343,6 +356,7 @@ class MobileScanner(
 // TODO: resume here for seamless transition
 //            if (isPaused) {
 //                resumeCamera()
+//                val cameraDirection = getCameraLensFacing(camera)
 //                mobileScannerStartedCallback(
 //                  MobileScannerStartParameters(
 //                    if (portrait) width else height,
@@ -352,7 +366,8 @@ class MobileScanner(
 //                    surfaceProducer!!.handlesCropAndRotation(),
 //                    currentTorchState,
 //                    surfaceProducer!!.id(),
-//                    numberOfCameras ?: 0
+//                    numberOfCameras ?: 0,
+//                    cameraDirection
 //                  )
 //                )
 //                return
@@ -465,6 +480,7 @@ class MobileScanner(
             val height = resolution.height.toDouble()
             val sensorRotationDegrees = camera?.cameraInfo?.sensorRotationDegrees ?: 0
             val portrait = sensorRotationDegrees % 180 == 0
+            val cameraDirection = getCameraLensFacing(camera)
 
             // Start with 'unavailable' torch state.
             var currentTorchState: Int = -1
@@ -488,7 +504,8 @@ class MobileScanner(
                     surfaceProducer!!.handlesCropAndRotation(),
                     currentTorchState,
                     surfaceProducer!!.id(),
-                    numberOfCameras ?: 0
+                    numberOfCameras ?: 0,
+                    cameraDirection,
                 )
             )
         }, executor)

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -10,6 +10,7 @@ import android.os.Looper
 import android.util.Size
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ExperimentalGetImage
+import androidx.camera.core.ExperimentalLensFacing
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions
 import dev.steenbakker.mobile_scanner.objects.BarcodeFormats
 import dev.steenbakker.mobile_scanner.objects.DetectionSpeed
@@ -114,6 +115,7 @@ class MobileScannerHandler(
         }
     }
 
+    @ExperimentalLensFacing
     @ExperimentalGetImage
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {
@@ -146,6 +148,7 @@ class MobileScannerHandler(
         }
     }
 
+    @ExperimentalLensFacing
     @ExperimentalGetImage
     private fun start(call: MethodCall, result: MethodChannel.Result) {
         val torch: Boolean = call.argument<Boolean>("torch") ?: false
@@ -191,7 +194,8 @@ class MobileScannerHandler(
                         "isPreviewPreTransformed" to it.isPreviewPreTransformed,
                         "sensorOrientation" to it.sensorOrientation,
                         "currentTorchState" to it.currentTorchState,
-                        "numberOfCameras" to it.numberOfCameras
+                        "numberOfCameras" to it.numberOfCameras,
+                        "cameraDirection" to it.cameraDirection
                     ))
                 }
             },

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/objects/MobileScannerStartParameters.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/objects/MobileScannerStartParameters.kt
@@ -8,5 +8,6 @@ class MobileScannerStartParameters(
     val isPreviewPreTransformed: Boolean,
     val currentTorchState: Int,
     val id: Long,
-    val numberOfCameras: Int
+    val numberOfCameras: Int,
+    val cameraDirection: Int?,
 )

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -434,10 +434,18 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                 let answer: [String : Any?]
 
                 if let device = self.device {
+                    let cameraDirection: Int? = switch(device.position) {
+                        case .back: 1
+                        case .unspecified: nil
+                        case .front: 0
+                        @unknown default: nil
+                    }
+                    
                     answer = [
                         "textureId": self.textureId,
                         "size": size,
                         "currentTorchState": device.hasTorch ? device.torchMode.rawValue : -1,
+                        "cameraDirection": cameraDirection,
                     ]
                 } else {
                     answer = [

--- a/example/lib/scanner_button_widgets.dart
+++ b/example/lib/scanner_button_widgets.dart
@@ -109,6 +109,10 @@ class SwitchCameraButton extends StatelessWidget {
             icon = const Icon(Icons.camera_front);
           case CameraFacing.back:
             icon = const Icon(Icons.camera_rear);
+          case CameraFacing.external:
+            icon = const Icon(Icons.usb);
+          case CameraFacing.unknown:
+            icon = const Icon(Icons.device_unknown);
         }
 
         return IconButton(

--- a/lib/src/enums/camera_facing.dart
+++ b/lib/src/enums/camera_facing.dart
@@ -1,21 +1,35 @@
 /// The facing of a camera.
 enum CameraFacing {
-  /// Front facing camera.
+  /// The camera is a front facing camera.
+  ///
+  /// This type of camera always faces the user.
   front(0),
 
-  /// Back facing camera.
-  back(1);
+  /// The camera is a back facing camera.
+  ///
+  /// This type of camera always faces away from the user.
+  back(1),
+
+  /// The camera is an external camera.
+  ///
+  /// For example a USB-camera.
+  external(2),
+
+  /// The camera facing direction is unknown.
+  unknown(-1);
 
   const CameraFacing(this.rawValue);
 
   factory CameraFacing.fromRawValue(int value) {
     switch (value) {
       case 0:
-        return CameraFacing.front;
+        return front;
       case 1:
-        return CameraFacing.back;
+        return back;
+      case 2:
+        return external;
       default:
-        throw ArgumentError.value(value, 'value', 'Invalid raw value.');
+        return unknown;
     }
   }
 

--- a/lib/src/enums/camera_facing.dart
+++ b/lib/src/enums/camera_facing.dart
@@ -20,7 +20,7 @@ enum CameraFacing {
 
   const CameraFacing(this.rawValue);
 
-  factory CameraFacing.fromRawValue(int value) {
+  factory CameraFacing.fromRawValue(int? value) {
     switch (value) {
       case 0:
         return front;

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
+import 'package:mobile_scanner/src/enums/camera_facing.dart';
 import 'package:mobile_scanner/src/enums/mobile_scanner_authorization_state.dart';
 import 'package:mobile_scanner/src/enums/mobile_scanner_error_code.dart';
 import 'package:mobile_scanner/src/enums/torch_state.dart';
@@ -307,13 +308,16 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
       );
     }
 
+    final CameraFacing cameraDirection =
+        CameraFacing.fromRawValue(startResult['cameraDirection'] as int?);
+
     _textureId = textureId;
 
     if (defaultTargetPlatform == TargetPlatform.android) {
       _surfaceProducerDelegate =
           AndroidSurfaceProducerDelegate.fromConfiguration(
         startResult,
-        startOptions.cameraDirection,
+        cameraDirection,
       );
       _surfaceProducerDelegate?.startListeningToDeviceOrientation(
         deviceOrientationChangedStream,
@@ -337,6 +341,7 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
     _pausing = false;
 
     return MobileScannerViewAttributes(
+      cameraDirection: cameraDirection,
       currentTorchMode: currentTorchState,
       numberOfCameras: numberOfCameras,
       size: size,

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -38,7 +38,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
         ),
         assert(
           facing != CameraFacing.unknown,
-          'The camera facing direction must be either front, back or external.',
+          'CameraFacing.unknown is not a valid camera direction.',
         ),
         super(const MobileScannerState.uninitialized());
 
@@ -303,6 +303,15 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
         errorDetails: MobileScannerErrorDetails(
           message:
               'The MobileScannerController was used after it has been disposed.',
+        ),
+      );
+    }
+
+    if (cameraDirection == CameraFacing.unknown) {
+      throw const MobileScannerException(
+        errorCode: MobileScannerErrorCode.genericError,
+        errorDetails: MobileScannerErrorDetails(
+          message: 'CameraFacing.unknown is not a valid camera direction.',
         ),
       );
     }

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -36,7 +36,11 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
           detectionTimeoutMs >= 0,
           'The detection timeout must be greater than or equal to 0.',
         ),
-        super(MobileScannerState.uninitialized(facing));
+        assert(
+          facing != CameraFacing.unknown,
+          'The camera facing direction must be either front, back or external.',
+        ),
+        super(const MobileScannerState.uninitialized());
 
   /// The desired resolution for the camera.
   ///

--- a/lib/src/mobile_scanner_view_attributes.dart
+++ b/lib/src/mobile_scanner_view_attributes.dart
@@ -1,15 +1,20 @@
 import 'dart:ui';
 
+import 'package:mobile_scanner/src/enums/camera_facing.dart';
 import 'package:mobile_scanner/src/enums/torch_state.dart';
 
 /// This class defines the attributes for the mobile scanner view.
 class MobileScannerViewAttributes {
   /// Construct a new [MobileScannerViewAttributes] instance.
   const MobileScannerViewAttributes({
+    required this.cameraDirection,
     required this.currentTorchMode,
-    this.numberOfCameras,
     required this.size,
+    this.numberOfCameras,
   });
+
+  /// The direction of the active camera.
+  final CameraFacing cameraDirection;
 
   /// The current torch state of the active camera.
   final TorchState currentTorchMode;

--- a/lib/src/objects/mobile_scanner_state.dart
+++ b/lib/src/objects/mobile_scanner_state.dart
@@ -23,10 +23,10 @@ class MobileScannerState {
   });
 
   /// Create a new [MobileScannerState] instance that is uninitialized.
-  const MobileScannerState.uninitialized(CameraFacing facing)
+  const MobileScannerState.uninitialized()
       : this(
           availableCameras: null,
-          cameraDirection: facing,
+          cameraDirection: CameraFacing.unknown,
           isInitialized: false,
           isRunning: false,
           size: Size.zero,

--- a/lib/src/web/barcode_reader.dart
+++ b/lib/src/web/barcode_reader.dart
@@ -16,16 +16,25 @@ abstract class BarcodeReader {
   /// This constructor is const, for subclasses.
   const BarcodeReader();
 
-  /// Whether the video feed is paused
-  bool? get paused =>
-      throw UnimplementedError('paused has not been implemented.');
+  /// Whether the video feed is paused.
+  bool? get paused {
+    throw UnimplementedError('paused has not been implemented.');
+  }
+
+  /// Get the video feed as a [MediaStream].
+  MediaStream? get videoStream {
+    throw UnimplementedError('videoStream has not been implemented.');
+  }
 
   /// Pause the barcode reader.
-  void pause() => throw UnimplementedError('pause() has not been implemented.');
+  void pause() {
+    throw UnimplementedError('pause() has not been implemented.');
+  }
 
   /// Resume the barcode reader.
-  Future<void> resume() =>
-      throw UnimplementedError('resume() has not been implemented.');
+  Future<void> resume() {
+    throw UnimplementedError('resume() has not been implemented.');
+  }
 
   /// Whether the scanner is currently scanning for barcodes.
   bool get isScanning {

--- a/lib/src/web/media_track_constraints_delegate.dart
+++ b/lib/src/web/media_track_constraints_delegate.dart
@@ -1,5 +1,6 @@
 import 'dart:js_interop';
 
+import 'package:mobile_scanner/src/enums/camera_facing.dart';
 import 'package:mobile_scanner/src/web/media_track_extension.dart';
 import 'package:web/web.dart';
 
@@ -7,6 +8,31 @@ import 'package:web/web.dart';
 final class MediaTrackConstraintsDelegate {
   /// Constructs a [MediaTrackConstraintsDelegate] instance.
   const MediaTrackConstraintsDelegate();
+
+  /// Get the camera direction from the given [videoStream].
+  CameraFacing getCameraDirection(MediaStream? videoStream) {
+    final MediaTrackSettings? trackSettings = getSettings(videoStream);
+
+    return switch (trackSettings?.facingMode) {
+      'environment' => CameraFacing.back,
+      'user' => CameraFacing.front,
+      _ => CameraFacing.unknown,
+    };
+  }
+
+  /// Convert the given [cameraDirection] into a facing mode string,
+  /// that is suitable as a MediaTrack constraint.
+  String getFacingMode(
+    CameraFacing cameraDirection,
+  ) {
+    return switch (cameraDirection) {
+      CameraFacing.back ||
+      CameraFacing.external ||
+      CameraFacing.unknown =>
+        'environment',
+      CameraFacing.front => 'user',
+    };
+  }
 
   /// Get the settings for the given [mediaStream].
   MediaTrackSettings? getSettings(MediaStream? mediaStream) {

--- a/lib/src/web/media_track_constraints_delegate.dart
+++ b/lib/src/web/media_track_constraints_delegate.dart
@@ -13,7 +13,7 @@ final class MediaTrackConstraintsDelegate {
   CameraFacing getCameraDirection(MediaStream? videoStream) {
     final MediaTrackSettings? trackSettings = getSettings(videoStream);
 
-    return switch (trackSettings?.facingMode) {
+    return switch (trackSettings?.facingModeNullable) {
       'environment' => CameraFacing.back,
       'user' => CameraFacing.front,
       _ => CameraFacing.unknown,
@@ -44,18 +44,9 @@ final class MediaTrackConstraintsDelegate {
 
     final MediaStreamTrack track = tracks.first;
 
-    final MediaTrackCapabilities capabilities;
-
-    if (track.getCapabilitiesNullable != null) {
-      capabilities = track.getCapabilities();
-    } else {
-      capabilities = MediaTrackCapabilities();
-    }
-
     final MediaTrackSettings settings = track.getSettings();
-    final JSArray<JSString>? facingModes = capabilities.facingModeNullable;
 
-    if (facingModes == null || facingModes.toDart.isEmpty) {
+    if (settings.facingModeNullable == null) {
       return MediaTrackSettings(
         width: settings.width,
         height: settings.height,

--- a/lib/src/web/media_track_extension.dart
+++ b/lib/src/web/media_track_extension.dart
@@ -1,18 +1,19 @@
 import 'dart:js_interop';
 import 'package:web/web.dart';
 
-/// This extension provides nullable properties for [MediaStreamTrack],
-/// for cases where the properties are not supported by all browsers.
-extension NullableMediaStreamTrackCapabilities on MediaStreamTrack {
-  /// The `getCapabilities` function is not supported on Firefox.
-  @JS('getCapabilities')
-  external JSFunction? get getCapabilitiesNullable;
-}
-
 /// This extension provides nullable properties for [MediaTrackCapabilities],
 /// for cases where the properties are not supported by all browsers.
 extension NullableMediaTrackCapabilities on MediaTrackCapabilities {
   /// The `facingMode` property is not supported on Safari.
   @JS('facingMode')
   external JSArray<JSString>? get facingModeNullable;
+}
+
+/// This extension provides nullable properties for [MediaTrackSettings],
+/// for cases where the properties are not supported by all browsers.
+extension NullableMediaTrackSettings on MediaTrackSettings {
+  /// The `facingMode` property is null on MacOS,
+  /// even though the capability is supported.
+  @JS('facingMode')
+  external JSString? get facingModeNullable;
 }

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -135,8 +135,19 @@ class MobileScannerWeb extends MobileScannerPlatform {
       videoStream,
     );
 
-    // TODO: facingModes is an empty array on MacOS Chrome, where there is no facing mode, but one, user facing camera.
+    // First try checking the facing mode.
     if (settings?.facingModeNullable?.toDart == 'user') {
+      videoElement.style.transform = 'scaleX(-1)';
+
+      return;
+    }
+
+    final MediaStreamTrack videoTrack =
+        videoStream.getVideoTracks().toDart.first;
+
+    // On MacOS, even though the facing mode is supported, it is not reported.
+    // Use the label for FaceTime cameras to detect the user facing webcam.
+    if (videoTrack.label.contains('FaceTime')) {
       videoElement.style.transform = 'scaleX(-1)';
     }
   }

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -14,6 +14,7 @@ import 'package:mobile_scanner/src/mobile_scanner_view_attributes.dart';
 import 'package:mobile_scanner/src/objects/barcode_capture.dart';
 import 'package:mobile_scanner/src/objects/start_options.dart';
 import 'package:mobile_scanner/src/web/barcode_reader.dart';
+import 'package:mobile_scanner/src/web/media_track_constraints_delegate.dart';
 import 'package:mobile_scanner/src/web/media_track_extension.dart';
 import 'package:mobile_scanner/src/web/zxing/zxing_barcode_reader.dart';
 import 'package:web/web.dart';
@@ -47,6 +48,10 @@ class MobileScannerWeb extends MobileScannerPlatform {
   /// See https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#instance_properties_of_video_tracks
   final StreamController<MediaTrackSettings> _settingsController =
       StreamController.broadcast();
+
+  /// The delegate that retrieves the media track settings.
+  final MediaTrackConstraintsDelegate _settingsDelegate =
+      const MediaTrackConstraintsDelegate();
 
   /// The texture ID for the camera view.
   int _textureId = 1;
@@ -126,31 +131,8 @@ class MobileScannerWeb extends MobileScannerPlatform {
     HTMLVideoElement videoElement,
     MediaStream videoStream,
   ) {
-    final List<MediaStreamTrack> tracks = videoStream.getVideoTracks().toDart;
-
-    if (tracks.isEmpty) {
-      return;
-    }
-
-    final MediaStreamTrack videoTrack = tracks.first;
-    final MediaTrackCapabilities capabilities;
-
-    if (videoTrack.getCapabilitiesNullable != null) {
-      capabilities = videoTrack.getCapabilities();
-    } else {
-      capabilities = MediaTrackCapabilities();
-    }
-
-    final JSArray<JSString>? facingModes = capabilities.facingModeNullable;
-
-    // TODO: this is an empty array on MacOS Chrome, where there is no facing mode, but one, user facing camera.
-    // We might be able to add a workaround, using the label of the video track.
-    // Facing mode is not supported by this track, do nothing.
-    if (facingModes == null || facingModes.toDart.isEmpty) {
-      return;
-    }
-
-    if (videoTrack.getSettings().facingMode == 'user') {
+    // TODO: facingModes is an empty array on MacOS Chrome, where there is no facing mode, but one, user facing camera.
+    if (_settingsDelegate.getSettings(videoStream)?.facingMode == 'user') {
       videoElement.style.transform = 'scaleX(-1)';
     }
   }
@@ -183,7 +165,10 @@ class MobileScannerWeb extends MobileScannerPlatform {
       constraints = MediaStreamConstraints(video: true.toJS);
     } else {
       final String facingMode = switch (cameraDirection) {
-        CameraFacing.back => 'environment',
+        CameraFacing.back ||
+        CameraFacing.external ||
+        CameraFacing.unknown =>
+          'environment',
         CameraFacing.front => 'user',
       };
 

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -246,7 +246,14 @@ class MobileScannerWeb extends MobileScannerPlatform {
     if (_barcodeReader != null) {
       if (_barcodeReader!.paused ?? false) {
         await _barcodeReader?.resume();
+
+        final CameraFacing cameraDirection =
+            _settingsDelegate.getCameraDirection(
+          _barcodeReader?.videoStream,
+        );
+
         return MobileScannerViewAttributes(
+          cameraDirection: cameraDirection,
           // The torch of a media stream is not available for video tracks.
           // See https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#instance_properties_of_video_tracks
           currentTorchMode: TorchState.unavailable,
@@ -336,7 +343,12 @@ class MobileScannerWeb extends MobileScannerPlatform {
         await _barcodeReader?.setTorchState(TorchState.on);
       }
 
+      final CameraFacing cameraDirection = _settingsDelegate.getCameraDirection(
+        videoStream,
+      );
+
       return MobileScannerViewAttributes(
+        cameraDirection: cameraDirection,
         // The torch of a media stream is not available for video tracks.
         // See https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#instance_properties_of_video_tracks
         currentTorchMode: TorchState.unavailable,

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -15,7 +15,6 @@ import 'package:mobile_scanner/src/objects/barcode_capture.dart';
 import 'package:mobile_scanner/src/objects/start_options.dart';
 import 'package:mobile_scanner/src/web/barcode_reader.dart';
 import 'package:mobile_scanner/src/web/media_track_constraints_delegate.dart';
-import 'package:mobile_scanner/src/web/media_track_extension.dart';
 import 'package:mobile_scanner/src/web/zxing/zxing_barcode_reader.dart';
 import 'package:web/web.dart';
 
@@ -164,13 +163,9 @@ class MobileScannerWeb extends MobileScannerPlatform {
     if (capabilities.isUndefinedOrNull || !capabilities.facingMode) {
       constraints = MediaStreamConstraints(video: true.toJS);
     } else {
-      final String facingMode = switch (cameraDirection) {
-        CameraFacing.back ||
-        CameraFacing.external ||
-        CameraFacing.unknown =>
-          'environment',
-        CameraFacing.front => 'user',
-      };
+      final String facingMode = _settingsDelegate.getFacingMode(
+        cameraDirection,
+      );
 
       constraints = MediaStreamConstraints(
         video: MediaTrackConstraintSet(

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -15,6 +15,7 @@ import 'package:mobile_scanner/src/objects/barcode_capture.dart';
 import 'package:mobile_scanner/src/objects/start_options.dart';
 import 'package:mobile_scanner/src/web/barcode_reader.dart';
 import 'package:mobile_scanner/src/web/media_track_constraints_delegate.dart';
+import 'package:mobile_scanner/src/web/media_track_extension.dart';
 import 'package:mobile_scanner/src/web/zxing/zxing_barcode_reader.dart';
 import 'package:web/web.dart';
 
@@ -130,8 +131,12 @@ class MobileScannerWeb extends MobileScannerPlatform {
     HTMLVideoElement videoElement,
     MediaStream videoStream,
   ) {
+    final MediaTrackSettings? settings = _settingsDelegate.getSettings(
+      videoStream,
+    );
+
     // TODO: facingModes is an empty array on MacOS Chrome, where there is no facing mode, but one, user facing camera.
-    if (_settingsDelegate.getSettings(videoStream)?.facingMode == 'user') {
+    if (settings?.facingModeNullable?.toDart == 'user') {
       videoElement.style.transform = 'scaleX(-1)';
     }
   }

--- a/lib/src/web/zxing/zxing_barcode_reader.dart
+++ b/lib/src/web/zxing/zxing_barcode_reader.dart
@@ -36,7 +36,7 @@ final class ZXingBarcodeReader extends BarcodeReader {
   ZXingBrowserMultiFormatReader? _reader;
 
   @override
-  bool get isScanning => _reader?.stream != null;
+  bool get isScanning => videoStream != null;
 
   @override
   Size get videoSize {
@@ -51,6 +51,9 @@ final class ZXingBarcodeReader extends BarcodeReader {
       videoElement.videoHeight.toDouble(),
     );
   }
+
+  @override
+  web.MediaStream? get videoStream => _reader?.stream;
 
   @override
   String get scriptUrl => 'https://unpkg.com/@zxing/library@0.21.3';

--- a/test/enums/camera_facing_test.dart
+++ b/test/enums/camera_facing_test.dart
@@ -7,6 +7,8 @@ void main() {
       const values = <int, CameraFacing>{
         0: CameraFacing.front,
         1: CameraFacing.back,
+        2: CameraFacing.external,
+        -1: CameraFacing.unknown,
       };
 
       for (final MapEntry<int, CameraFacing> entry in values.entries) {
@@ -16,18 +18,20 @@ void main() {
       }
     });
 
-    test('invalid raw value throws argument error', () {
-      const int negative = -1;
-      const int outOfRange = 2;
+    test('invalid raw value returns unknown', () {
+      const int negative = -10;
+      const int outOfRange = 3;
 
-      expect(() => CameraFacing.fromRawValue(negative), throwsArgumentError);
-      expect(() => CameraFacing.fromRawValue(outOfRange), throwsArgumentError);
+      expect(CameraFacing.fromRawValue(negative), CameraFacing.unknown);
+      expect(CameraFacing.fromRawValue(outOfRange), CameraFacing.unknown);
     });
 
     test('can be converted to raw value', () {
       const values = <CameraFacing, int>{
         CameraFacing.front: 0,
         CameraFacing.back: 1,
+        CameraFacing.external: 2,
+        CameraFacing.unknown: -1,
       };
 
       for (final MapEntry<CameraFacing, int> entry in values.entries) {

--- a/test/enums/camera_facing_test.dart
+++ b/test/enums/camera_facing_test.dart
@@ -4,14 +4,15 @@ import 'package:mobile_scanner/src/enums/camera_facing.dart';
 void main() {
   group('$CameraFacing tests', () {
     test('can be created from raw value', () {
-      const values = <int, CameraFacing>{
+      const values = <int?, CameraFacing>{
+        null: CameraFacing.unknown,
         0: CameraFacing.front,
         1: CameraFacing.back,
         2: CameraFacing.external,
         -1: CameraFacing.unknown,
       };
 
-      for (final MapEntry<int, CameraFacing> entry in values.entries) {
+      for (final MapEntry<int?, CameraFacing> entry in values.entries) {
         final CameraFacing result = CameraFacing.fromRawValue(entry.key);
 
         expect(result, entry.value);


### PR DESCRIPTION
This PR adds the remaining facing modes to the `CameraFacing` enum.
It also passes the actual `CameraFacing` value from the camera to the `MobileScannerState` / surface producer delegate, instead of the requested facing direction. That _should_ help prevent a wrong sign for the orientation correction.

Part of https://github.com/juliansteenbakker/mobile_scanner/issues/867
Work towards fixing https://github.com/juliansteenbakker/mobile_scanner/issues/1319
