### PR TITLE
16KB対応　mobile_scanner5.2.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,15 +2,14 @@ group 'dev.steenbakker.mobile_scanner'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.22'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.android.tools.build:gradle:8.13.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20"
     }
 }
 
@@ -67,18 +66,18 @@ dependencies {
     def useUnbundled = project.findProperty('dev.steenbakker.mobile_scanner.useUnbundled') ?: false
     if (useUnbundled.toBoolean()) {
         // Dynamically downloaded model via Google Play Services
-        implementation 'com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.0'
+        implementation 'com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.1'
     } else {
         // Bundled model in app
-        implementation 'com.google.mlkit:barcode-scanning:17.2.0'
+        implementation 'com.google.mlkit:barcode-scanning:17.3.0'
     }
 
     // org.jetbrains.kotlin:kotlin-bom artifact purpose is to align kotlin stdlib and related code versions.
     // See: https://youtrack.jetbrains.com/issue/KT-55297/kotlin-stdlib-should-declare-constraints-on-kotlin-stdlib-jdk8-and-kotlin-stdlib-jdk7
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.22"))
 
-    implementation 'androidx.camera:camera-lifecycle:1.3.3'
-    implementation 'androidx.camera:camera-camera2:1.3.3'
+    implementation 'androidx.camera:camera-lifecycle:1.5.0'
+    implementation 'androidx.camera:camera-camera2:1.5.0'
 
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.mockito:mockito-core:5.12.0'    

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -24,7 +24,8 @@ if (flutterVersionName == null) {
 
 android {
     namespace "dev.steenbakker.mobile_scanner_example"
-    compileSdk 34
+    compileSdk 36
+    ndkVersion flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -43,7 +44,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "dev.steenbakker.mobile_scanner_example"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu May 02 10:24:49 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.22" apply false
+    id "com.android.application" version "8.13.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## 概要
- アプリで依存関係のある `mobile_scanner: ^5.2.3`にAndroidの16KB対応を追加
- [support_android_16kb_page_size](https://github.com/iret-kondo/mobile_scanner/releases/tag/support_android_16kb_page_size)を参考に修正。