### PR TITLE
fix: [Android] reset isPaused flag on start() called

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -368,6 +368,8 @@ class MobileScanner(
         this.returnImage = returnImage
         this.invertImage = invertImage
 
+        isPaused = false
+        
         if (camera?.cameraInfo != null && preview != null && surfaceProducer != null && !isPaused) {
 
 // TODO: resume here for seamless transition


### PR DESCRIPTION
Fix for Android's reset of the flag isPaused, when start is called. After the first pause() it is set to true, but after never reset, so it always stays isPaused.
There is an open issue about this : https://github.com/juliansteenbakker/mobile_scanner/issues/1615