### PR TITLE
fix: update gradle JVM args

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
When running the example app, it apparently now fails with a Gradle memory error.
Building the example app did work, oddly enough.

There's an open Flutter tool issue for this, so I took the new JVM args from there :)