### PR TITLE
feat: add option to disable device orientation listener and fix overlay tap blocking

### DIFF
--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -296,7 +296,10 @@ class _MobileScannerState extends State<MobileScanner>
                   tapToFocusScannerWidget
                 else
                   scannerWidget,
-                IgnorePointer(child: overlay),
+                IgnorePointer(
+                  ignoring: widget.tapToFocus,
+                  child: overlay,
+                ),
               ],
             );
           },

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -34,6 +34,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
     this.torchEnabled = false,
     this.invertImage = false,
     this.autoZoom = false,
+    this.disableDeviceOrientationListener = false,
     this.initialZoom,
   }) : detectionTimeoutMs =
            detectionSpeed == DetectionSpeed.normal ? detectionTimeoutMs : 0,
@@ -135,6 +136,15 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   StreamSubscription<double>? _zoomScaleSubscription;
   StreamSubscription<DeviceOrientation>? _deviceOrientationSubscription;
 
+  /// Whether to disable the device orientation listener.
+  ///
+  /// When set to true, the controller will not listen to device orientation
+  /// changes and will not update the [MobileScannerState.deviceOrientation]
+  /// value.
+  ///
+  /// Defaults to false.
+  final bool disableDeviceOrientationListener;
+
   bool _isDisposed = false;
   // This completer keeps track of whether the MobileScanner widget,
   // that is attached to this controller,
@@ -194,7 +204,8 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
 
     if (MobileScannerPlatform.instance
         case final MethodChannelMobileScanner implementation
-        when defaultTargetPlatform != TargetPlatform.macOS) {
+        when defaultTargetPlatform != TargetPlatform.macOS &&
+            !disableDeviceOrientationListener) {
       _deviceOrientationSubscription = implementation
           .deviceOrientationChangedStream
           .listen((DeviceOrientation orientation) {


### PR DESCRIPTION
### Summary
This change introduces a way to prevent the controller from subscribing to device orientation updates, useful in scenarios where these updates are unnecessary or interfere with external logic.  
It works on Android and iOS.  
It can also help with the issues below while there is no implementation that fully respects the app orientation settings:

- #1588  
- #1579  
- #1571
- #1596

### What is included
- New `disableDeviceOrientationListener` parameter in `MobileScannerController`, allowing developers to opt out of orientation listening.
- Field documented with purpose and default value.
- Initialization updated to skip subscribing to orientation changes when `disableDeviceOrientationListener` is enabled.

### Additional fix
While working on this improvement, an issue was also fixed where an `IgnorePointer` widget was blocking all taps on the overlay even when `tapToFocus` was false

### Demo
<table>
<tr>
 <th> Listener enabled
 <th> Listener disabled
<tr>
 <td>

[<!-- Substitua essa linha com a imagem do antes e mantenha o espaço acima -->](https://github.com/user-attachments/assets/1e74f697-bb5f-4063-86c0-62e0b5f6d27b)
 <td>

[<!-- Substitua essa linha com a imagem do depois e mantenha o espaço acima -->](https://github.com/user-attachments/assets/342f8b1a-94af-4fea-beaa-dc1c3bd928aa)
</table>

