### PR TITLE
fix: core style

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,1 @@
 include: package:very_good_analysis/analysis_options.yaml
-
-linter:
-  rules:
-    omit_local_variable_types: false
-    specify_nonobvious_local_variable_types: true

--- a/lib/src/method_channel/android_surface_producer_delegate.dart
+++ b/lib/src/method_channel/android_surface_producer_delegate.dart
@@ -28,7 +28,7 @@ class AndroidSurfaceProducerDelegate {
       'naturalDeviceOrientation': final String naturalDeviceOrientation,
       'sensorOrientation': final int sensorOrientation,
     }) {
-      final DeviceOrientation naturalOrientation =
+      final naturalOrientation =
           naturalDeviceOrientation.parseDeviceOrientation();
 
       return AndroidSurfaceProducerDelegate(

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -93,14 +93,12 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
       return null;
     }
 
-    final barcodes =
-        data.cast<Map<Object?, Object?>>();
+    final barcodes = data.cast<Map<Object?, Object?>>();
 
     if (defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS ||
         defaultTargetPlatform == TargetPlatform.macOS) {
-      final imageData =
-          event['image'] as Map<Object?, Object?>?;
+      final imageData = event['image'] as Map<Object?, Object?>?;
       final image = imageData?['bytes'] as Uint8List?;
       final width = imageData?['width'] as double?;
       final height = imageData?['height'] as double?;
@@ -143,10 +141,9 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
   /// Throws a [MobileScannerException] if the permission is not granted.
   Future<void> _requestCameraPermission() async {
     try {
-      final authorizationState =
-          MobileScannerAuthorizationState.fromRawValue(
-            await methodChannel.invokeMethod<int>('state') ?? 0,
-          );
+      final authorizationState = MobileScannerAuthorizationState.fromRawValue(
+        await methodChannel.invokeMethod<int>('state') ?? 0,
+      );
 
       switch (authorizationState) {
         // Authorization was already granted, no need to request it again.
@@ -209,17 +206,19 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
     List<BarcodeFormat> formats = const <BarcodeFormat>[],
   }) async {
     try {
-      final result = await methodChannel
-          .invokeMapMethod<Object?, Object?>('analyzeImage', {
-            'filePath': path,
-            'formats':
-                formats.isEmpty
-                    ? null
-                    : [
-                      for (final BarcodeFormat format in formats)
-                        if (format != BarcodeFormat.unknown) format.rawValue,
-                    ],
-          });
+      final result = await methodChannel.invokeMapMethod<Object?, Object?>(
+        'analyzeImage',
+        {
+          'filePath': path,
+          'formats':
+              formats.isEmpty
+                  ? null
+                  : [
+                    for (final BarcodeFormat format in formats)
+                      if (format != BarcodeFormat.unknown) format.rawValue,
+                  ],
+        },
+      );
 
       return _parseBarcode(result);
     } on PlatformException catch (error) {

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -87,23 +87,23 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
       return null;
     }
 
-    final Object? data = event['data'];
+    final data = event['data'];
 
     if (data == null || data is! List<Object?>) {
       return null;
     }
 
-    final List<Map<Object?, Object?>> barcodes =
+    final barcodes =
         data.cast<Map<Object?, Object?>>();
 
     if (defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS ||
         defaultTargetPlatform == TargetPlatform.macOS) {
-      final Map<Object?, Object?>? imageData =
+      final imageData =
           event['image'] as Map<Object?, Object?>?;
-      final Uint8List? image = imageData?['bytes'] as Uint8List?;
-      final double? width = imageData?['width'] as double?;
-      final double? height = imageData?['height'] as double?;
+      final image = imageData?['bytes'] as Uint8List?;
+      final width = imageData?['width'] as double?;
+      final height = imageData?['height'] as double?;
 
       return BarcodeCapture(
         raw: event,
@@ -143,7 +143,7 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
   /// Throws a [MobileScannerException] if the permission is not granted.
   Future<void> _requestCameraPermission() async {
     try {
-      final MobileScannerAuthorizationState authorizationState =
+      final authorizationState =
           MobileScannerAuthorizationState.fromRawValue(
             await methodChannel.invokeMethod<int>('state') ?? 0,
           );
@@ -156,7 +156,7 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
         // So if the permission was denied, request it again.
         case MobileScannerAuthorizationState.denied:
         case MobileScannerAuthorizationState.undetermined:
-          final bool permissionGranted =
+          final permissionGranted =
               await methodChannel.invokeMethod<bool>('request') ?? false;
 
           if (!permissionGranted) {
@@ -209,7 +209,7 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
     List<BarcodeFormat> formats = const <BarcodeFormat>[],
   }) async {
     try {
-      final Map<Object?, Object?>? result = await methodChannel
+      final result = await methodChannel
           .invokeMapMethod<Object?, Object?>('analyzeImage', {
             'filePath': path,
             'formats':
@@ -282,7 +282,7 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
       throw UnimplementedError('setFocusPoint() has not been implemented.');
     }
 
-    final Map<String, Object?> params = <String, Object?>{
+    final params = <String, Object?>{
       'dx': position.dx,
       'dy': position.dy,
     };
@@ -330,7 +330,7 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
       );
     }
 
-    final int? textureId = startResult['textureId'] as int?;
+    final textureId = startResult['textureId'] as int?;
 
     if (textureId == null) {
       throw const MobileScannerException(
@@ -341,7 +341,7 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
       );
     }
 
-    final CameraFacing cameraDirection = CameraFacing.fromRawValue(
+    final cameraDirection = CameraFacing.fromRawValue(
       startResult['cameraDirection'] as int?,
     );
 
@@ -364,8 +364,8 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
       initialDeviceOrientation = orientation.parseDeviceOrientation();
     }
 
-    final int? numberOfCameras = startResult['numberOfCameras'] as int?;
-    final TorchState currentTorchState = TorchState.fromRawValue(
+    final numberOfCameras = startResult['numberOfCameras'] as int?;
+    final currentTorchState = TorchState.fromRawValue(
       startResult['currentTorchState'] as int? ?? -1,
     );
 

--- a/lib/src/method_channel/rotated_preview.dart
+++ b/lib/src/method_channel/rotated_preview.dart
@@ -27,7 +27,7 @@ final class RotatedPreview extends StatefulWidget {
     required double sensorOrientationDegrees,
     Key? key,
   }) {
-    final int facingSignForDirection = switch (cameraFacingDirection) {
+    final facingSignForDirection = switch (cameraFacingDirection) {
       CameraFacing.front => 1,
       CameraFacing.back => -1,
       CameraFacing.unknown => 1,
@@ -101,7 +101,7 @@ final class _RotatedPreviewState extends State<RotatedPreview> {
     required double sensorOrientationDegrees,
     required int sign,
   }) {
-    final double deviceOrientationDegrees = switch (orientation) {
+    final deviceOrientationDegrees = switch (orientation) {
       DeviceOrientation.portraitUp => 0,
       DeviceOrientation.landscapeRight => 90,
       DeviceOrientation.portraitDown => 180,
@@ -110,7 +110,7 @@ final class _RotatedPreviewState extends State<RotatedPreview> {
 
     // Rotate the camera preview according to
     // https://developer.android.com/media/camera/camera2/camera-preview#orientation_calculation.
-    double rotationDegrees =
+    var rotationDegrees =
         (sensorOrientationDegrees - deviceOrientationDegrees * sign + 360) %
         360;
 
@@ -127,7 +127,7 @@ final class _RotatedPreviewState extends State<RotatedPreview> {
 
   @override
   Widget build(BuildContext context) {
-    final double rotationDegrees = _computeRotationDegrees(
+    final rotationDegrees = _computeRotationDegrees(
       deviceOrientation,
       sensorOrientationDegrees: widget.sensorOrientationDegrees,
       sign: widget.facingSign,

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -270,10 +270,8 @@ class _MobileScannerState extends State<MobileScanner>
                   child: scannerWidget,
                   onTapUp: (details) async {
                     final size = MediaQuery.sizeOf(context);
-                    final relativeX =
-                        details.globalPosition.dx / size.width;
-                    final relativeY =
-                        details.globalPosition.dy / size.height;
+                    final relativeX = details.globalPosition.dx / size.width;
+                    final relativeY = details.globalPosition.dy / size.height;
 
                     await controller.setFocusPoint(
                       Offset(relativeX, relativeY),

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -183,7 +183,7 @@ class _MobileScannerState extends State<MobileScanner>
       return;
     }
 
-    final Rect newScanWindow = calculateScanWindowRelativeToTextureInPercentage(
+    final newScanWindow = calculateScanWindowRelativeToTextureInPercentage(
       widget.fit,
       widget.scanWindow!,
       textureSize: scannerState.size,
@@ -215,8 +215,8 @@ class _MobileScannerState extends State<MobileScanner>
       return;
     }
 
-    final double dx = (newScanWindow.width - scanWindow!.width).abs();
-    final double dy = (newScanWindow.height - scanWindow!.height).abs();
+    final dx = (newScanWindow.width - scanWindow!.width).abs();
+    final dy = (newScanWindow.height - scanWindow!.height).abs();
 
     // The new scan window has changed enough, allow updating the scan window.
     if (dx >= widget.scanWindowUpdateThreshold ||
@@ -238,7 +238,7 @@ class _MobileScannerState extends State<MobileScanner>
           return widget.placeholderBuilder?.call(context) ?? defaultPlaceholder;
         }
 
-        final MobileScannerException? error = value.error;
+        final error = value.error;
         if (error != null) {
           final Widget defaultError = ScannerErrorWidget(error: error);
 
@@ -249,7 +249,7 @@ class _MobileScannerState extends State<MobileScanner>
           builder: (context, constraints) {
             _maybeUpdateScanWindow(value, constraints);
 
-            final Widget? overlay = widget.overlayBuilder?.call(
+            final overlay = widget.overlayBuilder?.call(
               context,
               constraints,
             );
@@ -269,10 +269,10 @@ class _MobileScannerState extends State<MobileScanner>
                 return GestureDetector(
                   child: scannerWidget,
                   onTapUp: (details) async {
-                    final Size size = MediaQuery.sizeOf(context);
-                    final double relativeX =
+                    final size = MediaQuery.sizeOf(context);
+                    final relativeX =
                         details.globalPosition.dx / size.width;
-                    final double relativeY =
+                    final relativeY =
                         details.globalPosition.dy / size.height;
 
                     await controller.setFocusPoint(

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -16,7 +16,6 @@ import 'package:mobile_scanner/src/enums/torch_state.dart';
 import 'package:mobile_scanner/src/method_channel/mobile_scanner_method_channel.dart';
 import 'package:mobile_scanner/src/mobile_scanner_exception.dart';
 import 'package:mobile_scanner/src/mobile_scanner_platform_interface.dart';
-import 'package:mobile_scanner/src/mobile_scanner_view_attributes.dart';
 import 'package:mobile_scanner/src/objects/barcode_capture.dart';
 import 'package:mobile_scanner/src/objects/mobile_scanner_state.dart';
 import 'package:mobile_scanner/src/objects/start_options.dart';
@@ -242,7 +241,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
 
     _disposeListeners();
 
-    final TorchState oldTorchState = value.torchState;
+    final oldTorchState = value.torchState;
 
     // After the camera stopped, set the torch state to off,
     // as the torch state callback is never called when the camera is stopped.
@@ -319,7 +318,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
       return;
     }
 
-    final double clampedZoomScale = zoomScale.clamp(0.0, 1.0);
+    final clampedZoomScale = zoomScale.clamp(0.0, 1.0);
 
     // Update the zoom scale state to the new state.
     // When the platform has updated the zoom scale,
@@ -339,7 +338,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
       return;
     }
 
-    final Offset clampedPosition = Offset(
+    final clampedPosition = Offset(
       position.dx.clamp(0, 1),
       position.dy.clamp(0, 1),
     );
@@ -426,7 +425,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
       value = value.copyWith(isStarting: true);
     }
 
-    final StartOptions options = StartOptions(
+    final options = StartOptions(
       cameraDirection: cameraDirection ?? facing,
       cameraResolution: cameraResolution,
       detectionSpeed: detectionSpeed,
@@ -442,7 +441,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
     try {
       _setupListeners();
 
-      final MobileScannerViewAttributes viewAttributes =
+      final viewAttributes =
           await MobileScannerPlatform.instance.start(options);
 
       if (!_isDisposed) {
@@ -508,8 +507,8 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   Future<void> switchCamera() async {
     _throwIfNotInitialized();
 
-    final int? availableCameras = value.availableCameras;
-    final CameraFacing cameraDirection = value.cameraDirection;
+    final availableCameras = value.availableCameras;
+    final cameraDirection = value.cameraDirection;
 
     // Do nothing if the amount of cameras is less than 2 cameras.
     // If the the current platform does not provide the amount of cameras,
@@ -552,7 +551,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
       return;
     }
 
-    final TorchState torchState = value.torchState;
+    final torchState = value.torchState;
 
     if (torchState == TorchState.unavailable) {
       return;

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -441,8 +441,9 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
     try {
       _setupListeners();
 
-      final viewAttributes =
-          await MobileScannerPlatform.instance.start(options);
+      final viewAttributes = await MobileScannerPlatform.instance.start(
+        options,
+      );
 
       if (!_isDisposed) {
         value = value.copyWith(

--- a/lib/src/objects/address.dart
+++ b/lib/src/objects/address.dart
@@ -10,8 +10,8 @@ class Address {
 
   /// Creates a new [Address] instance from a map.
   factory Address.fromNative(Map<Object?, Object?> data) {
-    final List<Object?>? addressLines = data['addressLines'] as List<Object?>?;
-    final AddressType type = AddressType.fromRawValue(
+    final addressLines = data['addressLines'] as List<Object?>?;
+    final type = AddressType.fromRawValue(
       data['type'] as int? ?? 0,
     );
 

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -40,26 +40,26 @@ class Barcode {
 
   /// Creates a new [Barcode] instance from the given [data].
   factory Barcode.fromNative(Map<Object?, Object?> data) {
-    final Map<Object?, Object?>? calendarEvent =
+    final calendarEvent =
         data['calendarEvent'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? contactInfo =
+    final contactInfo =
         data['contactInfo'] as Map<Object?, Object?>?;
-    final List<Object?>? corners = data['corners'] as List<Object?>?;
-    final Map<Object?, Object?>? driverLicense =
+    final corners = data['corners'] as List<Object?>?;
+    final driverLicense =
         data['driverLicense'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? email =
+    final email =
         data['email'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? geoPoint =
+    final geoPoint =
         data['geoPoint'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? phone =
+    final phone =
         data['phone'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? sms = data['sms'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? size = data['size'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? url = data['url'] as Map<Object?, Object?>?;
-    final Map<Object?, Object?>? wifi = data['wifi'] as Map<Object?, Object?>?;
+    final sms = data['sms'] as Map<Object?, Object?>?;
+    final size = data['size'] as Map<Object?, Object?>?;
+    final url = data['url'] as Map<Object?, Object?>?;
+    final wifi = data['wifi'] as Map<Object?, Object?>?;
 
-    final double? barcodeWidth = size?['width'] as double?;
-    final double? barcodeHeight = size?['height'] as double?;
+    final barcodeWidth = size?['width'] as double?;
+    final barcodeHeight = size?['height'] as double?;
 
     return Barcode(
       calendarEvent:
@@ -75,8 +75,8 @@ class Barcode {
                 corners.cast<Map<Object?, Object?>>().map((
                   Map<Object?, Object?> e,
                 ) {
-                  final double x = e['x']! as double;
-                  final double y = e['y']! as double;
+                  final x = e['x']! as double;
+                  final y = e['y']! as double;
 
                   return Offset(x, y);
                 }),
@@ -226,8 +226,8 @@ class Barcode {
     // The size and corners are in the same coordinate space,
     // which is the camera input.
     // If the barcode size is unknown, scale to 0,0.
-    final double scaleX = size.width > 0 ? targetSize.width / size.width : 0;
-    final double scaleY = size.height > 0 ? targetSize.height / size.height : 0;
+    final scaleX = size.width > 0 ? targetSize.width / size.width : 0;
+    final scaleY = size.height > 0 ? targetSize.height / size.height : 0;
 
     return [
       for (final Offset offset in corners)

--- a/lib/src/objects/barcode.dart
+++ b/lib/src/objects/barcode.dart
@@ -40,19 +40,13 @@ class Barcode {
 
   /// Creates a new [Barcode] instance from the given [data].
   factory Barcode.fromNative(Map<Object?, Object?> data) {
-    final calendarEvent =
-        data['calendarEvent'] as Map<Object?, Object?>?;
-    final contactInfo =
-        data['contactInfo'] as Map<Object?, Object?>?;
+    final calendarEvent = data['calendarEvent'] as Map<Object?, Object?>?;
+    final contactInfo = data['contactInfo'] as Map<Object?, Object?>?;
     final corners = data['corners'] as List<Object?>?;
-    final driverLicense =
-        data['driverLicense'] as Map<Object?, Object?>?;
-    final email =
-        data['email'] as Map<Object?, Object?>?;
-    final geoPoint =
-        data['geoPoint'] as Map<Object?, Object?>?;
-    final phone =
-        data['phone'] as Map<Object?, Object?>?;
+    final driverLicense = data['driverLicense'] as Map<Object?, Object?>?;
+    final email = data['email'] as Map<Object?, Object?>?;
+    final geoPoint = data['geoPoint'] as Map<Object?, Object?>?;
+    final phone = data['phone'] as Map<Object?, Object?>?;
     final sms = data['sms'] as Map<Object?, Object?>?;
     final size = data['size'] as Map<Object?, Object?>?;
     final url = data['url'] as Map<Object?, Object?>?;

--- a/lib/src/objects/contact_info.dart
+++ b/lib/src/objects/contact_info.dart
@@ -19,11 +19,11 @@ class ContactInfo {
 
   /// Create a new [ContactInfo] instance from a map.
   factory ContactInfo.fromNative(Map<Object?, Object?> data) {
-    final List<Object?>? addresses = data['addresses'] as List<Object?>?;
-    final List<Object?>? emails = data['emails'] as List<Object?>?;
-    final List<Object?>? phones = data['phones'] as List<Object?>?;
-    final List<Object?>? urls = data['urls'] as List<Object?>?;
-    final Map<Object?, Object?>? name = data['name'] as Map<Object?, Object?>?;
+    final addresses = data['addresses'] as List<Object?>?;
+    final emails = data['emails'] as List<Object?>?;
+    final phones = data['phones'] as List<Object?>?;
+    final urls = data['urls'] as List<Object?>?;
+    final name = data['name'] as Map<Object?, Object?>?;
 
     return ContactInfo(
       addresses:

--- a/lib/src/objects/geo_point.dart
+++ b/lib/src/objects/geo_point.dart
@@ -8,8 +8,8 @@ class GeoPoint {
   /// If the data does not contain valid GeoPoint coordinates,
   /// then `0,0` is returned.
   factory GeoPoint.fromNative(Map<Object?, Object?> data) {
-    final double? latitude = data['latitude'] as double?;
-    final double? longitude = data['longitude'] as double?;
+    final latitude = data['latitude'] as double?;
+    final longitude = data['longitude'] as double?;
 
     // If either is not set, then this GeoPoint is invalid.
     // Return the geographic center as fallback.

--- a/lib/src/overlay/barcode_overlay.dart
+++ b/lib/src/overlay/barcode_overlay.dart
@@ -58,7 +58,7 @@ class _BarcodeOverlayState extends State<BarcodeOverlay> {
         return StreamBuilder<BarcodeCapture>(
           stream: widget.controller.barcodes,
           builder: (context, snapshot) {
-            final BarcodeCapture? barcodeCapture = snapshot.data;
+            final barcodeCapture = snapshot.data;
 
             // No barcode or preview size.
             if (barcodeCapture == null ||

--- a/lib/src/overlay/barcode_painter.dart
+++ b/lib/src/overlay/barcode_painter.dart
@@ -65,8 +65,11 @@ class BarcodePainter extends CustomPainter {
     final adjustedCameraPreviewSize =
         isLandscape ? cameraPreviewSize.flipped : cameraPreviewSize;
 
-    final ratios =
-        calculateBoxFitRatio(boxFit, adjustedCameraPreviewSize, size);
+    final ratios = calculateBoxFitRatio(
+      boxFit,
+      adjustedCameraPreviewSize,
+      size,
+    );
 
     final horizontalPadding =
         (adjustedCameraPreviewSize.width * ratios.widthRatio - size.width) / 2;
@@ -225,8 +228,7 @@ class BarcodePainter extends CustomPainter {
     case BoxFit.scaleDown:
       // If the content is larger than the large box, scale down to fit;
       // otherwise, no scaling
-      final ratio =
-          math.min(1, math.min(widthRatio, heightRatio)).toDouble();
+      final ratio = math.min(1, math.min(widthRatio, heightRatio)).toDouble();
       return (widthRatio: ratio, heightRatio: ratio);
   }
 }

--- a/lib/src/overlay/barcode_painter.dart
+++ b/lib/src/overlay/barcode_painter.dart
@@ -58,23 +58,23 @@ class BarcodePainter extends CustomPainter {
       return;
     }
 
-    final bool isLandscape =
+    final isLandscape =
         deviceOrientation == DeviceOrientation.landscapeLeft ||
         deviceOrientation == DeviceOrientation.landscapeRight;
 
-    final Size adjustedCameraPreviewSize =
+    final adjustedCameraPreviewSize =
         isLandscape ? cameraPreviewSize.flipped : cameraPreviewSize;
 
-    final ({double heightRatio, double widthRatio}) ratios =
+    final ratios =
         calculateBoxFitRatio(boxFit, adjustedCameraPreviewSize, size);
 
-    final double horizontalPadding =
+    final horizontalPadding =
         (adjustedCameraPreviewSize.width * ratios.widthRatio - size.width) / 2;
-    final double verticalPadding =
+    final verticalPadding =
         (adjustedCameraPreviewSize.height * ratios.heightRatio - size.height) /
         2;
 
-    final List<Offset> adjustedOffset = [
+    final adjustedOffset = <Offset>[
       for (final offset in barcodeCorners)
         Offset(
           offset.dx * ratios.widthRatio - horizontalPadding,
@@ -85,7 +85,7 @@ class BarcodePainter extends CustomPainter {
     if (adjustedOffset.length < 4) return;
 
     // Draw the rotated rectangle
-    final Path path = Path()..addPolygon(adjustedOffset, true);
+    final path = Path()..addPolygon(adjustedOffset, true);
 
     final paint =
         Paint()
@@ -96,23 +96,23 @@ class BarcodePainter extends CustomPainter {
     canvas.drawPath(path, paint);
 
     // Find center point of the barcode
-    final double centerX = (adjustedOffset[0].dx + adjustedOffset[2].dx) / 2;
-    final double centerY = (adjustedOffset[0].dy + adjustedOffset[2].dy) / 2;
-    final Offset center = Offset(centerX, centerY);
+    final centerX = (adjustedOffset[0].dx + adjustedOffset[2].dx) / 2;
+    final centerY = (adjustedOffset[0].dy + adjustedOffset[2].dy) / 2;
+    final center = Offset(centerX, centerY);
 
     // Calculate rotation angle
-    final double angle = math.atan2(
+    final angle = math.atan2(
       adjustedOffset[1].dy - adjustedOffset[0].dy,
       adjustedOffset[1].dx - adjustedOffset[0].dx,
     );
 
     // Set a smaller font size with auto-resizing logic
-    final double textSize =
+    final textSize =
         (barcodeSize.width * ratios.widthRatio) *
         0.08; // Scales with barcode size
     const double minTextSize = 6; // Minimum readable size
     const double maxTextSize = 12; // Maximum size
-    final double finalTextSize = textSize.clamp(minTextSize, maxTextSize);
+    final finalTextSize = textSize.clamp(minTextSize, maxTextSize);
 
     // Draw barcode value inside the overlay with rotation
     final textSpan = TextSpan(
@@ -127,8 +127,8 @@ class BarcodePainter extends CustomPainter {
     textPainter.text = textSpan;
     textPainter.layout(maxWidth: barcodeSize.width * ratios.widthRatio * 0.6);
 
-    final double textWidth = textPainter.width;
-    final double textHeight = textPainter.height;
+    final textWidth = textPainter.width;
+    final textHeight = textPainter.height;
 
     canvas
       ..save()
@@ -136,13 +136,13 @@ class BarcodePainter extends CustomPainter {
       ..rotate(angle) // Rotate the text to match the barcode
       ..translate(-center.dx, -center.dy);
 
-    final Rect textRect = Rect.fromCenter(
+    final textRect = Rect.fromCenter(
       center: center,
       width: textWidth * 1.1,
       height: textHeight * 1.1,
     );
 
-    final RRect textBackground = RRect.fromRectAndRadius(
+    final textBackground = RRect.fromRectAndRadius(
       textRect,
       const Radius.circular(6),
     );
@@ -160,7 +160,7 @@ class BarcodePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(BarcodePainter oldDelegate) {
-    const ListEquality<Offset> listEquality = ListEquality<Offset>();
+    const listEquality = ListEquality<Offset>();
 
     return !listEquality.equals(oldDelegate.barcodeCorners, barcodeCorners) ||
         oldDelegate.barcodeSize != barcodeSize ||
@@ -191,8 +191,8 @@ class BarcodePainter extends CustomPainter {
   }
 
   // Calculate the scaling ratios for width and height
-  final double widthRatio = size.width / cameraPreviewSize.width;
-  final double heightRatio = size.height / cameraPreviewSize.height;
+  final widthRatio = size.width / cameraPreviewSize.width;
+  final heightRatio = size.height / cameraPreviewSize.height;
 
   switch (boxFit) {
     case BoxFit.fill:
@@ -225,7 +225,7 @@ class BarcodePainter extends CustomPainter {
     case BoxFit.scaleDown:
       // If the content is larger than the large box, scale down to fit;
       // otherwise, no scaling
-      final double ratio =
+      final ratio =
           math.min(1, math.min(widthRatio, heightRatio)).toDouble();
       return (widthRatio: ratio, heightRatio: ratio);
   }

--- a/lib/src/overlay/scan_window_painter.dart
+++ b/lib/src/overlay/scan_window_painter.dart
@@ -48,7 +48,7 @@ class ScanWindowPainter extends CustomPainter {
     final backgroundPath = Path()..addRect(Offset.zero & size);
 
     // The cutout rect depends on the border radius.
-    final RRect cutoutRect =
+    final cutoutRect =
         borderRadius == BorderRadius.zero
             ? RRect.fromRectAndCorners(scanWindow)
             : RRect.fromRectAndCorners(
@@ -60,22 +60,22 @@ class ScanWindowPainter extends CustomPainter {
             );
 
     // The cutout path is always in the center.
-    final Path cutoutPath = Path()..addRRect(cutoutRect);
+    final cutoutPath = Path()..addRRect(cutoutRect);
 
     // Combine the two paths: overlay minus the cutout area
-    final Path overlayWithCutoutPath = Path.combine(
+    final overlayWithCutoutPath = Path.combine(
       PathOperation.difference,
       backgroundPath,
       cutoutPath,
     );
 
-    final Paint overlayWithCutoutPaint =
+    final overlayWithCutoutPaint =
         Paint()
           ..color = color
           ..style = PaintingStyle.fill
           ..blendMode = BlendMode.srcOver; // android
 
-    final Paint borderPaint =
+    final borderPaint =
         Paint()
           ..color = borderColor
           ..style = borderStyle

--- a/lib/src/scan_window_calculation.dart
+++ b/lib/src/scan_window_calculation.dart
@@ -25,15 +25,15 @@ Rect calculateScanWindowRelativeToTextureInPercentage(
 }) {
   // Convert the texture size to a size in widget-space, with the box fit
   // applied.
-  final FittedSizes fittedTextureSize = applyBoxFit(
+  final fittedTextureSize = applyBoxFit(
     fit,
     textureSize,
     widgetSize,
   );
 
   // Get the correct scaling values depending on the given BoxFit mode
-  double sx = fittedTextureSize.destination.width / textureSize.width;
-  double sy = fittedTextureSize.destination.height / textureSize.height;
+  var sx = fittedTextureSize.destination.width / textureSize.width;
+  var sy = fittedTextureSize.destination.height / textureSize.height;
 
   switch (fit) {
     case BoxFit.fill:
@@ -62,7 +62,7 @@ Rect calculateScanWindowRelativeToTextureInPercentage(
 
   // Fit the texture size to the widget rectangle given by the scaling values
   // above.
-  final Rect textureWindow = Alignment.center.inscribe(
+  final textureWindow = Alignment.center.inscribe(
     Size(textureSize.width * sx, textureSize.height * sy),
     Rect.fromLTWH(0, 0, widgetSize.width, widgetSize.height),
   );
@@ -77,19 +77,19 @@ Rect calculateScanWindowRelativeToTextureInPercentage(
 
   // Clip the scan window in texture coordinates with the texture bounds.
   // This prevents percentages outside the range [0; 1].
-  final Rect clippedScanWndInTexSpace = scanWindowInTexSpace.intersect(
+  final clippedScanWndInTexSpace = scanWindowInTexSpace.intersect(
     Rect.fromLTWH(0, 0, textureSize.width, textureSize.height),
   );
 
   // Compute relative rectangle coordinates,
   // with respect to the texture size, i.e. scan image.
-  final double percentageLeft =
+  final percentageLeft =
       clippedScanWndInTexSpace.left / textureSize.width;
-  final double percentageTop =
+  final percentageTop =
       clippedScanWndInTexSpace.top / textureSize.height;
-  final double percentageRight =
+  final percentageRight =
       clippedScanWndInTexSpace.right / textureSize.width;
-  final double percentageBottom =
+  final percentageBottom =
       clippedScanWndInTexSpace.bottom / textureSize.height;
 
   // This rectangle can be used to cut out a rectangle of the scan image.

--- a/lib/src/scan_window_calculation.dart
+++ b/lib/src/scan_window_calculation.dart
@@ -83,14 +83,10 @@ Rect calculateScanWindowRelativeToTextureInPercentage(
 
   // Compute relative rectangle coordinates,
   // with respect to the texture size, i.e. scan image.
-  final percentageLeft =
-      clippedScanWndInTexSpace.left / textureSize.width;
-  final percentageTop =
-      clippedScanWndInTexSpace.top / textureSize.height;
-  final percentageRight =
-      clippedScanWndInTexSpace.right / textureSize.width;
-  final percentageBottom =
-      clippedScanWndInTexSpace.bottom / textureSize.height;
+  final percentageLeft = clippedScanWndInTexSpace.left / textureSize.width;
+  final percentageTop = clippedScanWndInTexSpace.top / textureSize.height;
+  final percentageRight = clippedScanWndInTexSpace.right / textureSize.width;
+  final percentageBottom = clippedScanWndInTexSpace.bottom / textureSize.height;
 
   // This rectangle can be used to cut out a rectangle of the scan image.
   return Rect.fromLTRB(

--- a/lib/src/web/barcode_reader.dart
+++ b/lib/src/web/barcode_reader.dart
@@ -85,9 +85,9 @@ abstract class BarcodeReader {
       return;
     }
 
-    final Completer<void> completer = Completer();
+    final completer = Completer<void>();
 
-    final HTMLScriptElement script =
+    final script =
         HTMLScriptElement()
           ..id = scriptId
           ..async = true

--- a/lib/src/web/media_track_constraints_delegate.dart
+++ b/lib/src/web/media_track_constraints_delegate.dart
@@ -12,7 +12,7 @@ final class MediaTrackConstraintsDelegate {
 
   /// Get the camera direction from the given [videoStream].
   CameraFacing getCameraDirection(MediaStream? videoStream) {
-    final MediaTrackSettings? trackSettings = getSettings(videoStream);
+    final trackSettings = getSettings(videoStream);
 
     return switch (trackSettings?.facingModeNullable) {
       'environment' => CameraFacing.back,
@@ -34,15 +34,15 @@ final class MediaTrackConstraintsDelegate {
 
   /// Get the settings for the given [mediaStream].
   MediaTrackSettings? getSettings(MediaStream? mediaStream) {
-    final List<MediaStreamTrack>? tracks = mediaStream?.getVideoTracks().toDart;
+    final tracks = mediaStream?.getVideoTracks().toDart;
 
     if (tracks == null || tracks.isEmpty) {
       return null;
     }
 
-    final MediaStreamTrack track = tracks.first;
+    final track = tracks.first;
 
-    final MediaTrackSettings settings = track.getSettings();
+    final settings = track.getSettings();
 
     if (settings.facingModeNullable == null) {
       return MediaTrackSettings(width: settings.width, height: settings.height);

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -82,7 +82,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
   /// Create the [HTMLVideoElement] along with its parent container
   /// [HTMLDivElement].
   HTMLVideoElement _createVideoElement(int textureId) {
-    final HTMLVideoElement videoElement = HTMLVideoElement();
+    final videoElement = HTMLVideoElement();
 
     videoElement.style
       ..height = '100%'
@@ -135,7 +135,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
     HTMLVideoElement videoElement,
     MediaStream videoStream,
   ) {
-    final MediaTrackSettings? settings = _settingsDelegate.getSettings(
+    final settings = _settingsDelegate.getSettings(
       videoStream,
     );
 
@@ -146,7 +146,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
       return;
     }
 
-    final MediaStreamTrack videoTrack =
+    final videoTrack =
         videoStream.getVideoTracks().toDart.first;
 
     // On MacOS, even though the facing mode is supported, it is not reported.
@@ -174,7 +174,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
       );
     }
 
-    final MediaTrackSupportedConstraints capabilities =
+    final capabilities =
         window.navigator.mediaDevices.getSupportedConstraints();
 
     final MediaStreamConstraints constraints;
@@ -182,7 +182,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
     if (capabilities.isUndefinedOrNull || !capabilities.facingMode) {
       constraints = MediaStreamConstraints(video: true.toJS);
     } else {
-      final String facingMode = _settingsDelegate.getFacingMode(
+      final facingMode = _settingsDelegate.getFacingMode(
         cameraDirection,
       );
 
@@ -193,14 +193,14 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
     try {
       // Retrieving the media devices requests the camera permission.
-      final MediaStream videoStream =
+      final videoStream =
           await window.navigator.mediaDevices.getUserMedia(constraints).toDart;
 
       return videoStream;
     } on DOMException catch (error, stackTrace) {
-      final String errorMessage = error.toString();
+      final errorMessage = error.toString();
 
-      MobileScannerErrorCode errorCode = MobileScannerErrorCode.genericError;
+      var errorCode = MobileScannerErrorCode.genericError;
 
       // Handle both unsupported and permission errors from the web.
       if (errorMessage.contains('NotFoundError') ||
@@ -269,7 +269,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
       if (_barcodeReader!.paused ?? false) {
         await _barcodeReader?.resume();
 
-        final CameraFacing cameraDirection = _settingsDelegate
+        final cameraDirection = _settingsDelegate
             .getCameraDirection(_barcodeReader?.videoStream);
 
         return MobileScannerViewAttributes(
@@ -301,7 +301,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
     );
 
     // Request camera permissions and prepare the video stream.
-    final MediaStream videoStream = await _prepareVideoStream(
+    final videoStream = await _prepareVideoStream(
       startOptions.cameraDirection,
     );
 
@@ -357,13 +357,13 @@ class MobileScannerWeb extends MobileScannerPlatform {
         cancelOnError: false,
       );
 
-      final bool hasTorch = await _barcodeReader?.hasTorch() ?? false;
+      final hasTorch = await _barcodeReader?.hasTorch() ?? false;
 
       if (hasTorch && startOptions.torchEnabled) {
         await _barcodeReader?.setTorchState(TorchState.on);
       }
 
-      final CameraFacing cameraDirection = _settingsDelegate.getCameraDirection(
+      final cameraDirection = _settingsDelegate.getCameraDirection(
         videoStream,
       );
 

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -146,8 +146,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
       return;
     }
 
-    final videoTrack =
-        videoStream.getVideoTracks().toDart.first;
+    final videoTrack = videoStream.getVideoTracks().toDart.first;
 
     // On MacOS, even though the facing mode is supported, it is not reported.
     // Use the label for FaceTime cameras to detect the user facing webcam.
@@ -269,8 +268,9 @@ class MobileScannerWeb extends MobileScannerPlatform {
       if (_barcodeReader!.paused ?? false) {
         await _barcodeReader?.resume();
 
-        final cameraDirection = _settingsDelegate
-            .getCameraDirection(_barcodeReader?.videoStream);
+        final cameraDirection = _settingsDelegate.getCameraDirection(
+          _barcodeReader?.videoStream,
+        );
 
         return MobileScannerViewAttributes(
           cameraDirection: cameraDirection,

--- a/lib/src/web/zxing/result.dart
+++ b/lib/src/web/zxing/result.dart
@@ -63,13 +63,13 @@ extension type Result(JSObject _) implements JSObject {
   /// Get the corner points of the result, sorted in clockwise order if four
   /// points exist.
   List<Offset> get resultPoints {
-    final JSArray<ResultPoint>? points = _resultPoints;
+    final points = _resultPoints;
 
     if (points == null || points.length == 0) {
       return const [];
     }
 
-    final List<Offset> pointList =
+    final pointList =
         points.toDart.map((point) {
           return Offset(point.x, point.y);
         }).toList();
@@ -100,10 +100,10 @@ extension type Result(JSObject _) implements JSObject {
       return a.dy.compareTo(b.dy);
     });
 
-    final Offset topLeft = points[3];
-    final Offset topRight = points[2];
-    final Offset bottomRight = points[1];
-    final Offset bottomLeft = points[0];
+    final topLeft = points[3];
+    final topRight = points[2];
+    final bottomRight = points[1];
+    final bottomLeft = points[0];
 
     return [topLeft, topRight, bottomRight, bottomLeft];
   }
@@ -111,9 +111,9 @@ extension type Result(JSObject _) implements JSObject {
   /// Estimate missing fourth corner when given three points (for QR codes)
   List<Offset> estimateFourthPoint(List<Offset> points) {
     // Assume a parallelogram based on three known points
-    final Offset a = points[0];
-    final Offset b = points[1];
-    final Offset c = points[2];
+    final a = points[0];
+    final b = points[1];
+    final c = points[2];
 
     // Compute the missing point (approximate)
     final d = Offset(a.dx + (c.dx - b.dx), a.dy + (c.dy - b.dy));
@@ -124,8 +124,8 @@ extension type Result(JSObject _) implements JSObject {
   /// Estimate remaining corners when only two points are given
   /// (for 1D barcodes)
   List<Offset> estimateRemainingPoints(List<Offset> points) {
-    final Offset start = points[0];
-    final Offset end = points[1];
+    final start = points[0];
+    final end = points[1];
 
     // Approximate barcode height (arbitrary small value for 1D barcodes)
     const double heightOffset = 10;
@@ -143,7 +143,7 @@ extension type Result(JSObject _) implements JSObject {
     // The order of the points is dependent on the type of barcode.
     // Don't do a manual correction here, but leave it up to the reader
     // implementation.
-    final List<Offset> corners = resultPoints;
+    final corners = resultPoints;
 
     return Barcode(
       corners: corners,
@@ -161,14 +161,14 @@ extension type Result(JSObject _) implements JSObject {
       return Size.zero;
     }
 
-    final Iterable<double> xCoords = points.map((p) => p.dx);
-    final Iterable<double> yCoords = points.map((p) => p.dy);
+    final xCoords = points.map((p) => p.dx);
+    final yCoords = points.map((p) => p.dy);
 
     // Find the minimum and maximum x and y coordinates.
-    final double xMin = xCoords.reduce((a, b) => a < b ? a : b);
-    final double xMax = xCoords.reduce((a, b) => a > b ? a : b);
-    final double yMin = yCoords.reduce((a, b) => a < b ? a : b);
-    final double yMax = yCoords.reduce((a, b) => a > b ? a : b);
+    final xMin = xCoords.reduce((a, b) => a < b ? a : b);
+    final xMax = xCoords.reduce((a, b) => a > b ? a : b);
+    final yMin = yCoords.reduce((a, b) => a < b ? a : b);
+    final yMax = yCoords.reduce((a, b) => a > b ? a : b);
 
     return Size(xMax - xMin, yMax - yMin);
   }

--- a/lib/src/web/zxing/zxing_barcode_reader.dart
+++ b/lib/src/web/zxing/zxing_barcode_reader.dart
@@ -41,7 +41,7 @@ final class ZXingBarcodeReader extends BarcodeReader {
 
   @override
   Size get videoSize {
-    final web.HTMLVideoElement? videoElement = _reader?.videoElement;
+    final videoElement = _reader?.videoElement;
 
     if (videoElement == null) {
       return Size.zero;
@@ -64,7 +64,7 @@ final class ZXingBarcodeReader extends BarcodeReader {
       return null;
     }
 
-    final JSMap hints =
+    final hints =
         JSMap()
           // Set the formats hint.
           // See https://github.com/zxing-js/library/blob/master/src/core/DecodeHintType.ts#L45
@@ -86,7 +86,7 @@ final class ZXingBarcodeReader extends BarcodeReader {
     web.HTMLVideoElement videoElement,
     web.MediaStream videoStream,
   ) async {
-    final JSPromise? result =
+    final result =
         _reader?.attachStreamToVideo.callAsFunction(
               _reader,
               videoStream,
@@ -96,7 +96,7 @@ final class ZXingBarcodeReader extends BarcodeReader {
 
     await result?.toDart;
 
-    final web.MediaTrackSettings? settings = _mediaTrackConstraintsDelegate
+    final settings = _mediaTrackConstraintsDelegate
         .getSettings(videoStream);
 
     if (settings != null) {
@@ -158,8 +158,8 @@ final class ZXingBarcodeReader extends BarcodeReader {
     required web.HTMLVideoElement videoElement,
     required web.MediaStream videoStream,
   }) async {
-    final int detectionTimeoutMs = options.detectionTimeoutMs;
-    final List<BarcodeFormat> formats = [
+    final detectionTimeoutMs = options.detectionTimeoutMs;
+    final formats = <BarcodeFormat>[
       for (final BarcodeFormat format in options.formats)
         if (format != BarcodeFormat.unknown) format,
     ];
@@ -180,7 +180,7 @@ final class ZXingBarcodeReader extends BarcodeReader {
 
   @override
   Future<void> resume() async {
-    final JSPromise<JSAny?>? result = _reader?.videoElement?.play();
+    final result = _reader?.videoElement?.play();
     await result?.toDart;
   }
 
@@ -196,7 +196,7 @@ final class ZXingBarcodeReader extends BarcodeReader {
 extension on BarcodeFormat {
   /// Get the barcode format from the ZXing library.
   JSNumber get toJS {
-    final int zxingFormat = switch (this) {
+    final zxingFormat = switch (this) {
       BarcodeFormat.aztec => 0,
       BarcodeFormat.codabar => 1,
       BarcodeFormat.code39 => 2,

--- a/lib/src/web/zxing/zxing_barcode_reader.dart
+++ b/lib/src/web/zxing/zxing_barcode_reader.dart
@@ -96,8 +96,7 @@ final class ZXingBarcodeReader extends BarcodeReader {
 
     await result?.toDart;
 
-    final settings = _mediaTrackConstraintsDelegate
-        .getSettings(videoStream);
+    final settings = _mediaTrackConstraintsDelegate.getSettings(videoStream);
 
     if (settings != null) {
       _onMediaTrackSettingsChanged?.call(settings);

--- a/test/barcode_test.dart
+++ b/test/barcode_test.dart
@@ -6,19 +6,19 @@ import 'package:mobile_scanner/src/objects/barcode.dart';
 void main() {
   group('scaleCorners', () {
     test('returns empty list if barcode has no size or corners', () {
-      const Barcode barcode = Barcode();
+      const barcode = Barcode();
 
       expect(barcode.scaleCorners(const Size(100, 100)), isEmpty);
     });
 
     test('returns empty list if barcode has no corners', () {
-      const Barcode barcode = Barcode(size: Size(200, 200));
+      const barcode = Barcode(size: Size(200, 200));
 
       expect(barcode.scaleCorners(const Size(100, 100)), isEmpty);
     });
 
     test('returns zeroed corners if barcode has corners but no size', () {
-      const Barcode barcode = Barcode(
+      const barcode = Barcode(
         corners: [Offset.zero, Offset.zero, Offset.zero, Offset.zero],
       );
 
@@ -31,7 +31,7 @@ void main() {
     });
 
     test('returns zeroed corners if target size is empty', () {
-      const Barcode barcode = Barcode(
+      const barcode = Barcode(
         size: Size(200, 200),
         corners: [
           Offset(50, 50),
@@ -50,7 +50,7 @@ void main() {
     });
 
     test('returns scaled corners', () {
-      const Barcode barcode = Barcode(
+      const barcode = Barcode(
         size: Size(100, 100),
         corners: [
           Offset(25, 25),

--- a/test/enums/address_type_test.dart
+++ b/test/enums/address_type_test.dart
@@ -10,16 +10,16 @@ void main() {
         2: AddressType.home,
       };
 
-      for (final MapEntry<int, AddressType> entry in values.entries) {
-        final AddressType result = AddressType.fromRawValue(entry.key);
+      for (final entry in values.entries) {
+        final result = AddressType.fromRawValue(entry.key);
 
         expect(result, entry.value);
       }
     });
 
     test('invalid raw value returns AddressType.unknown', () {
-      const int negative = -1;
-      const int outOfRange = 3;
+      const negative = -1;
+      const outOfRange = 3;
 
       expect(AddressType.fromRawValue(negative), AddressType.unknown);
       expect(AddressType.fromRawValue(outOfRange), AddressType.unknown);
@@ -32,8 +32,8 @@ void main() {
         AddressType.home: 2,
       };
 
-      for (final MapEntry<AddressType, int> entry in values.entries) {
-        final int result = entry.key.rawValue;
+      for (final entry in values.entries) {
+        final result = entry.key.rawValue;
 
         expect(result, entry.value);
       }

--- a/test/enums/barcode_format_test.dart
+++ b/test/enums/barcode_format_test.dart
@@ -22,16 +22,16 @@ void main() {
         4096: BarcodeFormat.aztec,
       };
 
-      for (final MapEntry<int, BarcodeFormat> entry in values.entries) {
-        final BarcodeFormat result = BarcodeFormat.fromRawValue(entry.key);
+      for (final entry in values.entries) {
+        final result = BarcodeFormat.fromRawValue(entry.key);
 
         expect(result, entry.value);
       }
     });
 
     test('invalid raw value throws argument error', () {
-      const int negative = -2;
-      const int outOfRange = 4097;
+      const negative = -2;
+      const outOfRange = 4097;
 
       expect(() => BarcodeFormat.fromRawValue(negative), throwsArgumentError);
       expect(() => BarcodeFormat.fromRawValue(outOfRange), throwsArgumentError);
@@ -56,8 +56,8 @@ void main() {
         BarcodeFormat.aztec: 4096,
       };
 
-      for (final MapEntry<BarcodeFormat, int> entry in values.entries) {
-        final int result = entry.key.rawValue;
+      for (final entry in values.entries) {
+        final result = entry.key.rawValue;
 
         expect(result, entry.value);
       }

--- a/test/enums/barcode_type_test.dart
+++ b/test/enums/barcode_type_test.dart
@@ -20,16 +20,16 @@ void main() {
         12: BarcodeType.driverLicense,
       };
 
-      for (final MapEntry<int, BarcodeType> entry in values.entries) {
-        final BarcodeType result = BarcodeType.fromRawValue(entry.key);
+      for (final entry in values.entries) {
+        final result = BarcodeType.fromRawValue(entry.key);
 
         expect(result, entry.value);
       }
     });
 
     test('invalid raw value returns BarcodeType.unknown', () {
-      const int negative = -1;
-      const int outOfRange = 13;
+      const negative = -1;
+      const outOfRange = 13;
 
       expect(BarcodeType.fromRawValue(negative), BarcodeType.unknown);
       expect(BarcodeType.fromRawValue(outOfRange), BarcodeType.unknown);
@@ -52,8 +52,8 @@ void main() {
         BarcodeType.driverLicense: 12,
       };
 
-      for (final MapEntry<BarcodeType, int> entry in values.entries) {
-        final int result = entry.key.rawValue;
+      for (final entry in values.entries) {
+        final result = entry.key.rawValue;
 
         expect(result, entry.value);
       }

--- a/test/enums/camera_facing_test.dart
+++ b/test/enums/camera_facing_test.dart
@@ -12,16 +12,16 @@ void main() {
         -1: CameraFacing.unknown,
       };
 
-      for (final MapEntry<int?, CameraFacing> entry in values.entries) {
-        final CameraFacing result = CameraFacing.fromRawValue(entry.key);
+      for (final entry in values.entries) {
+        final result = CameraFacing.fromRawValue(entry.key);
 
         expect(result, entry.value);
       }
     });
 
     test('invalid raw value returns unknown', () {
-      const int negative = -10;
-      const int outOfRange = 3;
+      const negative = -10;
+      const outOfRange = 3;
 
       expect(CameraFacing.fromRawValue(negative), CameraFacing.unknown);
       expect(CameraFacing.fromRawValue(outOfRange), CameraFacing.unknown);
@@ -35,8 +35,8 @@ void main() {
         CameraFacing.unknown: -1,
       };
 
-      for (final MapEntry<CameraFacing, int> entry in values.entries) {
-        final int result = entry.key.rawValue;
+      for (final entry in values.entries) {
+        final result = entry.key.rawValue;
 
         expect(result, entry.value);
       }

--- a/test/enums/detection_speed_test.dart
+++ b/test/enums/detection_speed_test.dart
@@ -10,16 +10,16 @@ void main() {
         2: DetectionSpeed.unrestricted,
       };
 
-      for (final MapEntry<int, DetectionSpeed> entry in values.entries) {
-        final DetectionSpeed result = DetectionSpeed.fromRawValue(entry.key);
+      for (final entry in values.entries) {
+        final result = DetectionSpeed.fromRawValue(entry.key);
 
         expect(result, entry.value);
       }
     });
 
     test('invalid raw value throws argument error', () {
-      const int negative = -1;
-      const int outOfRange = 3;
+      const negative = -1;
+      const outOfRange = 3;
 
       expect(() => DetectionSpeed.fromRawValue(negative), throwsArgumentError);
       expect(
@@ -35,8 +35,8 @@ void main() {
         DetectionSpeed.unrestricted: 2,
       };
 
-      for (final MapEntry<DetectionSpeed, int> entry in values.entries) {
-        final int result = entry.key.rawValue;
+      for (final entry in values.entries) {
+        final result = entry.key.rawValue;
 
         expect(result, entry.value);
       }

--- a/test/enums/email_type_test.dart
+++ b/test/enums/email_type_test.dart
@@ -10,16 +10,16 @@ void main() {
         2: EmailType.home,
       };
 
-      for (final MapEntry<int, EmailType> entry in values.entries) {
-        final EmailType result = EmailType.fromRawValue(entry.key);
+      for (final entry in values.entries) {
+        final result = EmailType.fromRawValue(entry.key);
 
         expect(result, entry.value);
       }
     });
 
     test('invalid raw value returns EmailType.unknown', () {
-      const int negative = -1;
-      const int outOfRange = 3;
+      const negative = -1;
+      const outOfRange = 3;
 
       expect(EmailType.fromRawValue(negative), EmailType.unknown);
       expect(EmailType.fromRawValue(outOfRange), EmailType.unknown);
@@ -32,8 +32,8 @@ void main() {
         EmailType.home: 2,
       };
 
-      for (final MapEntry<EmailType, int> entry in values.entries) {
-        final int result = entry.key.rawValue;
+      for (final entry in values.entries) {
+        final result = entry.key.rawValue;
 
         expect(result, entry.value);
       }

--- a/test/enums/encryption_type_test.dart
+++ b/test/enums/encryption_type_test.dart
@@ -11,16 +11,16 @@ void main() {
         3: EncryptionType.wep,
       };
 
-      for (final MapEntry<int, EncryptionType> entry in values.entries) {
-        final EncryptionType result = EncryptionType.fromRawValue(entry.key);
+      for (final entry in values.entries) {
+        final result = EncryptionType.fromRawValue(entry.key);
 
         expect(result, entry.value);
       }
     });
 
     test('invalid raw value returns EncryptionType.unknown', () {
-      const int negative = -1;
-      const int outOfRange = 4;
+      const negative = -1;
+      const outOfRange = 4;
 
       expect(EncryptionType.fromRawValue(negative), EncryptionType.unknown);
       expect(EncryptionType.fromRawValue(outOfRange), EncryptionType.unknown);
@@ -34,8 +34,8 @@ void main() {
         EncryptionType.wep: 3,
       };
 
-      for (final MapEntry<EncryptionType, int> entry in values.entries) {
-        final int result = entry.key.rawValue;
+      for (final entry in values.entries) {
+        final result = entry.key.rawValue;
 
         expect(result, entry.value);
       }

--- a/test/enums/mobile_scanner_authorization_state_test.dart
+++ b/test/enums/mobile_scanner_authorization_state_test.dart
@@ -4,15 +4,15 @@ import 'package:mobile_scanner/src/enums/mobile_scanner_authorization_state.dart
 void main() {
   group('$MobileScannerAuthorizationState tests', () {
     test('can be created from raw value', () {
-      const Map<int, MobileScannerAuthorizationState> values = {
+      const values = <int, MobileScannerAuthorizationState>{
         0: MobileScannerAuthorizationState.undetermined,
         1: MobileScannerAuthorizationState.authorized,
         2: MobileScannerAuthorizationState.denied,
       };
 
-      for (final MapEntry<int, MobileScannerAuthorizationState> entry
+      for (final entry
           in values.entries) {
-        final MobileScannerAuthorizationState result =
+        final result =
             MobileScannerAuthorizationState.fromRawValue(entry.key);
 
         expect(result, entry.value);
@@ -20,8 +20,8 @@ void main() {
     });
 
     test('invalid raw value throws argument error', () {
-      const int negative = -1;
-      const int outOfRange = 3;
+      const negative = -1;
+      const outOfRange = 3;
 
       expect(
         () => MobileScannerAuthorizationState.fromRawValue(negative),
@@ -40,9 +40,9 @@ void main() {
         MobileScannerAuthorizationState.denied: 2,
       };
 
-      for (final MapEntry<MobileScannerAuthorizationState, int> entry
+      for (final entry
           in values.entries) {
-        final int result = entry.key.rawValue;
+        final result = entry.key.rawValue;
 
         expect(result, entry.value);
       }

--- a/test/enums/mobile_scanner_authorization_state_test.dart
+++ b/test/enums/mobile_scanner_authorization_state_test.dart
@@ -10,10 +10,8 @@ void main() {
         2: MobileScannerAuthorizationState.denied,
       };
 
-      for (final entry
-          in values.entries) {
-        final result =
-            MobileScannerAuthorizationState.fromRawValue(entry.key);
+      for (final entry in values.entries) {
+        final result = MobileScannerAuthorizationState.fromRawValue(entry.key);
 
         expect(result, entry.value);
       }
@@ -40,8 +38,7 @@ void main() {
         MobileScannerAuthorizationState.denied: 2,
       };
 
-      for (final entry
-          in values.entries) {
+      for (final entry in values.entries) {
         final result = entry.key.rawValue;
 
         expect(result, entry.value);

--- a/test/enums/phone_type_test.dart
+++ b/test/enums/phone_type_test.dart
@@ -12,16 +12,16 @@ void main() {
         4: PhoneType.mobile,
       };
 
-      for (final MapEntry<int, PhoneType> entry in values.entries) {
-        final PhoneType result = PhoneType.fromRawValue(entry.key);
+      for (final entry in values.entries) {
+        final result = PhoneType.fromRawValue(entry.key);
 
         expect(result, entry.value);
       }
     });
 
     test('invalid raw value returns PhoneType.unknown', () {
-      const int negative = -1;
-      const int outOfRange = 5;
+      const negative = -1;
+      const outOfRange = 5;
 
       expect(PhoneType.fromRawValue(negative), PhoneType.unknown);
       expect(PhoneType.fromRawValue(outOfRange), PhoneType.unknown);
@@ -36,8 +36,8 @@ void main() {
         PhoneType.mobile: 4,
       };
 
-      for (final MapEntry<PhoneType, int> entry in values.entries) {
-        final int result = entry.key.rawValue;
+      for (final entry in values.entries) {
+        final result = entry.key.rawValue;
 
         expect(result, entry.value);
       }

--- a/test/enums/torch_state_test.dart
+++ b/test/enums/torch_state_test.dart
@@ -11,16 +11,16 @@ void main() {
         -1: TorchState.unavailable,
       };
 
-      for (final MapEntry<int, TorchState> entry in values.entries) {
-        final TorchState result = TorchState.fromRawValue(entry.key);
+      for (final entry in values.entries) {
+        final result = TorchState.fromRawValue(entry.key);
 
         expect(result, entry.value);
       }
     });
 
     test('invalid raw value throws argument error', () {
-      const int negative = -2;
-      const int outOfRange = 3;
+      const negative = -2;
+      const outOfRange = 3;
 
       expect(() => TorchState.fromRawValue(negative), throwsArgumentError);
       expect(() => TorchState.fromRawValue(outOfRange), throwsArgumentError);
@@ -34,8 +34,8 @@ void main() {
         TorchState.auto: 2,
       };
 
-      for (final MapEntry<TorchState, int> entry in values.entries) {
-        final int result = entry.key.rawValue;
+      for (final entry in values.entries) {
+        final result = entry.key.rawValue;
 
         expect(result, entry.value);
       }

--- a/test/mobile_scanner_test.dart
+++ b/test/mobile_scanner_test.dart
@@ -68,7 +68,7 @@ void main() {
 
   group('MobileScanner Widget Tests', () {
     testWidgets('calls onDetect when barcode is scanned', (tester) async {
-      bool wasCalled = false;
+      var wasCalled = false;
       final barcodeStreamController = StreamController<BarcodeCapture>();
 
       when(
@@ -96,7 +96,7 @@ void main() {
     });
 
     testWidgets('displays error UI when an error occurs', (tester) async {
-      const MobileScannerException exception = MobileScannerException(
+      const exception = MobileScannerException(
         errorCode: MobileScannerErrorCode.controllerUninitialized,
       );
 

--- a/test/scan_window_test.dart
+++ b/test/scan_window_test.dart
@@ -19,7 +19,7 @@ void main() {
         ),
       );
 
-      final List<Map<String, Object>> testCases = [
+      final testCases = <Map<String, Object>>[
         {
           'name': 'BoxFit.none',
           'fit': BoxFit.none,
@@ -91,7 +91,7 @@ void main() {
         ),
       );
 
-      final List<Map<String, Object>> testCases = [
+      final testCases = <Map<String, Object>>[
         {
           'name': 'BoxFit.none',
           'fit': BoxFit.none,
@@ -142,7 +142,7 @@ void main() {
 
   group('calculateBoxFitRatio', () {
     group('Standard cases', () {
-      final List<Map<String, Object>> testCases = [
+      final testCases = <Map<String, Object>>[
         {
           'name': 'BoxFit.fill',
           'boxFit': BoxFit.fill,
@@ -192,7 +192,7 @@ void main() {
 
       for (final testCase in testCases) {
         test('${testCase['name']} scaling', () {
-          final ({double heightRatio, double widthRatio}) ratio =
+          final ratio =
               calculateBoxFitRatio(
                 testCase['boxFit']! as BoxFit,
                 cameraPreviewSize,
@@ -206,7 +206,7 @@ void main() {
 
     group('Edge cases', () {
       test('Zero width/height in cameraPreviewSize', () {
-        final ({double heightRatio, double widthRatio}) ratio =
+        final ratio =
             calculateBoxFitRatio(
               BoxFit.fill,
               const Size(0, 640),
@@ -217,7 +217,7 @@ void main() {
       });
 
       test('Zero width/height in target size', () {
-        final ({double heightRatio, double widthRatio}) ratio =
+        final ratio =
             calculateBoxFitRatio(
               BoxFit.fill,
               const Size(480, 640),
@@ -228,7 +228,7 @@ void main() {
       });
 
       test('Equal sizes (no scaling)', () {
-        final ({double heightRatio, double widthRatio}) ratio =
+        final ratio =
             calculateBoxFitRatio(
               BoxFit.fill,
               const Size(480, 640),
@@ -253,7 +253,7 @@ class ScanWindowTestContext {
   final Rect scanWindow;
 
   void testScanWindow(BoxFit fit, Rect expected) {
-    final Rect actual = calculateScanWindowRelativeToTextureInPercentage(
+    final actual = calculateScanWindowRelativeToTextureInPercentage(
       fit,
       scanWindow,
       textureSize: textureSize,

--- a/test/scan_window_test.dart
+++ b/test/scan_window_test.dart
@@ -192,12 +192,11 @@ void main() {
 
       for (final testCase in testCases) {
         test('${testCase['name']} scaling', () {
-          final ratio =
-              calculateBoxFitRatio(
-                testCase['boxFit']! as BoxFit,
-                cameraPreviewSize,
-                size,
-              );
+          final ratio = calculateBoxFitRatio(
+            testCase['boxFit']! as BoxFit,
+            cameraPreviewSize,
+            size,
+          );
           expect(ratio.widthRatio, testCase['expectedWidth']);
           expect(ratio.heightRatio, testCase['expectedHeight']);
         });
@@ -206,34 +205,31 @@ void main() {
 
     group('Edge cases', () {
       test('Zero width/height in cameraPreviewSize', () {
-        final ratio =
-            calculateBoxFitRatio(
-              BoxFit.fill,
-              const Size(0, 640),
-              const Size(432, 256),
-            );
+        final ratio = calculateBoxFitRatio(
+          BoxFit.fill,
+          const Size(0, 640),
+          const Size(432, 256),
+        );
         expect(ratio.widthRatio, 1.0);
         expect(ratio.heightRatio, 1.0);
       });
 
       test('Zero width/height in target size', () {
-        final ratio =
-            calculateBoxFitRatio(
-              BoxFit.fill,
-              const Size(480, 640),
-              const Size(0, 256),
-            );
+        final ratio = calculateBoxFitRatio(
+          BoxFit.fill,
+          const Size(480, 640),
+          const Size(0, 256),
+        );
         expect(ratio.widthRatio, 1.0);
         expect(ratio.heightRatio, 1.0);
       });
 
       test('Equal sizes (no scaling)', () {
-        final ratio =
-            calculateBoxFitRatio(
-              BoxFit.fill,
-              const Size(480, 640),
-              const Size(480, 640),
-            );
+        final ratio = calculateBoxFitRatio(
+          BoxFit.fill,
+          const Size(480, 640),
+          const Size(480, 640),
+        );
         expect(ratio.widthRatio, 1.0);
         expect(ratio.heightRatio, 1.0);
       });


### PR DESCRIPTION
We have two special lint rules in place, in order to enforce type annotation on local variables. However, this results in a lower score on pub.dev due to conflicting rules with their own scoring system. (https://pub.dev/packages/mobile_scanner/score)

I propose to remove these special rules and apply default style.