### PR TITLE
feat: Added support for switching between lens types

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -473,7 +473,7 @@ class MobileScannerHandler(
             .addCameraFilter { cameraInfos ->
                 val cameraManager = activity.getSystemService(Context.CAMERA_SERVICE) as CameraManager
 
-                cameraInfos.filter { cameraInfo ->
+                val filteredCameras = cameraInfos.filter { cameraInfo ->
                     try {
                         // Get the camera ID from CameraInfo
                         val cameraId = androidx.camera.camera2.interop.Camera2CameraInfo.from(cameraInfo).cameraId
@@ -502,6 +502,10 @@ class MobileScannerHandler(
                         true
                     }
                 }
+
+                // If filtering resulted in no cameras, return all cameras with correct facing
+                // to prevent camera binding failures
+                if (filteredCameras.isEmpty()) cameraInfos else filteredCameras
             }
             .build()
     }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScannerHandler.kt
@@ -11,6 +11,7 @@ import android.util.Size
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ExperimentalLensFacing
+import androidx.camera.camera2.interop.Camera2CameraInfo
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions
 import dev.steenbakker.mobile_scanner.objects.BarcodeFormats
 import dev.steenbakker.mobile_scanner.objects.DetectionSpeed
@@ -147,6 +148,7 @@ class MobileScannerHandler(
             "pause" -> pause(call, result)
             "stop" -> stop(call, result)
             "toggleTorch" -> toggleTorch(result)
+            "getSupportedLenses" -> getSupportedLenses(result)
             "analyzeImage" -> analyzeImage(call, result)
             "setScale" -> setScale(call, result)
             "resetScale" -> resetScale(result)
@@ -161,6 +163,7 @@ class MobileScannerHandler(
     private fun start(call: MethodCall, result: MethodChannel.Result) {
         val torch: Boolean = call.argument<Boolean>("torch") ?: false
         val facing: Int = call.argument<Int>("facing") ?: 0
+        val lensType: Int = call.argument<Int>("lensType") ?: -1
         val formats: List<Int>? = call.argument<List<Int>>("formats")
         val returnImage: Boolean = call.argument<Boolean>("returnImage") ?: false
         val speed: Int = call.argument<Int>("speed") ?: 1
@@ -177,8 +180,7 @@ class MobileScannerHandler(
 
         val barcodeScannerOptions: BarcodeScannerOptions? = buildBarcodeScannerOptions(formats, autoZoom)
 
-        val position =
-            if (facing == 0) CameraSelector.DEFAULT_FRONT_CAMERA else CameraSelector.DEFAULT_BACK_CAMERA
+        val position = selectCamera(facing, lensType)
 
         val detectionSpeed: DetectionSpeed = when (speed) {
             0 -> DetectionSpeed.NO_DUPLICATES
@@ -288,6 +290,47 @@ class MobileScannerHandler(
     private fun toggleTorch(result: MethodChannel.Result) {
         mobileScanner?.toggleTorch()
         result.success(null)
+    }
+
+    /**
+     * Get the list of supported lens types on this device.
+     *
+     * Analyzes all available cameras and categorizes them by their focal lengths.
+     */
+    private fun getSupportedLenses(result: MethodChannel.Result) {
+        val cameraManager = activity.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+        val supportedLenses = mutableSetOf<Int>()
+
+        try {
+            for (cameraId in cameraManager.cameraIdList) {
+                val characteristics = cameraManager.getCameraCharacteristics(cameraId)
+
+                // Get focal lengths available for this camera
+                val focalLengths = characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS)
+
+                if (focalLengths != null && focalLengths.isNotEmpty()) {
+                    // Use the first focal length as representative
+                    val focalLength = focalLengths[0]
+
+                    // Categorize based on focal length
+                    when {
+                        focalLength < 4.0f -> supportedLenses.add(1)  // Wide
+                        focalLength >= 4.0f && focalLength <= 6.0f -> supportedLenses.add(0)  // Normal
+                        focalLength > 6.0f -> supportedLenses.add(2)  // Zoom
+                    }
+                }
+            }
+
+            // If no lenses were detected, return 'any' (-1)
+            if (supportedLenses.isEmpty()) {
+                result.success(listOf(-1))
+            } else {
+                result.success(supportedLenses.toList())
+            }
+        } catch (e: Exception) {
+            // On error, return 'any' (-1) as a safe default
+            result.success(listOf(-1))
+        }
     }
 
     private fun setScale(call: MethodCall, result: MethodChannel.Result) {
@@ -407,6 +450,60 @@ class MobileScannerHandler(
                 e.localizedMessage
             )
         }
+    }
+
+    /**
+     * Select the appropriate camera based on facing direction and lens type.
+     *
+     * @param facing 0 = front, 1 = back
+     * @param lensType 0 = normal, 1 = wide, 2 = zoom, -1 = any
+     * @return CameraSelector configured for the desired camera
+     */
+    private fun selectCamera(facing: Int, lensType: Int): CameraSelector {
+        val lensFacing = if (facing == 0) CameraSelector.LENS_FACING_FRONT else CameraSelector.LENS_FACING_BACK
+
+        // If no specific lens type is requested, return default camera for facing direction
+        if (lensType == -1) {
+            return if (facing == 0) CameraSelector.DEFAULT_FRONT_CAMERA else CameraSelector.DEFAULT_BACK_CAMERA
+        }
+
+        // Build a camera selector that filters by both facing and lens characteristics
+        return CameraSelector.Builder()
+            .requireLensFacing(lensFacing)
+            .addCameraFilter { cameraInfos ->
+                val cameraManager = activity.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+
+                cameraInfos.filter { cameraInfo ->
+                    try {
+                        // Get the camera ID from CameraInfo
+                        val cameraId = androidx.camera.camera2.interop.Camera2CameraInfo.from(cameraInfo).cameraId
+                        val characteristics = cameraManager.getCameraCharacteristics(cameraId)
+
+                        // Get focal lengths available for this camera
+                        val focalLengths = characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS)
+
+                        if (focalLengths == null || focalLengths.isEmpty()) {
+                            return@filter lensType == -1
+                        }
+
+                        // Use the first focal length as representative
+                        val focalLength = focalLengths[0]
+
+                        // Categorize based on focal length (approximate 35mm equivalent ranges)
+                        // These ranges are heuristic and may need adjustment per device
+                        when (lensType) {
+                            0 -> focalLength >= 4.0f && focalLength <= 6.0f  // Normal (wide angle, ~26-35mm equiv)
+                            1 -> focalLength < 4.0f                            // Wide (ultra-wide, ~13-16mm equiv)
+                            2 -> focalLength > 6.0f                            // Zoom (telephoto, ~50mm+ equiv)
+                            else -> true
+                        }
+                    } catch (e: Exception) {
+                        // If we can't get characteristics, include this camera
+                        true
+                    }
+                }
+            }
+            .build()
     }
 
 }

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -99,6 +99,8 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
             start(call, result)
         case "toggleTorch":
             toggleTorch(result)
+        case "getSupportedLenses":
+            getSupportedLenses(result)
         case "setScale":
             setScale(call, result)
         case "setFocus":
@@ -324,7 +326,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                     return .landscapeRight
                 default:
                     break
-                }         
+                }
             }
         }
 
@@ -349,6 +351,47 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
 #endif
     }
 
+    /**
+     * Select the appropriate camera based on position and lens type.
+     *
+     * - Parameters:
+     *   - position: The camera position (front or back)
+     *   - lensType: The desired lens type (0 = normal, 1 = wide, 2 = zoom, -1 = any)
+     * - Returns: The selected AVCaptureDevice, or nil if not found
+     */
+    private func selectCamera(position: AVCaptureDevice.Position, lensType: Int) -> AVCaptureDevice? {
+#if os(iOS)
+        if #available(iOS 13.0, *) {
+            var deviceTypes: [AVCaptureDevice.DeviceType] = []
+
+            switch lensType {
+            case 0:
+                // Normal lens - prefer wide angle camera (standard on most phones)
+                deviceTypes = [.builtInWideAngleCamera]
+            case 1:
+                // Wide lens - prefer ultra-wide camera
+                deviceTypes = [.builtInUltraWideCamera, .builtInWideAngleCamera]
+            case 2:
+                // Zoom lens - prefer telephoto camera
+                deviceTypes = [.builtInTelephotoCamera, .builtInWideAngleCamera]
+            default:
+                // Any lens - use default discovery order
+                deviceTypes = [.builtInTripleCamera, .builtInDualCamera, .builtInWideAngleCamera]
+            }
+
+            // Try to find a device matching the requested types
+            let discoverySession = AVCaptureDevice.DiscoverySession(
+                deviceTypes: deviceTypes,
+                mediaType: .video,
+                position: position
+            )
+
+            return discoverySession.devices.first
+        }
+#endif
+        return nil
+    }
+
 
     func start(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         if (device != nil || captureSession != nil) {
@@ -365,6 +408,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
 
         let torch:Bool = argReader.bool(key: "torch") ?? false
         let facing:Int = argReader.int(key: "facing") ?? 1
+        let lensType:Int = argReader.int(key: "lensType") ?? -1
         let speed:Int = argReader.int(key: "speed") ?? 0
         let timeoutMs:Int = argReader.int(key: "timeout") ?? 0
         let initialZoom: CGFloat? = {
@@ -386,12 +430,10 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
 #else
         position = AVCaptureDevice.Position.front
 #endif
-        
-        // Open the camera device
+
+        // Open the camera device based on position and lens type
 #if os(iOS)
-        if #available(iOS 13.0, *) {
-            device = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInTripleCamera, .builtInDualCamera, .builtInWideAngleCamera], mediaType: .video, position: position).devices.first
-        }
+        device = selectCamera(position: position, lensType: lensType)
 #else
         if #available(macOS 10.15, *) {
             device = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: .video, position: position).devices.first
@@ -782,6 +824,72 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         }
 
         result(nil)
+    }
+
+    /**
+     * Get the list of supported lens types on this device.
+     *
+     * Analyzes all available camera devices and returns the supported lens types.
+     */
+    private func getSupportedLenses(_ result: @escaping FlutterResult) {
+#if os(iOS)
+        if #available(iOS 13.0, *) {
+            var supportedLenses = Set<Int>()
+
+            // Check back cameras
+            let backDevices = AVCaptureDevice.DiscoverySession(
+                deviceTypes: [.builtInWideAngleCamera, .builtInUltraWideCamera, .builtInTelephotoCamera],
+                mediaType: .video,
+                position: .back
+            ).devices
+
+            for device in backDevices {
+                switch device.deviceType {
+                case .builtInUltraWideCamera:
+                    supportedLenses.insert(1)  // Wide
+                case .builtInWideAngleCamera:
+                    supportedLenses.insert(0)  // Normal
+                case .builtInTelephotoCamera:
+                    supportedLenses.insert(2)  // Zoom
+                default:
+                    break
+                }
+            }
+
+            // Check front cameras
+            let frontDevices = AVCaptureDevice.DiscoverySession(
+                deviceTypes: [.builtInWideAngleCamera, .builtInUltraWideCamera, .builtInTelephotoCamera],
+                mediaType: .video,
+                position: .front
+            ).devices
+
+            for device in frontDevices {
+                switch device.deviceType {
+                case .builtInUltraWideCamera:
+                    supportedLenses.insert(1)  // Wide
+                case .builtInWideAngleCamera:
+                    supportedLenses.insert(0)  // Normal
+                case .builtInTelephotoCamera:
+                    supportedLenses.insert(2)  // Zoom
+                default:
+                    break
+                }
+            }
+
+            // If no lenses were detected, return 'any' (-1)
+            if supportedLenses.isEmpty {
+                result([-1])
+            } else {
+                result(Array(supportedLenses))
+            }
+        } else {
+            // For iOS < 13.0, return 'any' (-1)
+            result([-1])
+        }
+#else
+        // For macOS, return 'any' (-1)
+        result([-1])
+#endif
     }
 
     func pause(_ call: FlutterMethodCall, _ result: FlutterResult) {

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -386,7 +386,19 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                 position: position
             )
 
-            return discoverySession.devices.first
+            if let device = discoverySession.devices.first {
+                return device
+            }
+
+            // Fallback: try to get any wide angle camera for this position
+            // This ensures we maintain the correct camera facing even if the
+            // specific lens type is not available
+            let fallbackSession = AVCaptureDevice.DiscoverySession(
+                deviceTypes: [.builtInWideAngleCamera],
+                mediaType: .video,
+                position: position
+            )
+            return fallbackSession.devices.first
         }
 #endif
         return nil

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				1AADC473022DB6006ACA0CA0 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -278,6 +279,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1AADC473022DB6006ACA0CA0 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/example/lib/screens/mobile_scanner_advanced.dart
+++ b/example/lib/screens/mobile_scanner_advanced.dart
@@ -212,10 +212,11 @@ class _MobileScannerAdvancedState extends State<MobileScannerAdvanced> {
     if (controller == null) return;
 
     try {
-      final supportedLenses = await controller!.getSupportedLenses();
+      final List<CameraLensType> supportedLenses =
+          await controller!.getSupportedLenses();
       if (!mounted) return;
 
-      final lensNames = supportedLenses.map((lens) {
+      final String lensNames = supportedLenses.map((lens) {
         switch (lens) {
           case CameraLensType.normal:
             return 'Normal';
@@ -228,35 +229,39 @@ class _MobileScannerAdvancedState extends State<MobileScannerAdvanced> {
         }
       }).join('\n');
 
-      showDialog<void>(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('Supported Lenses'),
-          content: Text(
-            'Available camera lenses on this device:\n\n$lensNames',
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('OK'),
+      unawaited(
+        showDialog<void>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('Supported Lenses'),
+            content: Text(
+              'Available camera lenses on this device:\n\n$lensNames',
             ),
-          ],
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
         ),
       );
-    } catch (e) {
+    } on Exception catch (e) {
       if (!mounted) return;
 
-      showDialog<void>(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('Error'),
-          content: Text('Could not retrieve supported lenses:\n$e'),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('OK'),
-            ),
-          ],
+      unawaited(
+        showDialog<void>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('Error'),
+            content: Text('Could not retrieve supported lenses:\n$e'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
         ),
       );
     }
@@ -331,9 +336,9 @@ class _MobileScannerAdvancedState extends State<MobileScannerAdvanced> {
                     child: Text(_PopupMenuItems.formats.name),
                   ),
                   if (!kIsWeb)
-                    PopupMenuItem(
+                    const PopupMenuItem(
                       value: _PopupMenuItems.showSupportedLenses,
-                      child: const Text('Show Supported Lenses'),
+                      child: Text('Show Supported Lenses'),
                     ),
                   const PopupMenuDivider(),
                   if (!kIsWeb && Platform.isAndroid)

--- a/example/lib/screens/mobile_scanner_advanced.dart
+++ b/example/lib/screens/mobile_scanner_advanced.dart
@@ -8,6 +8,7 @@ import 'package:mobile_scanner_example/widgets/buttons/analyze_image_button.dart
 import 'package:mobile_scanner_example/widgets/buttons/pause_button.dart';
 import 'package:mobile_scanner_example/widgets/buttons/start_stop_button.dart';
 import 'package:mobile_scanner_example/widgets/buttons/switch_camera_button.dart';
+import 'package:mobile_scanner_example/widgets/buttons/switch_lens_button.dart';
 import 'package:mobile_scanner_example/widgets/buttons/toggle_flashlight_button.dart';
 import 'package:mobile_scanner_example/widgets/dialogs/barcode_format_dialog.dart';
 import 'package:mobile_scanner_example/widgets/dialogs/box_fit_dialog.dart';
@@ -29,6 +30,7 @@ enum _PopupMenuItems {
   boxFit,
   formats,
   scanWindow,
+  showSupportedLenses,
 }
 
 /// Implementation of Mobile Scanner example with advanced configuration
@@ -60,6 +62,8 @@ class _MobileScannerAdvancedState extends State<MobileScannerAdvanced> {
   BoxFit boxFit = BoxFit.contain;
   bool enableLifecycle = false;
 
+  CameraLensType currentLensType = CameraLensType.normal;
+
   /// Hides the MobileScanner widget while the MobileScannerController is
   /// rebuilding
   bool hideMobileScannerWidget = false;
@@ -76,6 +80,7 @@ class _MobileScannerAdvancedState extends State<MobileScannerAdvanced> {
     // torchEnabled: true,
     invertImage: invertImage,
     autoZoom: autoZoom,
+    lensType: currentLensType,
   );
 
   @override
@@ -196,6 +201,67 @@ class _MobileScannerAdvancedState extends State<MobileScannerAdvanced> {
     await controller?.start();
   }
 
+  Future<void> _onLensTypeChanged(CameraLensType newLensType) async {
+    setState(() {
+      currentLensType = newLensType;
+    });
+    await _reinitializeController();
+  }
+
+  Future<void> _showSupportedLenses() async {
+    if (controller == null) return;
+
+    try {
+      final supportedLenses = await controller!.getSupportedLenses();
+      if (!mounted) return;
+
+      final lensNames = supportedLenses.map((lens) {
+        switch (lens) {
+          case CameraLensType.normal:
+            return 'Normal';
+          case CameraLensType.wide:
+            return 'Wide/Ultra-Wide';
+          case CameraLensType.zoom:
+            return 'Zoom/Telephoto';
+          case CameraLensType.any:
+            return 'Any (Default)';
+        }
+      }).join('\n');
+
+      showDialog<void>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Supported Lenses'),
+          content: Text(
+            'Available camera lenses on this device:\n\n$lensNames',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+
+      showDialog<void>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Error'),
+          content: Text('Could not retrieve supported lenses:\n$e'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     late final scanWindow = Rect.fromCenter(
@@ -222,6 +288,9 @@ class _MobileScannerAdvancedState extends State<MobileScannerAdvanced> {
                   await _showBarcodeFormatDialog();
                 case _PopupMenuItems.boxFit:
                   await _showBoxFitDialog();
+                case _PopupMenuItems.showSupportedLenses:
+                  await _showSupportedLenses();
+                  return; // Don't reinitialize for this action
                 case _PopupMenuItems.returnImage:
                   returnImage = !returnImage;
                 case _PopupMenuItems.invertImage:
@@ -261,6 +330,11 @@ class _MobileScannerAdvancedState extends State<MobileScannerAdvanced> {
                     value: _PopupMenuItems.formats,
                     child: Text(_PopupMenuItems.formats.name),
                   ),
+                  if (!kIsWeb)
+                    PopupMenuItem(
+                      value: _PopupMenuItems.showSupportedLenses,
+                      child: const Text('Show Supported Lenses'),
+                    ),
                   const PopupMenuDivider(),
                   if (!kIsWeb && Platform.isAndroid)
                     CheckedPopupMenuItem(
@@ -403,6 +477,12 @@ class _MobileScannerAdvancedState extends State<MobileScannerAdvanced> {
                               StartStopButton(controller: controller!),
                               PauseButton(controller: controller!),
                               SwitchCameraButton(controller: controller!),
+                              if (!kIsWeb)
+                                SwitchLensButton(
+                                  controller: controller!,
+                                  currentLensType: currentLensType,
+                                  onLensTypeChanged: _onLensTypeChanged,
+                                ),
                               AnalyzeImageButton(controller: controller!),
                             ],
                           ),

--- a/example/lib/screens/mobile_scanner_advanced.dart
+++ b/example/lib/screens/mobile_scanner_advanced.dart
@@ -216,34 +216,37 @@ class _MobileScannerAdvancedState extends State<MobileScannerAdvanced> {
           await controller!.getSupportedLenses();
       if (!mounted) return;
 
-      final String lensNames = supportedLenses.map((lens) {
-        switch (lens) {
-          case CameraLensType.normal:
-            return 'Normal';
-          case CameraLensType.wide:
-            return 'Wide/Ultra-Wide';
-          case CameraLensType.zoom:
-            return 'Zoom/Telephoto';
-          case CameraLensType.any:
-            return 'Any (Default)';
-        }
-      }).join('\n');
+      final String lensNames = supportedLenses
+          .map((lens) {
+            switch (lens) {
+              case CameraLensType.normal:
+                return 'Normal';
+              case CameraLensType.wide:
+                return 'Wide/Ultra-Wide';
+              case CameraLensType.zoom:
+                return 'Zoom/Telephoto';
+              case CameraLensType.any:
+                return 'Any (Default)';
+            }
+          })
+          .join('\n');
 
       unawaited(
         showDialog<void>(
           context: context,
-          builder: (context) => AlertDialog(
-            title: const Text('Supported Lenses'),
-            content: Text(
-              'Available camera lenses on this device:\n\n$lensNames',
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('OK'),
+          builder:
+              (context) => AlertDialog(
+                title: const Text('Supported Lenses'),
+                content: Text(
+                  'Available camera lenses on this device:\n\n$lensNames',
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('OK'),
+                  ),
+                ],
               ),
-            ],
-          ),
         ),
       );
     } on Exception catch (e) {
@@ -252,16 +255,17 @@ class _MobileScannerAdvancedState extends State<MobileScannerAdvanced> {
       unawaited(
         showDialog<void>(
           context: context,
-          builder: (context) => AlertDialog(
-            title: const Text('Error'),
-            content: Text('Could not retrieve supported lenses:\n$e'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('OK'),
+          builder:
+              (context) => AlertDialog(
+                title: const Text('Error'),
+                content: Text('Could not retrieve supported lenses:\n$e'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('OK'),
+                  ),
+                ],
               ),
-            ],
-          ),
         ),
       );
     }

--- a/example/lib/widgets/buttons/switch_lens_button.dart
+++ b/example/lib/widgets/buttons/switch_lens_button.dart
@@ -39,9 +39,10 @@ class _SwitchLensButtonState extends State<SwitchLensButton> {
 
   Future<void> _loadSupportedLenses() async {
     try {
-      final supportedLenses = await widget.controller.getSupportedLenses();
+      final List<CameraLensType> supportedLenses =
+          await widget.controller.getSupportedLenses();
       // Filter out 'any' from the list and keep only specific lens types
-      final specificLenses = supportedLenses
+      final List<CameraLensType> specificLenses = supportedLenses
           .where((lens) => lens != CameraLensType.any)
           .toList();
 
@@ -50,13 +51,19 @@ class _SwitchLensButtonState extends State<SwitchLensButton> {
           _availableLenses = specificLenses;
         });
       }
-    } catch (e) {
+    } on Exception {
       // Keep default list if there's an error
     }
   }
 
   CameraLensType _getNextLensType() {
-    final currentIndex = _availableLenses.indexOf(widget.currentLensType);
+    // Safety check: return 'any' if no lenses are available
+    if (_availableLenses.isEmpty) {
+      return CameraLensType.any;
+    }
+
+    final int currentIndex =
+        _availableLenses.indexOf(widget.currentLensType);
 
     // If current lens is not in available lenses, return the first one
     if (currentIndex == -1) {
@@ -64,7 +71,7 @@ class _SwitchLensButtonState extends State<SwitchLensButton> {
     }
 
     // Get next lens, wrapping around to the first if we're at the end
-    final nextIndex = (currentIndex + 1) % _availableLenses.length;
+    final int nextIndex = (currentIndex + 1) % _availableLenses.length;
     return _availableLenses[nextIndex];
   }
 

--- a/example/lib/widgets/buttons/switch_lens_button.dart
+++ b/example/lib/widgets/buttons/switch_lens_button.dart
@@ -42,9 +42,8 @@ class _SwitchLensButtonState extends State<SwitchLensButton> {
       final List<CameraLensType> supportedLenses =
           await widget.controller.getSupportedLenses();
       // Filter out 'any' from the list and keep only specific lens types
-      final List<CameraLensType> specificLenses = supportedLenses
-          .where((lens) => lens != CameraLensType.any)
-          .toList();
+      final List<CameraLensType> specificLenses =
+          supportedLenses.where((lens) => lens != CameraLensType.any).toList();
 
       if (specificLenses.isNotEmpty && mounted) {
         setState(() {
@@ -62,8 +61,7 @@ class _SwitchLensButtonState extends State<SwitchLensButton> {
       return CameraLensType.any;
     }
 
-    final int currentIndex =
-        _availableLenses.indexOf(widget.currentLensType);
+    final int currentIndex = _availableLenses.indexOf(widget.currentLensType);
 
     // If current lens is not in available lenses, return the first one
     if (currentIndex == -1) {
@@ -119,10 +117,7 @@ class _SwitchLensButtonState extends State<SwitchLensButton> {
         ),
         Text(
           _getLensLabel(),
-          style: const TextStyle(
-            color: Colors.white,
-            fontSize: 10,
-          ),
+          style: const TextStyle(color: Colors.white, fontSize: 10),
         ),
       ],
     );

--- a/example/lib/widgets/buttons/switch_lens_button.dart
+++ b/example/lib/widgets/buttons/switch_lens_button.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+/// Button widget for switching between camera lens types
+class SwitchLensButton extends StatefulWidget {
+  /// Construct a new [SwitchLensButton] instance.
+  const SwitchLensButton({
+    required this.controller,
+    required this.currentLensType,
+    required this.onLensTypeChanged,
+    super.key,
+  });
+
+  /// Controller to get supported lenses
+  final MobileScannerController controller;
+
+  /// Current lens type
+  final CameraLensType currentLensType;
+
+  /// Callback when lens type changes
+  final ValueChanged<CameraLensType> onLensTypeChanged;
+
+  @override
+  State<SwitchLensButton> createState() => _SwitchLensButtonState();
+}
+
+class _SwitchLensButtonState extends State<SwitchLensButton> {
+  List<CameraLensType> _availableLenses = [
+    CameraLensType.normal,
+    CameraLensType.wide,
+    CameraLensType.zoom,
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSupportedLenses();
+  }
+
+  Future<void> _loadSupportedLenses() async {
+    try {
+      final supportedLenses = await widget.controller.getSupportedLenses();
+      // Filter out 'any' from the list and keep only specific lens types
+      final specificLenses = supportedLenses
+          .where((lens) => lens != CameraLensType.any)
+          .toList();
+
+      if (specificLenses.isNotEmpty && mounted) {
+        setState(() {
+          _availableLenses = specificLenses;
+        });
+      }
+    } catch (e) {
+      // Keep default list if there's an error
+    }
+  }
+
+  CameraLensType _getNextLensType() {
+    final currentIndex = _availableLenses.indexOf(widget.currentLensType);
+
+    // If current lens is not in available lenses, return the first one
+    if (currentIndex == -1) {
+      return _availableLenses.first;
+    }
+
+    // Get next lens, wrapping around to the first if we're at the end
+    final nextIndex = (currentIndex + 1) % _availableLenses.length;
+    return _availableLenses[nextIndex];
+  }
+
+  IconData _getLensIcon() {
+    switch (widget.currentLensType) {
+      case CameraLensType.normal:
+        return Icons.camera;
+      case CameraLensType.wide:
+        return Icons.camera_outdoor;
+      case CameraLensType.zoom:
+        return Icons.zoom_in;
+      case CameraLensType.any:
+        return Icons.camera_alt;
+    }
+  }
+
+  String _getLensLabel() {
+    switch (widget.currentLensType) {
+      case CameraLensType.normal:
+        return 'Normal';
+      case CameraLensType.wide:
+        return 'Wide';
+      case CameraLensType.zoom:
+        return 'Zoom';
+      case CameraLensType.any:
+        return 'Any';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Only show button if there are multiple lens options available
+    if (_availableLenses.length < 2) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        IconButton(
+          color: Colors.white,
+          iconSize: 32,
+          icon: Icon(_getLensIcon()),
+          onPressed: () => widget.onLensTypeChanged(_getNextLensType()),
+        ),
+        Text(
+          _getLensLabel(),
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 10,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/mobile_scanner.dart
+++ b/lib/mobile_scanner.dart
@@ -2,6 +2,7 @@ export 'src/enums/address_type.dart';
 export 'src/enums/barcode_format.dart';
 export 'src/enums/barcode_type.dart';
 export 'src/enums/camera_facing.dart';
+export 'src/enums/camera_lens_type.dart';
 export 'src/enums/detection_speed.dart';
 export 'src/enums/email_type.dart';
 export 'src/enums/encryption_type.dart';

--- a/lib/src/enums/camera_lens_type.dart
+++ b/lib/src/enums/camera_lens_type.dart
@@ -1,0 +1,41 @@
+/// The type of camera lens based on focal length.
+enum CameraLensType {
+  /// A normal/standard lens (typically around 26-35mm equivalent).
+  ///
+  /// This is the standard wide angle lens found on most smartphones.
+  normal(0),
+
+  /// An ultra-wide angle lens (typically around 13-16mm equivalent).
+  ///
+  /// This type of lens captures a wider field of view than the normal lens.
+  wide(1),
+
+  /// A telephoto/zoom lens (typically 50mm+ equivalent).
+  ///
+  /// This type of lens provides optical zoom capabilities.
+  zoom(2),
+
+  /// Any available lens type.
+  ///
+  /// When this is specified, the first available camera for the given
+  /// facing direction will be used, regardless of lens type.
+  any(-1);
+
+  const CameraLensType(this.rawValue);
+
+  factory CameraLensType.fromRawValue(int? value) {
+    switch (value) {
+      case 0:
+        return normal;
+      case 1:
+        return wide;
+      case 2:
+        return zoom;
+      default:
+        return any;
+    }
+  }
+
+  /// The raw value for the camera lens type.
+  final int rawValue;
+}

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/camera_facing.dart';
+import 'package:mobile_scanner/src/enums/camera_lens_type.dart';
 import 'package:mobile_scanner/src/enums/mobile_scanner_authorization_state.dart';
 import 'package:mobile_scanner/src/enums/mobile_scanner_error_code.dart';
 import 'package:mobile_scanner/src/enums/torch_state.dart';
@@ -419,6 +420,22 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
   @override
   Future<void> toggleTorch() async {
     await methodChannel.invokeMethod<void>('toggleTorch');
+  }
+
+  @override
+  Future<List<CameraLensType>> getSupportedLenses() async {
+    final List<Object?>? lensTypes =
+        await methodChannel.invokeListMethod<Object?>('getSupportedLenses');
+
+    if (lensTypes == null || lensTypes.isEmpty) {
+      // Default to 'any' if no lenses are reported
+      return [CameraLensType.any];
+    }
+
+    return lensTypes
+        .whereType<int>()
+        .map((rawValue) => CameraLensType.fromRawValue(rawValue))
+        .toList();
   }
 
   @override

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -432,10 +432,13 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
       return [CameraLensType.any];
     }
 
-    return lensTypes
+    final validLensTypes = lensTypes
         .whereType<int>()
         .map(CameraLensType.fromRawValue)
         .toList();
+
+    // Return 'any' if all values were filtered out as invalid
+    return validLensTypes.isEmpty ? [CameraLensType.any] : validLensTypes;
   }
 
   @override

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -424,7 +424,7 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
 
   @override
   Future<List<CameraLensType>> getSupportedLenses() async {
-    final List<Object?>? lensTypes =
+    final lensTypes =
         await methodChannel.invokeListMethod<Object?>('getSupportedLenses');
 
     if (lensTypes == null || lensTypes.isEmpty) {
@@ -434,7 +434,7 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
 
     return lensTypes
         .whereType<int>()
-        .map((rawValue) => CameraLensType.fromRawValue(rawValue))
+        .map(CameraLensType.fromRawValue)
         .toList();
   }
 

--- a/lib/src/method_channel/mobile_scanner_method_channel.dart
+++ b/lib/src/method_channel/mobile_scanner_method_channel.dart
@@ -424,18 +424,17 @@ class MethodChannelMobileScanner extends MobileScannerPlatform {
 
   @override
   Future<List<CameraLensType>> getSupportedLenses() async {
-    final lensTypes =
-        await methodChannel.invokeListMethod<Object?>('getSupportedLenses');
+    final lensTypes = await methodChannel.invokeListMethod<Object?>(
+      'getSupportedLenses',
+    );
 
     if (lensTypes == null || lensTypes.isEmpty) {
       // Default to 'any' if no lenses are reported
       return [CameraLensType.any];
     }
 
-    final validLensTypes = lensTypes
-        .whereType<int>()
-        .map(CameraLensType.fromRawValue)
-        .toList();
+    final validLensTypes =
+        lensTypes.whereType<int>().map(CameraLensType.fromRawValue).toList();
 
     // Return 'any' if all values were filtered out as invalid
     return validLensTypes.isEmpty ? [CameraLensType.any] : validLensTypes;

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -10,6 +10,7 @@ import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/camera_facing.dart';
+import 'package:mobile_scanner/src/enums/camera_lens_type.dart';
 import 'package:mobile_scanner/src/enums/detection_speed.dart';
 import 'package:mobile_scanner/src/enums/mobile_scanner_error_code.dart';
 import 'package:mobile_scanner/src/enums/torch_state.dart';
@@ -29,6 +30,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
     this.detectionSpeed = DetectionSpeed.normal,
     int detectionTimeoutMs = 250,
     this.facing = CameraFacing.back,
+    this.lensType = CameraLensType.any,
     this.formats = const <BarcodeFormat>[],
     this.returnImage = false,
     this.torchEnabled = false,
@@ -83,6 +85,17 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   ///
   /// Defaults to the back-facing camera.
   final CameraFacing facing;
+
+  /// The lens type for the camera.
+  ///
+  /// This allows selection between normal, wide, and zoom lenses on devices
+  /// with multiple cameras.
+  ///
+  /// Defaults to [CameraLensType.any], which uses the first available camera
+  /// for the given [facing] direction.
+  ///
+  /// Currently only supported on iOS 13+ and Android.
+  final CameraLensType lensType;
 
   /// The formats that the scanner should detect.
   ///
@@ -427,6 +440,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
 
     final options = StartOptions(
       cameraDirection: cameraDirection ?? facing,
+      cameraLensType: lensType,
       cameraResolution: cameraResolution,
       detectionSpeed: detectionSpeed,
       detectionTimeoutMs: detectionTimeoutMs,
@@ -562,6 +576,24 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
     // When the platform has updated the torch state,
     // it will send an update through the torch state event stream.
     await MobileScannerPlatform.instance.toggleTorch();
+  }
+
+  /// Get the list of supported camera lens types for the current device.
+  ///
+  /// Returns a list of [CameraLensType] values that are available on the device.
+  /// This can be used to determine which lens types can be used with the scanner.
+  ///
+  /// The returned list will always contain at least one lens type.
+  ///
+  /// This method can be called before starting the scanner.
+  ///
+  /// Example:
+  /// ```dart
+  /// final supportedLenses = await controller.getSupportedLenses();
+  /// print('Available lenses: $supportedLenses');
+  /// ```
+  Future<List<CameraLensType>> getSupportedLenses() async {
+    return MobileScannerPlatform.instance.getSupportedLenses();
   }
 
   /// Update the scan window with the given [window] rectangle.

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -580,8 +580,9 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
 
   /// Get the list of supported camera lens types for the current device.
   ///
-  /// Returns a list of [CameraLensType] values that are available on the device.
-  /// This can be used to determine which lens types can be used with the scanner.
+  /// Returns a list of [CameraLensType] values that are available on the
+  /// device. This can be used to determine which lens types can be used
+  /// with the scanner.
   ///
   /// The returned list will always contain at least one lens type.
   ///

--- a/lib/src/mobile_scanner_platform_interface.dart
+++ b/lib/src/mobile_scanner_platform_interface.dart
@@ -120,8 +120,8 @@ abstract class MobileScannerPlatform extends PlatformInterface {
 
   /// Get the list of supported camera lens types for the current device.
   ///
-  /// Returns a list of [CameraLensType] values that are available on the device.
-  /// The list will always contain at least one lens type.
+  /// Returns a list of [CameraLensType] values that are available on the
+  /// device. The list will always contain at least one lens type.
   ///
   /// This method can be called before starting the scanner.
   Future<List<CameraLensType>> getSupportedLenses() {

--- a/lib/src/mobile_scanner_platform_interface.dart
+++ b/lib/src/mobile_scanner_platform_interface.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
+import 'package:mobile_scanner/src/enums/camera_lens_type.dart';
 import 'package:mobile_scanner/src/enums/torch_state.dart';
 import 'package:mobile_scanner/src/method_channel/mobile_scanner_method_channel.dart';
 import 'package:mobile_scanner/src/mobile_scanner_view_attributes.dart';
@@ -115,6 +116,16 @@ abstract class MobileScannerPlatform extends PlatformInterface {
   /// Toggle the torch on the active camera on or off.
   Future<void> toggleTorch() {
     throw UnimplementedError('toggleTorch() has not been implemented.');
+  }
+
+  /// Get the list of supported camera lens types for the current device.
+  ///
+  /// Returns a list of [CameraLensType] values that are available on the device.
+  /// The list will always contain at least one lens type.
+  ///
+  /// This method can be called before starting the scanner.
+  Future<List<CameraLensType>> getSupportedLenses() {
+    throw UnimplementedError('getSupportedLenses() has not been implemented.');
   }
 
   /// Update the scan window to the given [window] rectangle.

--- a/lib/src/objects/start_options.dart
+++ b/lib/src/objects/start_options.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/enums/camera_facing.dart';
+import 'package:mobile_scanner/src/enums/camera_lens_type.dart';
 import 'package:mobile_scanner/src/enums/detection_speed.dart';
 
 /// This class defines the different start options for the mobile scanner.
@@ -9,6 +10,7 @@ class StartOptions {
   /// Construct a new [StartOptions] instance.
   const StartOptions({
     required this.cameraDirection,
+    required this.cameraLensType,
     required this.cameraResolution,
     required this.detectionSpeed,
     required this.detectionTimeoutMs,
@@ -22,6 +24,15 @@ class StartOptions {
 
   /// The direction for the camera.
   final CameraFacing cameraDirection;
+
+  /// The lens type for the camera.
+  ///
+  /// This allows selection between normal, wide, and zoom lenses on devices
+  /// with multiple cameras.
+  ///
+  /// When set to [CameraLensType.any], the first available camera for the
+  /// given [cameraDirection] will be used.
+  final CameraLensType cameraLensType;
 
   /// The desired camera resolution for the scanner.
   final Size? cameraResolution;
@@ -66,6 +77,7 @@ class StartOptions {
           cameraResolution!.height.toInt(),
         ],
       'facing': cameraDirection.rawValue,
+      'lensType': cameraLensType.rawValue,
       if (formats.isNotEmpty)
         'formats': formats.map((f) => f.rawValue).toList(),
       'returnImage': returnImage,

--- a/test/enums/camera_lens_type_test.dart
+++ b/test/enums/camera_lens_type_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/camera_lens_type.dart';
+
+void main() {
+  group('$CameraLensType tests', () {
+    test('can be created from raw value', () {
+      const values = <int?, CameraLensType>{
+        null: CameraLensType.any,
+        0: CameraLensType.normal,
+        1: CameraLensType.wide,
+        2: CameraLensType.zoom,
+        -1: CameraLensType.any,
+      };
+
+      for (final entry in values.entries) {
+        final result = CameraLensType.fromRawValue(entry.key);
+
+        expect(result, entry.value);
+      }
+    });
+
+    test('invalid raw value returns any', () {
+      const negative = -10;
+      const outOfRange = 3;
+
+      expect(CameraLensType.fromRawValue(negative), CameraLensType.any);
+      expect(CameraLensType.fromRawValue(outOfRange), CameraLensType.any);
+    });
+
+    test('can be converted to raw value', () {
+      const values = <CameraLensType, int>{
+        CameraLensType.normal: 0,
+        CameraLensType.wide: 1,
+        CameraLensType.zoom: 2,
+        CameraLensType.any: -1,
+      };
+
+      for (final entry in values.entries) {
+        final result = entry.key.rawValue;
+
+        expect(result, entry.value);
+      }
+    });
+
+    test('all enum values have unique raw values', () {
+      final rawValues = CameraLensType.values.map((e) => e.rawValue).toList();
+      final uniqueValues = rawValues.toSet();
+
+      expect(
+        rawValues.length,
+        uniqueValues.length,
+        reason: 'All CameraLensType values should have unique raw values',
+      );
+    });
+
+    test('roundtrip conversion preserves value', () {
+      for (final lensType in CameraLensType.values) {
+        final rawValue = lensType.rawValue;
+        final converted = CameraLensType.fromRawValue(rawValue);
+
+        expect(converted, lensType);
+      }
+    });
+  });
+}

--- a/test/get_supported_lenses_test.dart
+++ b/test/get_supported_lenses_test.dart
@@ -183,6 +183,27 @@ void main() {
       expect(lenses, contains(CameraLensType.zoom));
     });
 
+    test('returns "any" when all values are invalid', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          if (methodCall.method == 'getSupportedLenses') {
+            return ['invalid', null, 'another-invalid']; // All invalid
+          }
+          return null;
+        },
+      );
+
+      final lenses = await platform.getSupportedLenses();
+
+      // Should return 'any' when all values are filtered out
+      expect(lenses, hasLength(1));
+      expect(lenses.first, CameraLensType.any);
+    });
+
     test('handles platform returning -1 (any)', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(

--- a/test/get_supported_lenses_test.dart
+++ b/test/get_supported_lenses_test.dart
@@ -1,0 +1,271 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/camera_lens_type.dart';
+import 'package:mobile_scanner/src/method_channel/mobile_scanner_method_channel.dart';
+import 'package:mobile_scanner/src/mobile_scanner_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('getSupportedLenses() tests', () {
+    late MethodChannelMobileScanner platform;
+    late List<MethodCall> methodCalls;
+
+    setUp(() {
+      platform = MethodChannelMobileScanner();
+      MobileScannerPlatform.instance = platform;
+      methodCalls = <MethodCall>[];
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          switch (methodCall.method) {
+            case 'getSupportedLenses':
+              // Return mock lens types based on test cases
+              return null; // Will be overridden in specific tests
+            default:
+              return null;
+          }
+        },
+      );
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(platform.methodChannel, null);
+    });
+
+    test('returns list of supported lenses', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          if (methodCall.method == 'getSupportedLenses') {
+            return [0, 1, 2]; // normal, wide, zoom
+          }
+          return null;
+        },
+      );
+
+      final lenses = await platform.getSupportedLenses();
+
+      expect(lenses, hasLength(3));
+      expect(lenses, contains(CameraLensType.normal));
+      expect(lenses, contains(CameraLensType.wide));
+      expect(lenses, contains(CameraLensType.zoom));
+    });
+
+    test('returns normal lens only', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          if (methodCall.method == 'getSupportedLenses') {
+            return [0]; // normal only
+          }
+          return null;
+        },
+      );
+
+      final lenses = await platform.getSupportedLenses();
+
+      expect(lenses, hasLength(1));
+      expect(lenses.first, CameraLensType.normal);
+    });
+
+    test('returns wide lens only', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          if (methodCall.method == 'getSupportedLenses') {
+            return [1]; // wide only
+          }
+          return null;
+        },
+      );
+
+      final lenses = await platform.getSupportedLenses();
+
+      expect(lenses, hasLength(1));
+      expect(lenses.first, CameraLensType.wide);
+    });
+
+    test('returns zoom lens only', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          if (methodCall.method == 'getSupportedLenses') {
+            return [2]; // zoom only
+          }
+          return null;
+        },
+      );
+
+      final lenses = await platform.getSupportedLenses();
+
+      expect(lenses, hasLength(1));
+      expect(lenses.first, CameraLensType.zoom);
+    });
+
+    test('returns "any" when platform returns null', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          if (methodCall.method == 'getSupportedLenses') {
+            return null;
+          }
+          return null;
+        },
+      );
+
+      final lenses = await platform.getSupportedLenses();
+
+      expect(lenses, hasLength(1));
+      expect(lenses.first, CameraLensType.any);
+    });
+
+    test('returns "any" when platform returns empty list', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          if (methodCall.method == 'getSupportedLenses') {
+            return [];
+          }
+          return null;
+        },
+      );
+
+      final lenses = await platform.getSupportedLenses();
+
+      expect(lenses, hasLength(1));
+      expect(lenses.first, CameraLensType.any);
+    });
+
+    test('filters out invalid raw values', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          if (methodCall.method == 'getSupportedLenses') {
+            return [0, 'invalid', 1, null, 2]; // Mixed valid and invalid
+          }
+          return null;
+        },
+      );
+
+      final lenses = await platform.getSupportedLenses();
+
+      // Should only contain valid lens types (0, 1, 2)
+      expect(lenses, hasLength(3));
+      expect(lenses, contains(CameraLensType.normal));
+      expect(lenses, contains(CameraLensType.wide));
+      expect(lenses, contains(CameraLensType.zoom));
+    });
+
+    test('handles platform returning -1 (any)', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          if (methodCall.method == 'getSupportedLenses') {
+            return [-1]; // any
+          }
+          return null;
+        },
+      );
+
+      final lenses = await platform.getSupportedLenses();
+
+      expect(lenses, hasLength(1));
+      expect(lenses.first, CameraLensType.any);
+    });
+
+    test('calls correct method on platform channel', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          if (methodCall.method == 'getSupportedLenses') {
+            return [0];
+          }
+          return null;
+        },
+      );
+
+      await platform.getSupportedLenses();
+
+      expect(methodCalls, hasLength(1));
+      expect(methodCalls.first.method, 'getSupportedLenses');
+    });
+
+    test('returns normal and zoom lenses (common dual camera setup)', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          if (methodCall.method == 'getSupportedLenses') {
+            return [0, 2]; // normal and zoom
+          }
+          return null;
+        },
+      );
+
+      final lenses = await platform.getSupportedLenses();
+
+      expect(lenses, hasLength(2));
+      expect(lenses, contains(CameraLensType.normal));
+      expect(lenses, contains(CameraLensType.zoom));
+      expect(lenses, isNot(contains(CameraLensType.wide)));
+    });
+
+    test('returns normal, wide, and zoom (common triple camera setup)',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        platform.methodChannel,
+        (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+
+          if (methodCall.method == 'getSupportedLenses') {
+            return [0, 1, 2]; // normal, wide, zoom
+          }
+          return null;
+        },
+      );
+
+      final lenses = await platform.getSupportedLenses();
+
+      expect(lenses, hasLength(3));
+      expect(lenses, contains(CameraLensType.normal));
+      expect(lenses, contains(CameraLensType.wide));
+      expect(lenses, contains(CameraLensType.zoom));
+    });
+  });
+}

--- a/test/get_supported_lenses_test.dart
+++ b/test/get_supported_lenses_test.dart
@@ -18,19 +18,19 @@ void main() {
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+            platform.methodChannel,
+            (MethodCall methodCall) async {
+              methodCalls.add(methodCall);
 
-          switch (methodCall.method) {
-            case 'getSupportedLenses':
-              // Return mock lens types based on test cases
-              return null; // Will be overridden in specific tests
-            default:
-              return null;
-          }
-        },
-      );
+              switch (methodCall.method) {
+                case 'getSupportedLenses':
+                  // Return mock lens types based on test cases
+                  return null; // Will be overridden in specific tests
+                default:
+                  return null;
+              }
+            },
+          );
     });
 
     tearDown(() {
@@ -41,16 +41,16 @@ void main() {
     test('returns list of supported lenses', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+            platform.methodChannel,
+            (MethodCall methodCall) async {
+              methodCalls.add(methodCall);
 
-          if (methodCall.method == 'getSupportedLenses') {
-            return [0, 1, 2]; // normal, wide, zoom
-          }
-          return null;
-        },
-      );
+              if (methodCall.method == 'getSupportedLenses') {
+                return [0, 1, 2]; // normal, wide, zoom
+              }
+              return null;
+            },
+          );
 
       final lenses = await platform.getSupportedLenses();
 
@@ -63,16 +63,16 @@ void main() {
     test('returns normal lens only', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+            platform.methodChannel,
+            (MethodCall methodCall) async {
+              methodCalls.add(methodCall);
 
-          if (methodCall.method == 'getSupportedLenses') {
-            return [0]; // normal only
-          }
-          return null;
-        },
-      );
+              if (methodCall.method == 'getSupportedLenses') {
+                return [0]; // normal only
+              }
+              return null;
+            },
+          );
 
       final lenses = await platform.getSupportedLenses();
 
@@ -83,16 +83,16 @@ void main() {
     test('returns wide lens only', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+            platform.methodChannel,
+            (MethodCall methodCall) async {
+              methodCalls.add(methodCall);
 
-          if (methodCall.method == 'getSupportedLenses') {
-            return [1]; // wide only
-          }
-          return null;
-        },
-      );
+              if (methodCall.method == 'getSupportedLenses') {
+                return [1]; // wide only
+              }
+              return null;
+            },
+          );
 
       final lenses = await platform.getSupportedLenses();
 
@@ -103,16 +103,16 @@ void main() {
     test('returns zoom lens only', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+            platform.methodChannel,
+            (MethodCall methodCall) async {
+              methodCalls.add(methodCall);
 
-          if (methodCall.method == 'getSupportedLenses') {
-            return [2]; // zoom only
-          }
-          return null;
-        },
-      );
+              if (methodCall.method == 'getSupportedLenses') {
+                return [2]; // zoom only
+              }
+              return null;
+            },
+          );
 
       final lenses = await platform.getSupportedLenses();
 
@@ -123,16 +123,16 @@ void main() {
     test('returns "any" when platform returns null', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+            platform.methodChannel,
+            (MethodCall methodCall) async {
+              methodCalls.add(methodCall);
 
-          if (methodCall.method == 'getSupportedLenses') {
-            return null;
-          }
-          return null;
-        },
-      );
+              if (methodCall.method == 'getSupportedLenses') {
+                return null;
+              }
+              return null;
+            },
+          );
 
       final lenses = await platform.getSupportedLenses();
 
@@ -143,16 +143,16 @@ void main() {
     test('returns "any" when platform returns empty list', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+            platform.methodChannel,
+            (MethodCall methodCall) async {
+              methodCalls.add(methodCall);
 
-          if (methodCall.method == 'getSupportedLenses') {
-            return [];
-          }
-          return null;
-        },
-      );
+              if (methodCall.method == 'getSupportedLenses') {
+                return [];
+              }
+              return null;
+            },
+          );
 
       final lenses = await platform.getSupportedLenses();
 
@@ -163,16 +163,16 @@ void main() {
     test('filters out invalid raw values', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+            platform.methodChannel,
+            (MethodCall methodCall) async {
+              methodCalls.add(methodCall);
 
-          if (methodCall.method == 'getSupportedLenses') {
-            return [0, 'invalid', 1, null, 2]; // Mixed valid and invalid
-          }
-          return null;
-        },
-      );
+              if (methodCall.method == 'getSupportedLenses') {
+                return [0, 'invalid', 1, null, 2]; // Mixed valid and invalid
+              }
+              return null;
+            },
+          );
 
       final lenses = await platform.getSupportedLenses();
 
@@ -186,16 +186,16 @@ void main() {
     test('returns "any" when all values are invalid', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+            platform.methodChannel,
+            (MethodCall methodCall) async {
+              methodCalls.add(methodCall);
 
-          if (methodCall.method == 'getSupportedLenses') {
-            return ['invalid', null, 'another-invalid']; // All invalid
-          }
-          return null;
-        },
-      );
+              if (methodCall.method == 'getSupportedLenses') {
+                return ['invalid', null, 'another-invalid']; // All invalid
+              }
+              return null;
+            },
+          );
 
       final lenses = await platform.getSupportedLenses();
 
@@ -207,16 +207,16 @@ void main() {
     test('handles platform returning -1 (any)', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+            platform.methodChannel,
+            (MethodCall methodCall) async {
+              methodCalls.add(methodCall);
 
-          if (methodCall.method == 'getSupportedLenses') {
-            return [-1]; // any
-          }
-          return null;
-        },
-      );
+              if (methodCall.method == 'getSupportedLenses') {
+                return [-1]; // any
+              }
+              return null;
+            },
+          );
 
       final lenses = await platform.getSupportedLenses();
 
@@ -227,16 +227,16 @@ void main() {
     test('calls correct method on platform channel', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+            platform.methodChannel,
+            (MethodCall methodCall) async {
+              methodCalls.add(methodCall);
 
-          if (methodCall.method == 'getSupportedLenses') {
-            return [0];
-          }
-          return null;
-        },
-      );
+              if (methodCall.method == 'getSupportedLenses') {
+                return [0];
+              }
+              return null;
+            },
+          );
 
       await platform.getSupportedLenses();
 
@@ -247,16 +247,16 @@ void main() {
     test('returns normal and zoom lenses (common dual camera setup)', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+            platform.methodChannel,
+            (MethodCall methodCall) async {
+              methodCalls.add(methodCall);
 
-          if (methodCall.method == 'getSupportedLenses') {
-            return [0, 2]; // normal and zoom
-          }
-          return null;
-        },
-      );
+              if (methodCall.method == 'getSupportedLenses') {
+                return [0, 2]; // normal and zoom
+              }
+              return null;
+            },
+          );
 
       final lenses = await platform.getSupportedLenses();
 
@@ -266,27 +266,29 @@ void main() {
       expect(lenses, isNot(contains(CameraLensType.wide)));
     });
 
-    test('returns normal, wide, and zoom (common triple camera setup)',
-        () async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-        platform.methodChannel,
-        (MethodCall methodCall) async {
-          methodCalls.add(methodCall);
+    test(
+      'returns normal, wide, and zoom (common triple camera setup)',
+      () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              platform.methodChannel,
+              (MethodCall methodCall) async {
+                methodCalls.add(methodCall);
 
-          if (methodCall.method == 'getSupportedLenses') {
-            return [0, 1, 2]; // normal, wide, zoom
-          }
-          return null;
-        },
-      );
+                if (methodCall.method == 'getSupportedLenses') {
+                  return [0, 1, 2]; // normal, wide, zoom
+                }
+                return null;
+              },
+            );
 
-      final lenses = await platform.getSupportedLenses();
+        final lenses = await platform.getSupportedLenses();
 
-      expect(lenses, hasLength(3));
-      expect(lenses, contains(CameraLensType.normal));
-      expect(lenses, contains(CameraLensType.wide));
-      expect(lenses, contains(CameraLensType.zoom));
-    });
+        expect(lenses, hasLength(3));
+        expect(lenses, contains(CameraLensType.normal));
+        expect(lenses, contains(CameraLensType.wide));
+        expect(lenses, contains(CameraLensType.zoom));
+      },
+    );
   });
 }

--- a/test/mobile_scanner_controller_lens_type_test.dart
+++ b/test/mobile_scanner_controller_lens_type_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_scanner/src/enums/camera_lens_type.dart';
 import 'package:mobile_scanner/src/mobile_scanner_controller.dart';
@@ -11,7 +13,7 @@ void main() {
 
       expect(controller.lensType, CameraLensType.any);
 
-      controller.dispose();
+      unawaited(controller.dispose());
     });
 
     test('controller initializes with normal lens type', () {
@@ -21,7 +23,7 @@ void main() {
 
       expect(controller.lensType, CameraLensType.normal);
 
-      controller.dispose();
+      unawaited(controller.dispose());
     });
 
     test('controller initializes with wide lens type', () {
@@ -31,7 +33,7 @@ void main() {
 
       expect(controller.lensType, CameraLensType.wide);
 
-      controller.dispose();
+      unawaited(controller.dispose());
     });
 
     test('controller initializes with zoom lens type', () {
@@ -41,7 +43,7 @@ void main() {
 
       expect(controller.lensType, CameraLensType.zoom);
 
-      controller.dispose();
+      unawaited(controller.dispose());
     });
 
     test('lens type persists throughout controller lifecycle', () {
@@ -55,7 +57,7 @@ void main() {
       // Lens type should remain the same even after operations
       expect(controller.lensType, CameraLensType.zoom);
 
-      controller.dispose();
+      unawaited(controller.dispose());
 
       // Even after disposal, the property should still be accessible
       expect(controller.lensType, CameraLensType.zoom);
@@ -79,9 +81,9 @@ void main() {
       expect(wideController.lensType, CameraLensType.wide);
       expect(zoomController.lensType, CameraLensType.zoom);
 
-      normalController.dispose();
-      wideController.dispose();
-      zoomController.dispose();
+      unawaited(normalController.dispose());
+      unawaited(wideController.dispose());
+      unawaited(zoomController.dispose());
     });
 
     test('controller with all lens types can be created', () {
@@ -92,7 +94,7 @@ void main() {
         );
 
         expect(controller.lensType, lensType);
-        controller.dispose();
+        unawaited(controller.dispose());
       }
     });
 
@@ -107,7 +109,7 @@ void main() {
       // The lens type should remain the same (it's a final property)
       expect(controller.lensType, initialLensType);
 
-      controller.dispose();
+      unawaited(controller.dispose());
     });
   });
 }

--- a/test/mobile_scanner_controller_lens_type_test.dart
+++ b/test/mobile_scanner_controller_lens_type_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/camera_lens_type.dart';
+import 'package:mobile_scanner/src/mobile_scanner_controller.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MobileScannerController lens type tests', () {
+    test('controller initializes with default lens type (any)', () {
+      final controller = MobileScannerController();
+
+      expect(controller.lensType, CameraLensType.any);
+
+      controller.dispose();
+    });
+
+    test('controller initializes with normal lens type', () {
+      final controller = MobileScannerController(
+        lensType: CameraLensType.normal,
+      );
+
+      expect(controller.lensType, CameraLensType.normal);
+
+      controller.dispose();
+    });
+
+    test('controller initializes with wide lens type', () {
+      final controller = MobileScannerController(
+        lensType: CameraLensType.wide,
+      );
+
+      expect(controller.lensType, CameraLensType.wide);
+
+      controller.dispose();
+    });
+
+    test('controller initializes with zoom lens type', () {
+      final controller = MobileScannerController(
+        lensType: CameraLensType.zoom,
+      );
+
+      expect(controller.lensType, CameraLensType.zoom);
+
+      controller.dispose();
+    });
+
+    test('lens type persists throughout controller lifecycle', () {
+      final controller = MobileScannerController(
+        autoStart: false,
+        lensType: CameraLensType.zoom,
+      );
+
+      expect(controller.lensType, CameraLensType.zoom);
+
+      // Lens type should remain the same even after operations
+      expect(controller.lensType, CameraLensType.zoom);
+
+      controller.dispose();
+
+      // Even after disposal, the property should still be accessible
+      expect(controller.lensType, CameraLensType.zoom);
+    });
+
+    test('different controllers can have different lens types', () {
+      final normalController = MobileScannerController(
+        autoStart: false,
+        lensType: CameraLensType.normal,
+      );
+      final wideController = MobileScannerController(
+        autoStart: false,
+        lensType: CameraLensType.wide,
+      );
+      final zoomController = MobileScannerController(
+        autoStart: false,
+        lensType: CameraLensType.zoom,
+      );
+
+      expect(normalController.lensType, CameraLensType.normal);
+      expect(wideController.lensType, CameraLensType.wide);
+      expect(zoomController.lensType, CameraLensType.zoom);
+
+      normalController.dispose();
+      wideController.dispose();
+      zoomController.dispose();
+    });
+
+    test('controller with all lens types can be created', () {
+      for (final lensType in CameraLensType.values) {
+        final controller = MobileScannerController(
+          autoStart: false,
+          lensType: lensType,
+        );
+
+        expect(controller.lensType, lensType);
+        controller.dispose();
+      }
+    });
+
+    test('lens type property is read-only and immutable', () {
+      final controller = MobileScannerController(
+        lensType: CameraLensType.wide,
+      );
+
+      final initialLensType = controller.lensType;
+      expect(initialLensType, CameraLensType.wide);
+
+      // The lens type should remain the same (it's a final property)
+      expect(controller.lensType, initialLensType);
+
+      controller.dispose();
+    });
+  });
+}

--- a/test/start_options_test.dart
+++ b/test/start_options_test.dart
@@ -146,7 +146,9 @@ void main() {
         expect(
           map['lensType'],
           lensType.rawValue,
-          reason: 'Lens type $lensType should map to raw value ${lensType.rawValue}',
+          reason:
+              'Lens type $lensType should map to raw value '
+              '${lensType.rawValue}',
         );
       }
     });
@@ -163,12 +165,12 @@ void main() {
         torchEnabled: false,
         invertImage: false,
         autoZoom: false,
-        initialZoom: 2.0,
+        initialZoom: 2,
       );
 
       final map = options.toMap();
 
-      expect(map['initialZoom'], 2.0);
+      expect(map['initialZoom'], 2);
     });
 
     test('toMap handles all camera facing directions', () {
@@ -198,7 +200,9 @@ void main() {
         expect(
           map['facing'],
           facing.rawValue,
-          reason: 'Camera facing $facing should map to raw value ${facing.rawValue}',
+          reason:
+              'Camera facing $facing should map to raw value '
+              '${facing.rawValue}',
         );
       }
     });

--- a/test/start_options_test.dart
+++ b/test/start_options_test.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/barcode_format.dart';
+import 'package:mobile_scanner/src/enums/camera_facing.dart';
+import 'package:mobile_scanner/src/enums/camera_lens_type.dart';
+import 'package:mobile_scanner/src/enums/detection_speed.dart';
+import 'package:mobile_scanner/src/objects/start_options.dart';
+
+void main() {
+  group('$StartOptions tests', () {
+    test('toMap includes all required fields', () {
+      const options = StartOptions(
+        cameraDirection: CameraFacing.back,
+        cameraLensType: CameraLensType.normal,
+        cameraResolution: null,
+        detectionSpeed: DetectionSpeed.normal,
+        detectionTimeoutMs: 250,
+        formats: [],
+        returnImage: false,
+        torchEnabled: false,
+        invertImage: false,
+        autoZoom: false,
+        initialZoom: null,
+      );
+
+      final map = options.toMap();
+
+      expect(map['facing'], CameraFacing.back.rawValue);
+      expect(map['lensType'], CameraLensType.normal.rawValue);
+      expect(map['speed'], DetectionSpeed.normal.rawValue);
+      expect(map['timeout'], 250);
+      expect(map['returnImage'], false);
+      expect(map['torch'], false);
+      expect(map['invertImage'], false);
+      expect(map['autoZoom'], false);
+    });
+
+    test('toMap includes camera resolution when provided', () {
+      const options = StartOptions(
+        cameraDirection: CameraFacing.back,
+        cameraLensType: CameraLensType.any,
+        cameraResolution: Size(1920, 1080),
+        detectionSpeed: DetectionSpeed.normal,
+        detectionTimeoutMs: 250,
+        formats: [],
+        returnImage: false,
+        torchEnabled: false,
+        invertImage: false,
+        autoZoom: false,
+        initialZoom: null,
+      );
+
+      final map = options.toMap();
+
+      expect(map['cameraResolution'], [1920, 1080]);
+    });
+
+    test('toMap excludes camera resolution when null', () {
+      const options = StartOptions(
+        cameraDirection: CameraFacing.back,
+        cameraLensType: CameraLensType.any,
+        cameraResolution: null,
+        detectionSpeed: DetectionSpeed.normal,
+        detectionTimeoutMs: 250,
+        formats: [],
+        returnImage: false,
+        torchEnabled: false,
+        invertImage: false,
+        autoZoom: false,
+        initialZoom: null,
+      );
+
+      final map = options.toMap();
+
+      expect(map.containsKey('cameraResolution'), false);
+    });
+
+    test('toMap includes formats when provided', () {
+      const options = StartOptions(
+        cameraDirection: CameraFacing.back,
+        cameraLensType: CameraLensType.any,
+        cameraResolution: null,
+        detectionSpeed: DetectionSpeed.normal,
+        detectionTimeoutMs: 250,
+        formats: [BarcodeFormat.qrCode, BarcodeFormat.code128],
+        returnImage: false,
+        torchEnabled: false,
+        invertImage: false,
+        autoZoom: false,
+        initialZoom: null,
+      );
+
+      final map = options.toMap();
+
+      expect(
+        map['formats'],
+        [BarcodeFormat.qrCode.rawValue, BarcodeFormat.code128.rawValue],
+      );
+    });
+
+    test('toMap excludes formats when empty', () {
+      const options = StartOptions(
+        cameraDirection: CameraFacing.back,
+        cameraLensType: CameraLensType.any,
+        cameraResolution: null,
+        detectionSpeed: DetectionSpeed.normal,
+        detectionTimeoutMs: 250,
+        formats: [],
+        returnImage: false,
+        torchEnabled: false,
+        invertImage: false,
+        autoZoom: false,
+        initialZoom: null,
+      );
+
+      final map = options.toMap();
+
+      expect(map.containsKey('formats'), false);
+    });
+
+    test('toMap correctly maps all lens types', () {
+      const lensTypes = [
+        CameraLensType.normal,
+        CameraLensType.wide,
+        CameraLensType.zoom,
+        CameraLensType.any,
+      ];
+
+      for (final lensType in lensTypes) {
+        final options = StartOptions(
+          cameraDirection: CameraFacing.back,
+          cameraLensType: lensType,
+          cameraResolution: null,
+          detectionSpeed: DetectionSpeed.normal,
+          detectionTimeoutMs: 250,
+          formats: [],
+          returnImage: false,
+          torchEnabled: false,
+          invertImage: false,
+          autoZoom: false,
+          initialZoom: null,
+        );
+
+        final map = options.toMap();
+
+        expect(
+          map['lensType'],
+          lensType.rawValue,
+          reason: 'Lens type $lensType should map to raw value ${lensType.rawValue}',
+        );
+      }
+    });
+
+    test('toMap includes initialZoom when provided', () {
+      const options = StartOptions(
+        cameraDirection: CameraFacing.back,
+        cameraLensType: CameraLensType.any,
+        cameraResolution: null,
+        detectionSpeed: DetectionSpeed.normal,
+        detectionTimeoutMs: 250,
+        formats: [],
+        returnImage: false,
+        torchEnabled: false,
+        invertImage: false,
+        autoZoom: false,
+        initialZoom: 2.0,
+      );
+
+      final map = options.toMap();
+
+      expect(map['initialZoom'], 2.0);
+    });
+
+    test('toMap handles all camera facing directions', () {
+      const facingDirections = [
+        CameraFacing.front,
+        CameraFacing.back,
+        CameraFacing.external,
+      ];
+
+      for (final facing in facingDirections) {
+        final options = StartOptions(
+          cameraDirection: facing,
+          cameraLensType: CameraLensType.any,
+          cameraResolution: null,
+          detectionSpeed: DetectionSpeed.normal,
+          detectionTimeoutMs: 250,
+          formats: [],
+          returnImage: false,
+          torchEnabled: false,
+          invertImage: false,
+          autoZoom: false,
+          initialZoom: null,
+        );
+
+        final map = options.toMap();
+
+        expect(
+          map['facing'],
+          facing.rawValue,
+          reason: 'Camera facing $facing should map to raw value ${facing.rawValue}',
+        );
+      }
+    });
+
+    test('toMap handles boolean flags correctly', () {
+      const testCases = [
+        (returnImage: true, torch: true, invertImage: true, autoZoom: true),
+        (returnImage: false, torch: false, invertImage: false, autoZoom: false),
+        (returnImage: true, torch: false, invertImage: true, autoZoom: false),
+      ];
+
+      for (final testCase in testCases) {
+        final options = StartOptions(
+          cameraDirection: CameraFacing.back,
+          cameraLensType: CameraLensType.any,
+          cameraResolution: null,
+          detectionSpeed: DetectionSpeed.normal,
+          detectionTimeoutMs: 250,
+          formats: [],
+          returnImage: testCase.returnImage,
+          torchEnabled: testCase.torch,
+          invertImage: testCase.invertImage,
+          autoZoom: testCase.autoZoom,
+          initialZoom: null,
+        );
+
+        final map = options.toMap();
+
+        expect(map['returnImage'], testCase.returnImage);
+        expect(map['torch'], testCase.torch);
+        expect(map['invertImage'], testCase.invertImage);
+        expect(map['autoZoom'], testCase.autoZoom);
+      }
+    });
+  });
+}


### PR DESCRIPTION
This PR adds support for selecting specific camera lens types (normal, wide, zoom) on devices with multiple cameras. 

The implementation includes a new lensType parameter in MobileScannerController, a getSupportedLenses() method to query available lenses, and platform-specific lens detection using Camera2 API on Android and AVCaptureDevice on iOS. 

I've also updated the example app includes a lens switcher button that cycles through available lenses and a menu item to display supported lens types.