### PR TITLE
feat: add focus point func, initial zoom position and use of ultra wide camera on Ios

### DIFF
--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerErrorCodes.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerErrorCodes.swift
@@ -24,6 +24,7 @@ struct MobileScannerErrorCodes {
     static let GENERIC_ERROR_MESSAGE = "An unknown error occurred."
     // This message is used with the 'GENERIC_ERROR' error code.
     static let INVALID_ZOOM_SCALE_ERROR_MESSAGE = "The zoom scale should be between 0 and 1 (both inclusive)"
+    static let INVALID_FOCUS_POINT = "The focus needs both X and Y coordinates between 0 and 1."
     static let NO_CAMERA_ERROR = "MOBILE_SCANNER_NO_CAMERA_ERROR"
     static let NO_CAMERA_ERROR_MESSAGE = "No cameras available."
     static let SET_SCALE_WHEN_STOPPED_ERROR = "MOBILE_SCANNER_SET_SCALE_WHEN_STOPPED_ERROR"

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -101,6 +101,8 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
             toggleTorch(result)
         case "setScale":
             setScale(call, result)
+        case "setFocus":
+            setFocus(call, result)
         case "resetScale":
             resetScale(call, result)
         case "pause":
@@ -346,6 +348,8 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         let facing:Int = argReader.int(key: "facing") ?? 1
         let speed:Int = argReader.int(key: "speed") ?? 0
         let timeoutMs:Int = argReader.int(key: "timeout") ?? 0
+        let initialZoom: CGFloat = CGFloat(argReader.float(key: "initialZoom") ?? 1)
+        let useUltraWide:Bool = argReader.bool(key: "useUltraWide") ?? false
         symbologies = argReader.toSymbology()
         MobileScannerPlugin.returnImage = argReader.bool(key: "returnImage") ?? false
 
@@ -360,7 +364,10 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
 #endif
         
         // Open the camera device
-        if #available(macOS 10.15, *) {
+        if #available(iOS 13.0, *) {
+            let type: AVCaptureDevice.DeviceType = useUltraWide ? .builtInUltraWideCamera : .builtInWideAngleCamera
+            device = AVCaptureDevice.DiscoverySession(deviceTypes: [type], mediaType: .video, position: position).devices.first
+        } else if #available(macOS 10.15, *) {
             device = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: .video, position: position).devices.first
         } else {
             device = AVCaptureDevice.devices(for: .video).filter({$0.position == position}).first
@@ -380,7 +387,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         captureSession!.beginConfiguration()
         
         // Check the zoom factor at switching from ultra wide camera to wide camera.
-        standardZoomFactor = 1
+        standardZoomFactor = initialZoom
 #if os(iOS)
         if #available(iOS 13.0, *) {
             for (index, actualDevice) in device.constituentDevices.enumerated() {
@@ -454,6 +461,13 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                 // Turn on the torch if requested.
                 if (torch) {
                     self.turnTorchOn()
+                }
+                
+                // Set the initial zoom factor
+                do {
+                    try self.setScaleInternal(initialZoom)
+                } catch {
+                    // Do nothing.
                 }
 
 #if os(iOS)
@@ -585,6 +599,45 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         }
 
     }
+    
+    private func setFocus(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+                  let dx = args["dx"] as? CGFloat,
+                  let dy = args["dy"] as? CGFloat else {
+                result(FlutterError(code: MobileScannerErrorCodes.GENERIC_ERROR,
+                                    message: MobileScannerErrorCodes.INVALID_FOCUS_POINT,
+                                    details: "The focus coordinates are not valid."))
+                return
+            }
+            let focusPoint = CGPoint(x: dx, y: dy)
+        
+        do {
+            if (device == nil) {
+                throw MobileScannerError.zoomWhenStopped
+            }
+
+    #if os(iOS)
+                if device.isFocusPointOfInterestSupported {
+                    do {
+                        try device.lockForConfiguration()
+                        device.focusPointOfInterest = focusPoint
+                        device.focusMode = .autoFocus
+                        device.unlockForConfiguration()
+                    } catch {
+                        throw MobileScannerError.zoomError(error)
+                    }
+                }
+    #endif
+        
+            result(nil)
+        } catch {
+            result(FlutterError(code: MobileScannerErrorCodes.GENERIC_ERROR,
+                                message: MobileScannerErrorCodes.GENERIC_ERROR_MESSAGE,
+                                details: nil))
+        }
+    }
+
+    
     
 #if os(iOS)
     /// Set the device orientation if it differs from previous orientation
@@ -890,6 +943,10 @@ class MapArgumentReader {
 
     func int(key: String) -> Int? {
         return (args?[key] as? NSNumber)?.intValue
+    }
+    
+    func float(key: String) -> Float? {
+        return (args?[key] as? NSNumber)?.floatValue
     }
 
     func bool(key: String) -> Bool? {

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/example/lib/screens/mobile_scanner_advanced.dart
+++ b/example/lib/screens/mobile_scanner_advanced.dart
@@ -296,107 +296,119 @@ class _MobileScannerAdvancedState extends State<MobileScannerAdvanced> {
       body:
           controller == null || hideMobileScannerWidget
               ? const Placeholder()
-              : Stack(
-                children: [
-                  MobileScanner(
-                    // useAppLifecycleState: false, // Only set to false if you want
-                    // to handle lifecycle changes yourself
-                    scanWindow: useScanWindow ? scanWindow : null,
-                    controller: controller,
-                    errorBuilder: (context, error) {
-                      return ScannerErrorWidget(error: error);
-                    },
-                    fit: boxFit,
-                  ),
-                  if (useBarcodeOverlay)
-                    BarcodeOverlay(controller: controller!, boxFit: boxFit),
-                  // The scanWindow is not supported on the web.
-                  if (useScanWindow)
-                    ScanWindowOverlay(
-                      scanWindow: scanWindow,
-                      controller: controller!,
+              : GestureDetector(
+                onTapUp: (TapUpDetails details) {
+                  final Size size = MediaQuery.of(context).size;
+                  final double relativeX =
+                      details.globalPosition.dx / size.width;
+                  final double relativeY =
+                      details.globalPosition.dy / size.height;
+
+                  controller?.setFocusPoint(Offset(relativeX, relativeY));
+                },
+                child: Stack(
+                  children: [
+                    MobileScanner(
+                      // useAppLifecycleState: false, // Only set to false if you want
+                      // to handle lifecycle changes yourself
+                      scanWindow: useScanWindow ? scanWindow : null,
+                      controller: controller,
+                      errorBuilder: (context, error) {
+                        return ScannerErrorWidget(error: error);
+                      },
+                      fit: boxFit,
                     ),
-                  if (returnImage)
-                    Align(
-                      alignment: Alignment.topRight,
-                      child: Card(
-                        clipBehavior: Clip.hardEdge,
-                        shape: RoundedRectangleBorder(
-                          side: const BorderSide(color: Colors.white),
-                          borderRadius: BorderRadius.circular(10),
-                        ),
-                        child: SizedBox(
-                          width: 100,
-                          height: 100,
-                          child: StreamBuilder<BarcodeCapture>(
-                            stream: controller!.barcodes,
-                            builder: (context, snapshot) {
-                              final BarcodeCapture? barcode = snapshot.data;
+                    if (useBarcodeOverlay)
+                      BarcodeOverlay(controller: controller!, boxFit: boxFit),
+                    // The scanWindow is not supported on the web.
+                    if (useScanWindow)
+                      ScanWindowOverlay(
+                        scanWindow: scanWindow,
+                        controller: controller!,
+                      ),
+                    if (returnImage)
+                      Align(
+                        alignment: Alignment.topRight,
+                        child: Card(
+                          clipBehavior: Clip.hardEdge,
+                          shape: RoundedRectangleBorder(
+                            side: const BorderSide(color: Colors.white),
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: SizedBox(
+                            width: 100,
+                            height: 100,
+                            child: StreamBuilder<BarcodeCapture>(
+                              stream: controller!.barcodes,
+                              builder: (context, snapshot) {
+                                final BarcodeCapture? barcode = snapshot.data;
 
-                              if (barcode == null) {
-                                return const Center(
-                                  child: Text(
-                                    'Your scanned barcode will appear here',
-                                    textAlign: TextAlign.center,
-                                  ),
-                                );
-                              }
-
-                              final Uint8List? barcodeImage = barcode.image;
-
-                              if (barcodeImage == null) {
-                                return const Center(
-                                  child: Text('No image for this barcode.'),
-                                );
-                              }
-
-                              return Image.memory(
-                                barcodeImage,
-                                fit: BoxFit.cover,
-                                gaplessPlayback: true,
-                                errorBuilder: (context, error, stackTrace) {
-                                  return Center(
+                                if (barcode == null) {
+                                  return const Center(
                                     child: Text(
-                                      'Could not decode image bytes. $error',
+                                      'Your scanned barcode will appear here',
+                                      textAlign: TextAlign.center,
                                     ),
                                   );
-                                },
-                              );
-                            },
+                                }
+
+                                final Uint8List? barcodeImage = barcode.image;
+
+                                if (barcodeImage == null) {
+                                  return const Center(
+                                    child: Text('No image for this barcode.'),
+                                  );
+                                }
+
+                                return Image.memory(
+                                  barcodeImage,
+                                  fit: BoxFit.cover,
+                                  gaplessPlayback: true,
+                                  errorBuilder: (context, error, stackTrace) {
+                                    return Center(
+                                      child: Text(
+                                        'Could not decode image bytes. $error',
+                                      ),
+                                    );
+                                  },
+                                );
+                              },
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                  Align(
-                    alignment: Alignment.bottomCenter,
-                    child: Container(
+                    Align(
                       alignment: Alignment.bottomCenter,
-                      height: 200,
-                      color: const Color.fromRGBO(0, 0, 0, 0.4),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Expanded(
-                            child: ScannedBarcodeLabel(
-                              barcodes: controller!.barcodes,
+                      child: Container(
+                        alignment: Alignment.bottomCenter,
+                        height: 200,
+                        color: const Color.fromRGBO(0, 0, 0, 0.4),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Expanded(
+                              child: ScannedBarcodeLabel(
+                                barcodes: controller!.barcodes,
+                              ),
                             ),
-                          ),
-                          if (!kIsWeb) ZoomScaleSlider(controller: controller!),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                            children: [
-                              ToggleFlashlightButton(controller: controller!),
-                              StartStopButton(controller: controller!),
-                              PauseButton(controller: controller!),
-                              SwitchCameraButton(controller: controller!),
-                              AnalyzeImageButton(controller: controller!),
-                            ],
-                          ),
-                        ],
+                            if (!kIsWeb)
+                              ZoomScaleSlider(controller: controller!),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                              children: [
+                                ToggleFlashlightButton(controller: controller!),
+                                StartStopButton(controller: controller!),
+                                PauseButton(controller: controller!),
+                                SwitchCameraButton(controller: controller!),
+                                AnalyzeImageButton(controller: controller!),
+                              ],
+                            ),
+                          ],
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
     );
   }

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -273,6 +274,19 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
   @override
   Future<void> setZoomScale(double zoomScale) async {
     await methodChannel.invokeMethod<void>('setScale', zoomScale);
+  }
+
+  @override
+  Future<void> setFocusPoint(Offset position) async {
+    final Map<String, dynamic> params = <String, dynamic>{
+      'dx': position.dx,
+      'dy': position.dy,
+    };
+    if (Platform.isIOS) {
+      await methodChannel.invokeMethod<void>('setFocus', params);
+    } else {
+      throw UnimplementedError('setFocusPoint() has not been implemented.');
+    }
   }
 
   @override

--- a/lib/src/mobile_scanner_platform_interface.dart
+++ b/lib/src/mobile_scanner_platform_interface.dart
@@ -83,6 +83,14 @@ abstract class MobileScannerPlatform extends PlatformInterface {
     throw UnimplementedError('setZoomScale() has not been implemented.');
   }
 
+  /// Set the focus position for the camera.
+  ///
+  /// Pass a position in x, y coordinates where top left is (0,0) and
+  /// bottom right is (1,1). The focus is only currently supported on iOS
+  Future<void> setFocusPoint(Offset position) {
+    throw UnimplementedError('setFocusPoint() has not been implemented.');
+  }
+
   /// Start the barcode scanner and prepare a scanner view.
   ///
   /// Upon calling this method, the necessary camera permission will be

--- a/lib/src/objects/start_options.dart
+++ b/lib/src/objects/start_options.dart
@@ -17,6 +17,8 @@ class StartOptions {
     required this.torchEnabled,
     required this.invertImage,
     required this.autoZoom,
+    required this.initialZoom,
+    required this.useUltraWide,
   });
 
   /// The direction for the camera.
@@ -51,6 +53,18 @@ class StartOptions {
   /// option.
   final bool autoZoom;
 
+  /// If set this sets the zoom scale factor when the camera launches
+  /// this avoids having to add a callback to modify the zoom to start at
+  /// a specific position
+  ///
+  /// Only support on iOS
+  final double initialZoom;
+
+  /// Whether we should default to the ultra-wide camera if available
+  ///
+  /// Only supported on iOS.
+  final bool useUltraWide;
+
   /// Converts this object to a map.
   Map<String, Object?> toMap() {
     return <String, Object?>{
@@ -68,6 +82,8 @@ class StartOptions {
       'torch': torchEnabled,
       'invertImage': invertImage,
       'autoZoom': autoZoom,
+      'initialZoom': initialZoom,
+      'useUltraWide': useUltraWide,
     };
   }
 }

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -259,6 +259,11 @@ class MobileScannerWeb extends MobileScannerPlatform {
   }
 
   @override
+  Future<void> setFocusPoint(Offset position) {
+    throw UnimplementedError('setFocusPoint() has not been implemented.');
+  }
+
+  @override
   Future<MobileScannerViewAttributes> start(StartOptions startOptions) async {
     if (_barcodeReader != null) {
       if (_barcodeReader!.paused ?? false) {


### PR DESCRIPTION
This pull request adds a couple enhancements to the package. It adds a `setFocus` parameter that allows the camera to change focus, similar to the current `setZoom` functionality. 

It also adds two new options, `initialZoom` and `useUltraWide`, to the `startCamera` method. The `initialZoom` parameter allows setting the camera's initial zoom scale, while the `useUltraWide` parameter enables the ultra-wide camera on iOS (And so fixes #1239)

I tried to follow the coding patterns and style you guys used in the package, let me know if you want me to modify anything.