### PR TITLE
feat: bump version to 7.0.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 7.0.0-beta.7
 
 **BREAKING CHANGES:**
 
@@ -7,6 +7,9 @@
 Improvements:
 * [Android] Turn off logging for CameraX, except for the `Log.ERROR` logging level.
 * Added `CameraFacing.external` and `CameraFacing.unknown` enum values.
+
+Bugs fixed:
+* [Android] Fixed an issue when compiling with Kotlin 1.8.0 or higher.
 
 ## 7.0.0-beta.6
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal barcode and QR code scanner for Flutter based on MLKit. Uses CameraX on Android, AVFoundation on iOS and Apple Vision & AVFoundation on macOS.
-version: 7.0.0-beta.6
+version: 7.0.0-beta.7
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 screenshots:


### PR DESCRIPTION
This PR bumps the beta version to hotfix the Kotlin compilation bug that happens on Kotlin 1.8.0 but not on Kotlin 1.7.x

This was [reported by a user](https://github.com/juliansteenbakker/mobile_scanner/issues/1225#issuecomment-2674878064) independently of me fixing it, so I would like to release a hotfix.