### PR TITLE
chore: remove Kotlin bom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,10 @@ unlinked_spec.ds
 **/macos/Flutter/GeneratedPluginRegistrant.swift
 **/macos/Flutter/ephemeral
 
+# Swift Package Manager related
+.build/
+.swiftpm/
+
 # Coverage
 coverage/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.8
+Improvements:
+* [Android] Remove the dependency on `org.jetbrains.kotlin:kotlin-bom`.
+
 ## 6.0.7
 Improvements:
 * [Android] Updated bundled barcode scanning library to v17.3.0

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,10 +73,6 @@ dependencies {
         implementation 'com.google.mlkit:barcode-scanning:17.3.0'
     }
 
-    // org.jetbrains.kotlin:kotlin-bom artifact purpose is to align kotlin stdlib and related code versions.
-    // See: https://youtrack.jetbrains.com/issue/KT-55297/kotlin-stdlib-should-declare-constraints-on-kotlin-stdlib-jdk8-and-kotlin-stdlib-jdk7
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.22"))
-
     implementation 'androidx.camera:camera-lifecycle:1.3.4'
     implementation 'androidx.camera:camera-camera2:1.3.4'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'

--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -11,3 +11,5 @@ GeneratedPluginRegistrant.java
 key.properties
 **/*.keystore
 **/*.jks
+
+**/.cxx

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -24,7 +24,8 @@ if (flutterVersionName == null) {
 
 android {
     namespace "dev.steenbakker.mobile_scanner_example"
-    compileSdk 34
+    compileSdk 35
+    ndkVersion "26.3.11579264"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
@@ -43,7 +44,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "dev.steenbakker.mobile_scanner_example"
         minSdkVersion 24
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal barcode and QR code scanner for Flutter based on MLKit. Uses CameraX on Android, AVFoundation on iOS and Apple Vision & AVFoundation on macOS.
-version: 6.0.7
+version: 6.0.8
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 screenshots:


### PR DESCRIPTION
This PR removes the dependency on the Kotlin BOM, which is no longer needed.

It also updates the example app to compileSDK 35 and updates an outdated NDK version (for the example's image_picker usage)