### PR TITLE
fix: Update MobileScannerPlugin.swift

### DIFF
--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -464,14 +464,19 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                 let size = ["width": Double(dimensions.width), "height": Double(dimensions.height)]
 #endif
                 // Return the result on the main thread after the session starts.
-                let answer: [String : Any?]
+                var answer: [String : Any?]
 
                 if let device = self.device {
-                    let cameraDirection: Int? = switch(device.position) {
-                        case .back: 1
-                        case .unspecified: nil
-                        case .front: 0
-                        @unknown default: nil
+                    var cameraDirection: Int?
+                    switch(device.position) {
+                        case .back:
+                            cameraDirection = 1
+                        case .front:
+                            cameraDirection = 0
+                        case .unspecified:
+                            cameraDirection = nil
+                        @unknown default:
+                            cameraDirection = nil
                     }
                     
                     answer = [
@@ -1003,11 +1008,11 @@ extension VNBarcodeObservation {
         let height = distanceBetween(adjustedTopLeft, adjustedBottomLeft) * CGFloat(imageHeight)
         var rawBytes: FlutterStandardTypedData? = nil
         
-        if #available(iOS 17.0, macOS 14.0, *) {
-            if let payloadData = payloadData {
-                rawBytes = FlutterStandardTypedData(bytes: payloadData)
-            }
-        }
+        // if #available(iOS 17.0, macOS 14.0, *) {
+        //     if let dataBytes = self.payloadData {
+        //         rawBytes = FlutterStandardTypedData(bytes: dataBytes)
+        //     }
+        // }
 
         let data = [
             // Clockwise, starting from the top-left corner.


### PR DESCRIPTION
Fixes issue [1471](https://github.com/juliansteenbakker/mobile_scanner/issues/1471) on macos 12.

this is kind of a workaround and the debug consoles screams at you if you try to run the app but it runs and doesn't show any other signs of errors.

most probable cause of this was that I was using XCode 14 because I was on macos 12 monterey. the API couldnt find some of the functions when compiling the app for macos.