### PR TITLE
fix: replace deprecated Radio API with RadioGroup

### DIFF
--- a/example/lib/widgets/dialogs/box_fit_dialog.dart
+++ b/example/lib/widgets/dialogs/box_fit_dialog.dart
@@ -70,4 +70,3 @@ class _BoxFitDialogState extends State<BoxFitDialog> {
     );
   }
 }
-

--- a/example/lib/widgets/dialogs/box_fit_dialog.dart
+++ b/example/lib/widgets/dialogs/box_fit_dialog.dart
@@ -34,19 +34,25 @@ class _BoxFitDialogState extends State<BoxFitDialog> {
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          for (final fit in BoxFit.values)
-            RadioListTile<BoxFit>(
-              title: Text(fit.name),
-              value: fit,
-              groupValue: tempBoxFit,
-              onChanged: (BoxFit? value) {
-                if (value != null) {
-                  setState(() {
-                    tempBoxFit = value;
-                  });
-                }
-              },
+          RadioGroup<BoxFit>(
+            groupValue: tempBoxFit,
+            onChanged: (BoxFit? value) {
+              if (value != null) {
+                setState(() {
+                  tempBoxFit = value;
+                });
+              }
+            },
+            child: Column(
+              children: [
+                for (final fit in BoxFit.values)
+                  RadioListTile<BoxFit>(
+                    title: Text(fit.name),
+                    value: fit,
+                  ),
+              ],
             ),
+          ),
         ],
       ),
       actions: [
@@ -64,3 +70,4 @@ class _BoxFitDialogState extends State<BoxFitDialog> {
     );
   }
 }
+

--- a/example/lib/widgets/dialogs/detection_speed_dialog.dart
+++ b/example/lib/widgets/dialogs/detection_speed_dialog.dart
@@ -1,19 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
-/// A dialog widget that allows users to select a detection speed for the
-/// scanner.
+/// A dialog widget that allows users to select a [DetectionSpeed] value.
 ///
-/// The detection speed is chosen from a predefined set of options using radio
-/// buttons. Once the user selects a speed, the dialog closes and returns the
-/// selected value.
+/// The [DetectionSpeed] value is chosen from a list of predefined options using
+/// radio buttons. The selected value is returned when the user confirms their
+/// choice.
 class DetectionSpeedDialog extends StatelessWidget {
   /// Creates a [DetectionSpeedDialog].
   ///
-  /// Requires a [selectedSpeed] which represents the currently chosen speed.
+  /// Requires a [selectedSpeed] which represents the currently selected speed
+  /// option.
   const DetectionSpeedDialog({required this.selectedSpeed, super.key});
 
-  /// The currently selected detection speed.
+  /// The currently selected [DetectionSpeed] option.
   final DetectionSpeed selectedSpeed;
 
   @override
@@ -23,19 +23,27 @@ class DetectionSpeedDialog extends StatelessWidget {
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          for (final speed in DetectionSpeed.values)
-            RadioListTile<DetectionSpeed>(
-              title: Text(speed.name),
-              value: speed,
-              groupValue: selectedSpeed,
-              onChanged: (DetectionSpeed? value) {
-                if (value != null) {
-                  Navigator.pop(context, value);
-                }
-              },
+          RadioGroup<DetectionSpeed>(
+            groupValue: selectedSpeed,
+            onChanged: (DetectionSpeed? value) {
+              if (value != null) {
+                Navigator.pop(context, value);
+              }
+            },
+            child: Column(
+              children: [
+                for (final speed in DetectionSpeed.values)
+                  RadioListTile<DetectionSpeed>(
+                    title: Text(speed.name),
+                    value: speed,
+                  ),
+              ],
             ),
+          ),
         ],
       ),
     );
   }
 }
+
+

--- a/example/lib/widgets/dialogs/detection_speed_dialog.dart
+++ b/example/lib/widgets/dialogs/detection_speed_dialog.dart
@@ -45,5 +45,3 @@ class DetectionSpeedDialog extends StatelessWidget {
     );
   }
 }
-
-

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:meta/meta.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/camera_facing.dart';
 import 'package:mobile_scanner/src/enums/detection_speed.dart';


### PR DESCRIPTION
- Replace deprecated groupValue and onChanged properties in RadioListTile
- Wrap radio buttons with RadioGroup for better accessibility
- Fixes 4 deprecation warnings in dialog widgets