### PR TITLE
feat(android): add photo capture functionality

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -15,6 +15,10 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.util.Size
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
 import android.view.Surface
 import androidx.annotation.VisibleForTesting
 import androidx.camera.camera2.Camera2Config
@@ -74,6 +78,7 @@ class MobileScanner(
     private var scanner: BarcodeScanner? = null
     private var lastScanned: List<String?>? = null
     private var scannerTimeout = false
+    private var imageCapture: ImageCapture? = null
     private var displayListener: DisplayManager.DisplayListener? = null
 
     /// Configurable variables
@@ -441,19 +446,21 @@ class MobileScanner(
 
             val analysis = analysisBuilder.build().apply { setAnalyzer(executor, captureOutput) }
 
-            try {
-                camera = cameraProvider?.bindToLifecycle(
-                    activity as LifecycleOwner,
-                    cameraPosition,
-                    preview,
-                    analysis
-                )
-                cameraSelector = cameraPosition
-            } catch(exception: Exception) {
-                mobileScannerErrorCallback(NoCamera())
+            imageCapture = ImageCapture.Builder().build()
 
-                return@addListener
-            }
+try {
+    camera = cameraProvider?.bindToLifecycle(
+        activity as LifecycleOwner,
+        cameraPosition,
+        preview,
+        analysis,
+        imageCapture
+    )
+    cameraSelector = cameraPosition
+} catch(exception: Exception) {
+    mobileScannerErrorCallback(NoCamera())
+    return@addListener
+}
 
             camera?.let {
                 // Register the torch listener
@@ -508,6 +515,26 @@ class MobileScanner(
             )
         }, executor)
 
+    }
+    fun capturePhoto(result: MethodChannel.Result) {
+        val imageCapture = this.imageCapture ?: return
+
+        val photoFile = File(activity.externalMediaDirs.first(), "${System.currentTimeMillis()}.jpg")
+
+        val outputOptions = ImageCapture.OutputFileOptions.Builder(photoFile).build()
+
+        imageCapture.takePicture(
+            outputOptions,
+            ContextCompat.getMainExecutor(activity),
+            object : ImageCapture.OnImageSavedCallback {
+                override fun onError(exc: ImageCaptureException) {
+                    result.error("CAPTURE_ERROR", "Failed to capture image: ${exc.message}", null)
+                }
+
+                override fun onImageSaved(output: ImageCapture.OutputFileResults) {
+                    result.success(photoFile.absolutePath)
+                }
+            })
     }
 
     /**

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -151,6 +151,7 @@ class MobileScannerHandler(
             "setScale" -> setScale(call, result)
             "resetScale" -> resetScale(result)
             "updateScanWindow" -> updateScanWindow(call, result)
+            "capturePhoto" -> mobileScanner?.capturePhoto(result)
             else -> result.notImplemented()
         }
     }

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -276,6 +276,14 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
   }
 
   @override
+  Future<String?> capturePhoto() async {
+    if (_textureId == null) {
+      return null;
+    }
+    return methodChannel.invokeMethod<String>('capturePhoto');
+  }
+
+  @override
   Future<MobileScannerViewAttributes> start(StartOptions startOptions) async {
     if (!_pausing && _textureId != null) {
       throw MobileScannerException(

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -281,6 +281,14 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
     return MobileScannerPlatform.instance.buildCameraView();
   }
 
+  Future<String?> capturePhoto() async {
+    _throwIfNotInitialized();
+    if (!value.isRunning) {
+      return null;
+    }
+    return MobileScannerPlatform.instance.capturePhoto();
+  }
+
   /// Reset the zoom scale of the camera.
   ///
   /// Does nothing if the camera is not running.

--- a/lib/src/mobile_scanner_platform_interface.dart
+++ b/lib/src/mobile_scanner_platform_interface.dart
@@ -64,6 +64,11 @@ abstract class MobileScannerPlatform extends PlatformInterface {
     throw UnimplementedError('buildCameraView() has not been implemented.');
   }
 
+  /// Captures a photo and returns the path to the saved image.
+  Future<String?> capturePhoto() {
+    throw UnimplementedError('capturePhoto() has not been implemented.');
+  }
+
   /// Reset the zoom scale, so that the camera is fully zoomed out.
   Future<void> resetZoomScale() {
     throw UnimplementedError('resetZoomScale() has not been implemented.');


### PR DESCRIPTION
This pull request introduces a new feature that allows developers to capture a photo while the mobile_scanner is active. This functionality is currently implemented for Android only.

A new capturePhoto() method has been added to the MobileScannerController, which can be called to trigger a photo capture. The method returns a Future<String?> containing the path to the saved image file on the device.