### PR TITLE
fix: replaced dead analysisBuilder with correct target rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.3.0
+## NEXT
 
 **Improvements**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 7.3.0
+
+**Improvements**
+
+* [Android] Migrated barcode bounding box from `boundingBox` to `cornerPoints` for more accurate scan window detection.
+
+**Bug Fixes**
+
+* [Android] Fixed incorrect texture size on orientation change.
+* Fixed overlay rendering at wrong position after orientation change.
+
 ## 7.2.0
 
 **Highlights**

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/DeviceOrientationListener.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/DeviceOrientationListener.kt
@@ -30,11 +30,15 @@ class DeviceOrientationListener(
     // The last received orientation. This is used to prevent duplicate events.
     private var lastOrientation: PlatformChannel.DeviceOrientation? = null
 
+    /// Called with the new [Surface.ROTATION_*] value whenever the display rotation changes.
+    var onDisplayRotationChanged: ((Int) -> Unit)? = null
+
     // Listener for display configuration changes.
     private val displayListener = object : DisplayManager.DisplayListener {
         override fun onDisplayAdded(displayId: Int) {}
         override fun onDisplayRemoved(displayId: Int) {}
         override fun onDisplayChanged(displayId: Int) {
+            onDisplayRotationChanged?.invoke(getDisplay().rotation)
             sendOrientationIfChanged()
         }
     }

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/DeviceOrientationListener.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/DeviceOrientationListener.kt
@@ -65,6 +65,7 @@ class DeviceOrientationListener(
     fun stop() {
         val displayManager = activity.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
         displayManager.unregisterDisplayListener(displayListener)
+        onDisplayRotationChanged = null
     }
 
     @Suppress("deprecation")

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/DeviceOrientationListener.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/DeviceOrientationListener.kt
@@ -30,7 +30,7 @@ class DeviceOrientationListener(
     // The last received orientation. This is used to prevent duplicate events.
     private var lastOrientation: PlatformChannel.DeviceOrientation? = null
 
-    /// Called with the new [Surface.ROTATION_*] value whenever the display rotation changes.
+    // Called with the new [Surface.ROTATION_*] value whenever the display rotation changes.
     var onDisplayRotationChanged: ((Int) -> Unit)? = null
 
     // Listener for display configuration changes.

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -321,13 +321,12 @@ class MobileScanner(
         barcode: Barcode,
         inputImage: ImageProxy
     ): Boolean {
-        // TODO: use `cornerPoints` instead, since the bounding box is not bound to the coordinate system of the input image
-        // On iOS we do this correctly, so the calculation should match that.
-        val barcodeBoundingBox = barcode.boundingBox ?: return false
+        val cornerPoints = barcode.cornerPoints ?: return false
 
         try {
-            val imageWidth = inputImage.height
-            val imageHeight = inputImage.width
+            val rotationDegrees = inputImage.imageInfo.rotationDegrees
+            val imageWidth = if (rotationDegrees % 180 == 0) inputImage.width else inputImage.height
+            val imageHeight = if (rotationDegrees % 180 == 0) inputImage.height else inputImage.width
 
             val left = (scanWindow[0] * imageWidth).roundToInt()
             val top = (scanWindow[1] * imageHeight).roundToInt()
@@ -336,7 +335,7 @@ class MobileScanner(
 
             val scaledScanWindow = Rect(left, top, right, bottom)
 
-            return scaledScanWindow.contains(barcodeBoundingBox)
+            return cornerPoints.all { scaledScanWindow.contains(it.x, it.y) }
         } catch (_: IllegalArgumentException) {
             // Rounding of the scan window dimensions can fail, due to encountering NaN.
             // If we get NaN, rather than give a false positive, just return false.

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -1,10 +1,8 @@
 package dev.steenbakker.mobile_scanner
 
 import android.app.Activity
-import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Rect
-import android.hardware.display.DisplayManager
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
@@ -75,7 +73,6 @@ class MobileScanner(
     private var scanner: BarcodeScanner? = null
     private var lastScanned: List<String?>? = null
     private var scannerTimeout = false
-    private var displayListener: DisplayManager.DisplayListener? = null
     private var imageAnalysis: ImageAnalysis? = null
     private var analysisExecutor = Executors.newSingleThreadExecutor()
 
@@ -424,7 +421,6 @@ class MobileScanner(
             val analysisBuilder = ImageAnalysis.Builder()
                 .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                 .setOutputImageFormat(OUTPUT_IMAGE_FORMAT_YUV_420_888)
-            val displayManager = activity.applicationContext.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
 
             val cameraResolution =  cameraResolutionWanted ?: Size(1920, 1080)
 
@@ -437,20 +433,8 @@ class MobileScanner(
             )
             analysisBuilder.setResolutionSelector(selectorBuilder.build()).build()
 
-            if (displayListener == null) {
-                displayListener = object : DisplayManager.DisplayListener {
-                    override fun onDisplayAdded(displayId: Int) {}
-
-                    override fun onDisplayRemoved(displayId: Int) {}
-
-                    override fun onDisplayChanged(displayId: Int) {
-                        imageAnalysis?.targetRotation = activity.display?.rotation ?: Surface.ROTATION_0
-                    }
-                }
-
-                displayManager.registerDisplayListener(
-                    displayListener, null,
-                )
+            deviceOrientationListener.onDisplayRotationChanged = { rotation ->
+                imageAnalysis?.targetRotation = rotation
             }
 
             val analysis = analysisBuilder.build().apply { setAnalyzer(analysisExecutor, captureOutput) }
@@ -585,13 +569,6 @@ class MobileScanner(
 //    }
 
     private fun releaseCamera() {
-        if (displayListener != null) {
-            val displayManager = activity.applicationContext.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-
-            displayManager.unregisterDisplayListener(displayListener)
-            displayListener = null
-        }
-
         val owner = activity as LifecycleOwner
         // Release the camera observers first.
         camera?.cameraInfo?.let {

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -603,6 +603,7 @@ class MobileScanner(
         // Unbind the camera use cases, the preview is a use case.
         // The camera will be closed when the last use case is unbound.
         cameraProvider?.unbindAll()
+        imageAnalysis = null
 
         // Release the surface for the preview.
         surfaceProducer?.release()

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mobile_scanner/src/method_channel/mobile_scanner_method_channel.dart';
 import 'package:mobile_scanner/src/mobile_scanner_controller.dart';
 import 'package:mobile_scanner/src/mobile_scanner_exception.dart';
@@ -251,7 +252,13 @@ class _MobileScannerState extends State<MobileScanner>
         ScanWindowUtils.calculateScanWindowRelativeToTextureInPercentage(
           widget.fit,
           widgetScanWindow,
-          textureSize: scannerState.size,
+          textureSize:
+              scannerState.deviceOrientation ==
+                          DeviceOrientation.landscapeLeft ||
+                      scannerState.deviceOrientation ==
+                          DeviceOrientation.landscapeRight
+                  ? scannerState.size.flipped
+                  : scannerState.size,
           widgetSize: constraints.biggest,
         );
 

--- a/lib/src/mobile_scanner.dart
+++ b/lib/src/mobile_scanner.dart
@@ -252,13 +252,12 @@ class _MobileScannerState extends State<MobileScanner>
         ScanWindowUtils.calculateScanWindowRelativeToTextureInPercentage(
           widget.fit,
           widgetScanWindow,
-          textureSize:
-              scannerState.deviceOrientation ==
-                          DeviceOrientation.landscapeLeft ||
-                      scannerState.deviceOrientation ==
-                          DeviceOrientation.landscapeRight
-                  ? scannerState.size.flipped
-                  : scannerState.size,
+          textureSize: switch (scannerState.deviceOrientation) {
+            DeviceOrientation.landscapeLeft ||
+            DeviceOrientation.landscapeRight => scannerState.size.flipped,
+            DeviceOrientation.portraitUp ||
+            DeviceOrientation.portraitDown => scannerState.size,
+          },
           widgetSize: constraints.biggest,
         );
 

--- a/lib/src/overlay/barcode_overlay.dart
+++ b/lib/src/overlay/barcode_overlay.dart
@@ -41,12 +41,39 @@ class _BarcodeOverlayState extends State<BarcodeOverlay> {
   );
 
   DeviceOrientation? _lastOrientation;
-  bool _orientationChanged = false;
+  int _orientationResetKey = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onControllerChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant BarcodeOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_onControllerChanged);
+      widget.controller.addListener(_onControllerChanged);
+      _lastOrientation = null;
+    }
+  }
 
   @override
   void dispose() {
+    widget.controller.removeListener(_onControllerChanged);
     _textPainter.dispose();
     super.dispose();
+  }
+
+  void _onControllerChanged() {
+    final orientation = widget.controller.value.deviceOrientation;
+    if (_lastOrientation != null && _lastOrientation != orientation) {
+      setState(() {
+        _orientationResetKey++;
+      });
+    }
+    _lastOrientation = orientation;
   }
 
   @override
@@ -59,24 +86,10 @@ class _BarcodeOverlayState extends State<BarcodeOverlay> {
           return const SizedBox();
         }
 
-        // Mark stale when the device orientation changes,
-        // so the StreamBuilder discards its current snapshot.
-        if (_lastOrientation != null &&
-            _lastOrientation != value.deviceOrientation) {
-          _orientationChanged = true;
-        }
-        _lastOrientation = value.deviceOrientation;
-
         return StreamBuilder<BarcodeCapture>(
+          key: ValueKey(_orientationResetKey),
           stream: widget.controller.barcodes,
           builder: (context, snapshot) {
-            // Discard the stale snapshot from before the rotation.
-            // The next stream event will provide fresh corners.
-            if (_orientationChanged) {
-              _orientationChanged = false;
-              return const SizedBox();
-            }
-
             final barcodeCapture = snapshot.data;
 
             // No barcode or preview size.

--- a/lib/src/overlay/barcode_overlay.dart
+++ b/lib/src/overlay/barcode_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 /// This widget represents an overlay that paints the bounding boxes of detected
@@ -39,6 +40,9 @@ class _BarcodeOverlayState extends State<BarcodeOverlay> {
     textDirection: TextDirection.ltr,
   );
 
+  DeviceOrientation? _lastOrientation;
+  bool _orientationChanged = false;
+
   @override
   void dispose() {
     _textPainter.dispose();
@@ -55,9 +59,24 @@ class _BarcodeOverlayState extends State<BarcodeOverlay> {
           return const SizedBox();
         }
 
+        // Mark stale when the device orientation changes,
+        // so the StreamBuilder discards its current snapshot.
+        if (_lastOrientation != null &&
+            _lastOrientation != value.deviceOrientation) {
+          _orientationChanged = true;
+        }
+        _lastOrientation = value.deviceOrientation;
+
         return StreamBuilder<BarcodeCapture>(
           stream: widget.controller.barcodes,
           builder: (context, snapshot) {
+            // Discard the stale snapshot from before the rotation.
+            // The next stream event will provide fresh corners.
+            if (_orientationChanged) {
+              _orientationChanged = false;
+              return const SizedBox();
+            }
+
             final barcodeCapture = snapshot.data;
 
             // No barcode or preview size.


### PR DESCRIPTION
This PR fixes the orientation of the overlay on rotation of the device by updating the targetRotation of the analysis object.

It also removes the dead ResolutionSelector code, as the analysisBuilder is never used after building.