### PR TITLE
fix: change old surface producer API usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 7.0.0-beta.9
+
+**BREAKING CHANGES:**
+
+* This release requires Flutter 3.29.0 or higher.
+
+Bugs fixed:
+* [Android] Fixed a timing issue for the SurfaceProducer implementation, by switching to the `onSurfaceCleanup` callback. 
+
 ## 7.0.0-beta.8
 
 Improvements:

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -233,9 +233,7 @@ class MobileScanner(
                             // whenever a new Surface is needed.
                         }
 
-                        // TODO: replace with "onSurfaceCleanup" when available in Flutter 3.28 or later
-                        // See https://github.com/flutter/flutter/pull/160937
-                        override fun onSurfaceDestroyed() {
+                        override fun onSurfaceCleanup() {
                             // Invalidate the SurfaceRequest so that CameraX knows to to make a new request
                             // for a surface.
                             request.invalidate()

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,8 +6,8 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 0.0.1
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.0"
+  sdk: ">=3.7.0 <4.0.0"
+  flutter: ">=3.29.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal barcode and QR code scanner for Flutter based on MLKit. Uses CameraX on Android, AVFoundation on iOS and Apple Vision & AVFoundation on macOS.
-version: 7.0.0-beta.8
+version: 7.0.0-beta.9
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 screenshots:
@@ -16,8 +16,8 @@ screenshots:
   path: example/screenshots/overlay.png
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.0"
+  sdk: ">=3.7.0 <4.0.0"
+  flutter: ">=3.29.0"
 
 dependencies:
   collection: ">=1.15.0 <2.0.0"


### PR DESCRIPTION
This PR addresses a TODO with the SurfaceProducer implementation.

Part of #1381 