### PR TITLE
feat: add error message if controller is used before attached to a mobile scanner widget

### DIFF
--- a/lib/src/enums/mobile_scanner_error_code.dart
+++ b/lib/src/enums/mobile_scanner_error_code.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
-import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:mobile_scanner/src/mobile_scanner.dart' show MobileScanner;
+import 'package:mobile_scanner/src/mobile_scanner_controller.dart';
 
 /// This enum defines the different error codes for the mobile scanner.
 enum MobileScannerErrorCode {

--- a/lib/src/enums/mobile_scanner_error_code.dart
+++ b/lib/src/enums/mobile_scanner_error_code.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/services.dart';
-import 'package:mobile_scanner/src/mobile_scanner_controller.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
 
 /// This enum defines the different error codes for the mobile scanner.
 enum MobileScannerErrorCode {
@@ -28,7 +28,6 @@ enum MobileScannerErrorCode {
   /// Scanning is unsupported on the current device.
   unsupported,
 
-  /// Get the human-readable message for the error code.
   /// The controller is currently initializing.
   ///
   /// This error occurs when [MobileScannerController.start] is called while
@@ -40,7 +39,20 @@ enum MobileScannerErrorCode {
   /// - Alternatively, disable automatic initialization by setting
   ///   [MobileScannerController.autoStart] to `false` if you plan to manually
   ///   start the camera.
-  controllerInitializing;
+  controllerInitializing,
+
+  /// The controller is not attached to any widget.
+  ///
+  /// This error occurs when [MobileScannerController.start] is called
+  /// before the controller has been attached to a [MobileScanner] widget.
+  ///
+  /// To fix this error:
+  /// - Ensure that a [MobileScanner] widget is built and linked to the
+  ///   controller.
+  /// - The [MobileScanner] widget automatically attaches the controller
+  ///   when it is initialized.
+  /// - Wait until the widget is fully built before calling start.
+  controllerNotAttached;
 
   /// Convert the given [PlatformException.code] to a [MobileScannerErrorCode].
   factory MobileScannerErrorCode.fromPlatformException(
@@ -85,6 +97,10 @@ enum MobileScannerErrorCode {
             'starting manually.';
       case MobileScannerErrorCode.genericError:
         return 'An unexpected error occurred.';
+      case MobileScannerErrorCode.controllerNotAttached:
+        return 'The MobileScannerController has not been attached to '
+            'MobileScanner. Call start() after the MobileScanner widget is '
+            'built.';
     }
   }
 }

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -266,6 +266,9 @@ class _MobileScannerState extends State<MobileScanner>
   StreamSubscription<BarcodeCapture>? _subscription;
 
   Future<void> initMobileScanner() async {
+    controller = widget.controller ?? MobileScannerController();
+
+    controller.attach();
     // If debug mode is enabled, stop the controller first before starting it.
     // If a hot-restart is initiated, the controller won't be stopped, and
     // because there is no way of knowing if a hot-restart has happened,
@@ -321,7 +324,6 @@ class _MobileScannerState extends State<MobileScanner>
   @override
   void initState() {
     super.initState();
-    controller = widget.controller ?? MobileScannerController();
     unawaited(initMobileScanner());
   }
 

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -128,6 +128,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   StreamSubscription<DeviceOrientation>? _deviceOrientationSubscription;
 
   bool _isDisposed = false;
+  bool _isAttached = false;
 
   void _disposeListeners() {
     _barcodesSubscription?.cancel();
@@ -335,6 +336,15 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
       );
     }
 
+    if (!_isAttached) {
+      throw MobileScannerException(
+        errorCode: MobileScannerErrorCode.controllerDisposed,
+        errorDetails: MobileScannerErrorDetails(
+          message: MobileScannerErrorCode.controllerDisposed.message,
+        ),
+      );
+    }
+
     if (cameraDirection == CameraFacing.unknown) {
       throw const MobileScannerException(
         errorCode: MobileScannerErrorCode.genericError,
@@ -525,5 +535,11 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
     super.dispose();
 
     await MobileScannerPlatform.instance.dispose();
+  }
+
+  /// Keeps track if the controller is correctly attached to the MobileScanner
+  /// widget.
+  void attach() {
+    _isAttached = true;
   }
 }


### PR DESCRIPTION
Fixes #1415 