### PR TITLE
fix: improve pixel format selection for video output on iPhone 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 7.1.4
+
+* [Apple] Fixed crash on iPhone 17 when starting MobileScanner by checking available pixel formats before setting video output settings. ([#1578](https://github.com/juliansteenbakker/mobile_scanner/issues/1578))
+
 ### 7.1.3
 
 * Overlay: Updated `BarcodePainter` to receive `deviceOrientation` and dynamically adjust `cameraPreviewSize`, fixing barcode overlay misalignment during device rotation changes [](https://github.com/juliansteenbakker/mobile_scanner/issues/1462).

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -457,7 +457,43 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
 
         // Add video output
         let videoOutput = AVCaptureVideoDataOutput()
-        videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+        
+        // Fix for iPhone 17: Check available pixel formats before setting
+        // Issue: https://github.com/juliansteenbakker/mobile_scanner/issues/1578
+        
+        // Define preferred pixel formats in order of preference
+        let preferredFormats: [OSType] = [
+            kCVPixelFormatType_32BGRA,
+            kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+            kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+        ]
+        
+        // Get available formats and convert from NSNumber to OSType
+        let availableFormats = videoOutput.availableVideoPixelFormatTypes
+        let availablePixelFormats = availableFormats.compactMap { ($0 as NSNumber).uint32Value }
+        
+        // Find the first preferred format that is available
+        var selectedFormat: OSType?
+        for format in preferredFormats {
+            if availablePixelFormats.contains(format) {
+                selectedFormat = format
+                break
+            }
+        }
+        
+        // Fallback: use first available format if no preferred format found
+        if selectedFormat == nil, let firstAvailable = availablePixelFormats.first {
+            selectedFormat = firstAvailable
+        }
+        
+        // Apply the selected format or fallback to the old default
+        if let format = selectedFormat {
+            videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: format]
+        } else {
+            // Ultimate fallback: use the original default format
+            videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+        }
+        
         videoOutput.alwaysDiscardsLateVideoFrames = true
 
         videoOutput.setSampleBufferDelegate(self, queue: DispatchQueue.main)

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -455,53 +455,15 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         }
         captureSession!.sessionPreset = AVCaptureSession.Preset.high
 
-        // Add video output
         let videoOutput = AVCaptureVideoDataOutput()
-        
-        // Fix for iPhone 17: Check available pixel formats before setting
-        // Issue: https://github.com/juliansteenbakker/mobile_scanner/issues/1578
-        
-        // Define preferred pixel formats in order of preference
-        let preferredFormats: [OSType] = [
-            kCVPixelFormatType_32BGRA,
-            kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
-            kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
-        ]
-        
-        // Get available formats and convert from NSNumber to OSType
-        let availableFormats = videoOutput.availableVideoPixelFormatTypes
-        let availablePixelFormats = availableFormats.compactMap { ($0 as NSNumber).uint32Value }
-        
-        // Find the first preferred format that is available
-        var selectedFormat: OSType?
-        for format in preferredFormats {
-            if availablePixelFormats.contains(format) {
-                selectedFormat = format
-                break
-            }
-        }
-        
-        // Fallback: use first available format if no preferred format found
-        if selectedFormat == nil, let firstAvailable = availablePixelFormats.first {
-            selectedFormat = firstAvailable
-        }
-        
-        // Apply the selected format or fallback to the old default
-        if let format = selectedFormat {
-            videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: format]
-        } else {
-            // Ultimate fallback: use the original default format
-            videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
-        }
-        
-        videoOutput.alwaysDiscardsLateVideoFrames = true
 
+        let format = getPreferredVideoFormat(videoOutput: videoOutput)
+        videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: format]
+        videoOutput.alwaysDiscardsLateVideoFrames = true
         videoOutput.setSampleBufferDelegate(self, queue: DispatchQueue.main)
         captureSession!.addOutput(videoOutput)
         let deviceVideoOrientation = self.getVideoOrientation()
-        
 
-        // Adjust orientation for the video connection
         if let connection = videoOutput.connections.first {
             if connection.isVideoOrientationSupported {
                 connection.videoOrientation = deviceVideoOrientation
@@ -514,7 +476,6 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
 
         captureSession!.commitConfiguration()
 
-        // Move startRunning to a background thread to avoid blocking the main UI thread.
         DispatchQueue.global(qos: .background).async {
             self.captureSession!.startRunning()
 
@@ -527,12 +488,10 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                     dimensions = CMVideoDimensions()
                 }
 
-                // Turn on the torch if requested.
                 if (torch) {
                     self.turnTorchOn()
                 }
                 
-                // Set the initial zoom factor
                 if (initialZoom != nil) {
                     do {
                         try self.setScaleInternal(initialZoom!)
@@ -577,6 +536,34 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                 result(answer)
             }
         }
+    }
+
+    /// Get the preferred video format for the given video output.
+    private func getPreferredVideoFormat(videoOutput: AVCaptureVideoDataOutput) -> OSType {
+        // Define preferred pixel formats in order of preference
+        let preferredFormats: [OSType] = [
+            kCVPixelFormatType_32BGRA,
+            kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+            kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+        ]
+        
+        // Get available formats and convert from NSNumber to OSType
+        let availableFormats = videoOutput.availableVideoPixelFormatTypes
+        let availablePixelFormats = availableFormats.compactMap { ($0 as NSNumber).uint32Value }
+        
+        // Find the first preferred format that is available
+        for format in preferredFormats {
+            if availablePixelFormats.contains(format) {
+                return format
+            }
+        }
+        
+        if let firstAvailable = availablePixelFormats.first {
+            return firstAvailable
+        }
+        
+        // Ultimate fallback: use the original default format
+        return kCVPixelFormatType_32BGRA
     }
 
     /// Turn the torch on.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal Flutter barcode and QR code scanner using CameraX/ML Kit for Android, AVFoundation/Apple Vision for iOS & macOS, and ZXing for web.
-version: 7.1.3
+version: 7.1.4
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 screenshots:


### PR DESCRIPTION
# Improve Pixel Format Selection for Video Output on iPhone 17

## Problem

iPhone 17 devices (iOS 26.0.1) crash when starting MobileScanner with the error:
```
-[AVCaptureVideoDataOutput setVideoSettings:] Unsupported pixel format type - use -availableVideoCVPixelFormatTypes
```

**Root Cause**: The code was hardcoding a pixel format (`kCVPixelFormatType_32BGRA`) without checking which formats are actually supported by the device. On iPhone 17, this format is not available, causing the crash.

## Solution

Updated the pixel format selection logic in `start()` to:

1. **Check available formats**: Use `availableVideoPixelFormatTypes` from `AVCaptureVideoDataOutput` to query supported pixel formats on the device.

2. **Prioritize formats in order**:
   - `kCVPixelFormatType_32BGRA`
   - `kCVPixelFormatType_420YpCbCr8BiPlanarFullRange`
   - `kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange`

3. **Fallback**: If none of the preferred formats are available, select the first available format from the device's supported formats.

This ensures we only set a pixel format that the device supports, preventing crashes on iPhone 17 and newer devices while maintaining backward compatibility with older iOS devices.

## Code Changes

- **Location**: `darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift` (lines 461-495)
- **Change**: Replaced hardcoded pixel format assignment with dynamic format selection logic that checks device capabilities before setting `videoSettings`.

## Result

- ✅ No more crashes on iPhone 17 when starting the scanner
- ✅ Backward compatible with older iOS devices
- ✅ Automatically selects the best available format based on device capabilities

## References

- Issue: https://github.com/juliansteenbakker/mobile_scanner/issues/1578
- Similar issue reported in Flutter camera package

Fixes #1578

