### PR TITLE
fix: improve video orientation handling for iOS 13 and above

### DIFF
--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -275,6 +275,26 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
     
     private func getVideoOrientation() -> AVCaptureVideoOrientation {
 #if os(iOS)
+        // Get the orientation from the window scene if available
+        // When the app's orientation is fixed and the app orientation is actually different from the device orientation, it malfunctions.
+        if #available(iOS 13.0, *){
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene{
+                let orientation = windowScene.interfaceOrientation
+                switch orientation {
+                case .portrait:
+                    return .portrait
+                case .portraitUpsideDown:
+                    return .portraitUpsideDown
+                case .landscapeLeft:
+                    return .landscapeLeft
+                case .landscapeRight:
+                    return .landscapeRight
+                default:
+                    break
+                }         
+            }
+        }
+
         var videoOrientation: AVCaptureVideoOrientation
 
         switch UIDevice.current.orientation {

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -277,7 +277,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
 #if os(iOS)
         // Get the orientation from the window scene if available
         // When the app's orientation is fixed and the app orientation is actually different from the device orientation, it malfunctions.
-        if #available(iOS 13.0, *){
+        if #available(iOS 13.0, *) {
             if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene{
                 let orientation = windowScene.interfaceOrientation
                 switch orientation {

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -278,7 +278,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         // Get the orientation from the window scene if available
         // When the app's orientation is fixed and the app orientation is actually different from the device orientation, it malfunctions.
         if #available(iOS 13.0, *) {
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene{
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
                 let orientation = windowScene.interfaceOrientation
                 switch orientation {
                 case .portrait:


### PR DESCRIPTION
When the app's orientation is fixed but the device is held in a different direction, the camera view may sometimes appear rotated incorrectly.

- For iOS 13+: Use UIWindowScene.interfaceOrientation for accurate orientation detection.
- Fallback to UIDevice.current.orientation for earlier iOS versions.

