### PR TITLE
fix(android): respect app orientation lock in camera preview

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/DeviceOrientationListener.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/DeviceOrientationListener.kt
@@ -2,11 +2,15 @@ package dev.steenbakker.mobile_scanner
 
 import android.app.Activity
 import android.content.Context
+import android.content.res.Configuration
 import android.hardware.SensorManager
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.view.Display
 import android.view.OrientationEventListener
 import android.view.Surface
+import android.view.WindowManager
 import dev.steenbakker.mobile_scanner.utils.serialize
 import io.flutter.embedding.engine.systemchannels.PlatformChannel
 import io.flutter.plugin.common.EventChannel
@@ -50,17 +54,51 @@ class DeviceOrientationListener(
         disable()
     }
 
+    @Suppress("deprecation")
+    private fun getDisplay(): Display {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activity.display!!
+        } else {
+            (activity.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
+        }
+    }
+
+    /**
+     * Gets the current user interface orientation based on the display rotation
+     * and configuration orientation. This respects the app's orientation lock.
+     */
+    private fun getUIOrientation(): PlatformChannel.DeviceOrientation {
+        val rotation: Int = getDisplay().rotation
+        val orientation: Int = activity.resources.configuration.orientation
+
+        return when(orientation) {
+            Configuration.ORIENTATION_PORTRAIT -> {
+                if (rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_90) {
+                    PlatformChannel.DeviceOrientation.PORTRAIT_UP
+                } else {
+                    PlatformChannel.DeviceOrientation.PORTRAIT_DOWN
+                }
+            }
+            Configuration.ORIENTATION_LANDSCAPE -> {
+                if (rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_90) {
+                    PlatformChannel.DeviceOrientation.LANDSCAPE_LEFT
+                } else {
+                    PlatformChannel.DeviceOrientation.LANDSCAPE_RIGHT
+                }
+            }
+            Configuration.ORIENTATION_UNDEFINED -> PlatformChannel.DeviceOrientation.PORTRAIT_UP
+            else -> PlatformChannel.DeviceOrientation.PORTRAIT_UP
+        }
+    }
+
     override fun onOrientationChanged(orientation: Int) {
         if (orientation == ORIENTATION_UNKNOWN) {
             return
         }
 
-        val newOrientation = when (orientation) {
-            in 45..134 -> PlatformChannel.DeviceOrientation.LANDSCAPE_RIGHT
-            in 135..224 -> PlatformChannel.DeviceOrientation.PORTRAIT_DOWN
-            in 225..314 -> PlatformChannel.DeviceOrientation.LANDSCAPE_LEFT
-            else -> PlatformChannel.DeviceOrientation.PORTRAIT_UP
-        }
+        // Use the actual UI orientation instead of sensor orientation
+        // This ensures we respect the app's orientation lock
+        val newOrientation = getUIOrientation()
 
         if (newOrientation != lastOrientation) {
             lastOrientation = newOrientation


### PR DESCRIPTION
Fixes #1571

The camera preview was rotating even when the app orientation was locked to portrait mode using SystemChrome.setPreferredOrientations. This was caused by OrientationEventListener responding to physical device rotation regardless of the app's orientation lock.

Changes:
- Modified onOrientationChanged to use getUIOrientation() instead of raw sensor data
- Added getUIOrientation() method that checks both Configuration.orientation and Display.rotation to respect the app's actual orientation
- Added getDisplay() helper method with Android R compatibility

This ensures the camera preview respects the app's orientation lock and prevents distortion when the device is physically rotated.