### PR TITLE
fix: Assign event channel streams to null on stop()

### DIFF
--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -400,6 +400,8 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
     _textureId = null;
     _pausing = false;
     _surfaceProducerDelegate = null;
+    _eventsStream = null;
+    _deviceOrientationStream = null;
 
     await methodChannel.invokeMethod<void>('stop', {'force': force});
   }


### PR DESCRIPTION
Fix #1537 