### PR TITLE
feat: web camera improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [Web] The preferred camera device ID is now persisted in localStorage and reused on the next start.
 * [Web] Focus, exposure, and white-balance constraints are now applied automatically when supported by the browser (Image Capture API).
-* [Web] The camera now uses [StartOptions().cameraResolution], and falls back to 1920×1080 as the ideal resolution for improved barcode detection.
+* [Web] The camera now uses `StartOptions.cameraResolution` as the ideal resolution, falling back to 1920×1080.
 * [Web] The barcode overlay is now mirrored when the video preview is mirrored (e.g. front camera).
 
 ## 7.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [Web] The preferred camera device ID is now persisted in localStorage and reused on the next start.
 * [Web] Focus, exposure, and white-balance constraints are now applied automatically when supported by the browser (Image Capture API).
+* [Web] The camera now requests 1920×1080 as the ideal resolution for improved barcode detection.
 
 ## 7.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [Web] The preferred camera device ID is now persisted in localStorage and reused on the next start.
 * [Web] Focus, exposure, and white-balance constraints are now applied automatically when supported by the browser (Image Capture API).
 * [Web] The camera now requests 1920×1080 as the ideal resolution for improved barcode detection.
+* [Web] The barcode overlay is now mirrored when the video preview is mirrored (e.g. front camera).
 
 ## 7.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [Web] The preferred camera device ID is now persisted in localStorage and reused on the next start.
 * [Web] Focus, exposure, and white-balance constraints are now applied automatically when supported by the browser (Image Capture API).
-* [Web] The camera now requests 1920×1080 as the ideal resolution for improved barcode detection.
+* [Web] The camera now uses [StartOptions().cameraResolution], and falls back to 1920×1080 as the ideal resolution for improved barcode detection.
 * [Web] The barcode overlay is now mirrored when the video preview is mirrored (e.g. front camera).
 
 ## 7.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## NEXT
+
+**Improvements**
+
+* [Web] The preferred camera device ID is now persisted in localStorage and reused on the next start.
+* [Web] Focus, exposure, and white-balance constraints are now applied automatically when supported by the browser (Image Capture API).
+
 ## 7.2.0
 
 **Highlights**

--- a/lib/src/web/media_track_extension.dart
+++ b/lib/src/web/media_track_extension.dart
@@ -24,4 +24,8 @@ extension NullableMediaTrackSettings on MediaTrackSettings {
   /// even though the capability is supported.
   @JS('facingMode')
   external JSString? get facingModeNullable;
+
+  /// The `deviceId` of the source device for this track.
+  @JS('deviceId')
+  external JSString? get deviceIdNullable;
 }

--- a/lib/src/web/media_track_extension.dart
+++ b/lib/src/web/media_track_extension.dart
@@ -5,6 +5,7 @@ import 'package:web/web.dart';
 /// to handle non-secure contexts (HTTP) where [Navigator.mediaDevices]
 /// is undefined.
 extension NullableNavigatorMediaDevices on Navigator {
+  /// The `mediaDevices` of the source device.
   @JS('mediaDevices')
   external MediaDevices? get mediaDevicesNullable;
 }

--- a/lib/src/web/media_track_extension.dart
+++ b/lib/src/web/media_track_extension.dart
@@ -1,6 +1,14 @@
 import 'dart:js_interop';
 import 'package:web/web.dart';
 
+/// This extension provides a nullable [mediaDevices] property for [Navigator],
+/// to handle non-secure contexts (HTTP) where [Navigator.mediaDevices]
+/// is undefined.
+extension NullableNavigatorMediaDevices on Navigator {
+  @JS('mediaDevices')
+  external MediaDevices? get mediaDevicesNullable;
+}
+
 /// This extension provides nullable properties for [MediaTrackCapabilities],
 /// for cases where the properties are not supported by all browsers.
 extension NullableMediaTrackCapabilities on MediaTrackCapabilities {

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -185,7 +185,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
   String? _getStoredDeviceId() {
     try {
       return window.localStorage.getItem(_kPreferredDeviceIdKey);
-    } on Object catch (_) {
+    } on DOMException catch (_) {
       return null;
     }
   }
@@ -194,7 +194,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
   void _storeDeviceId(String deviceId) {
     try {
       window.localStorage.setItem(_kPreferredDeviceIdKey, deviceId);
-    } on Object catch (_) {
+    } on DOMException catch (_) {
       // Ignore — e.g. Safari private browsing mode disables storage.
     }
   }
@@ -208,7 +208,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
       return devices.any(
         (d) => d.kind == 'videoinput' && d.deviceId == deviceId,
       );
-    } on Object catch (_) {
+    } on DOMException catch (_) {
       return false;
     }
   }

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -256,6 +256,10 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
     final capabilities = mediaDevices.getSupportedConstraints();
 
+    // Request high resolution for better barcode detection.
+    final width = ConstrainULongRange(ideal: 1920);
+    final height = ConstrainULongRange(ideal: 1080);
+
     var useStoredDevice = false;
     final MediaStreamConstraints constraints;
 
@@ -268,16 +272,26 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
       constraints = useStoredDevice
           ? MediaStreamConstraints(
-              video: MediaTrackConstraintSet(deviceId: storedDeviceId.toJS),
+              video: MediaTrackConstraintSet(
+                deviceId: storedDeviceId.toJS,
+                width: width,
+                height: height,
+              ),
             )
-          : MediaStreamConstraints(video: true.toJS);
+          : MediaStreamConstraints(
+              video: MediaTrackConstraintSet(width: width, height: height),
+            );
     } else {
       // facingMode is supported (mobile). Always use it so that switching
       // between front and back cameras works correctly.
       final facingMode = _settingsDelegate.getFacingMode(cameraDirection);
 
       constraints = MediaStreamConstraints(
-        video: MediaTrackConstraintSet(facingMode: facingMode.toJS),
+        video: MediaTrackConstraintSet(
+          facingMode: facingMode.toJS,
+          width: width,
+          height: height,
+        ),
       );
     }
 

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -239,7 +239,10 @@ class MobileScannerWeb extends MobileScannerPlatform {
   /// Throws a [MobileScannerException] if the permission was denied,
   /// or if using a video stream, with the given set of constraints, is
   /// unsupported.
-  Future<MediaStream> _prepareVideoStream(CameraFacing cameraDirection) async {
+  Future<MediaStream> _prepareVideoStream(
+    CameraFacing cameraDirection, {
+    Size? cameraResolution,
+  }) async {
     final mediaDevices = window.navigator.mediaDevicesNullable;
 
     if (mediaDevices == null) {
@@ -254,9 +257,12 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
     final capabilities = mediaDevices.getSupportedConstraints();
 
-    // Request high resolution for better barcode detection.
-    final width = ConstrainULongRange(ideal: 1920);
-    final height = ConstrainULongRange(ideal: 1080);
+    final width = ConstrainULongRange(
+      ideal: cameraResolution?.width.toInt() ?? 1920,
+    );
+    final height = ConstrainULongRange(
+      ideal: cameraResolution?.height.toInt() ?? 1080,
+    );
 
     var useStoredDevice = false;
     final MediaStreamConstraints constraints;
@@ -442,7 +448,10 @@ class MobileScannerWeb extends MobileScannerPlatform {
     );
 
     // Request camera permissions and prepare the video stream.
-    final videoStream = await _prepareVideoStream(startOptions.cameraDirection);
+    final videoStream = await _prepareVideoStream(
+      startOptions.cameraDirection,
+      cameraResolution: startOptions.cameraResolution,
+    );
 
     try {
       // Clear the existing barcodes.

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -162,7 +162,9 @@ class MobileScannerWeb extends MobileScannerPlatform {
   /// or if using a video stream, with the given set of constraints, is
   /// unsupported.
   Future<MediaStream> _prepareVideoStream(CameraFacing cameraDirection) async {
-    if (window.navigator.mediaDevices.isUndefinedOrNull) {
+    final mediaDevices = window.navigator.mediaDevicesNullable;
+
+    if (mediaDevices == null) {
       throw const MobileScannerException(
         errorCode: MobileScannerErrorCode.unsupported,
         errorDetails: MobileScannerErrorDetails(
@@ -172,8 +174,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
       );
     }
 
-    final capabilities =
-        window.navigator.mediaDevices.getSupportedConstraints();
+    final capabilities = mediaDevices.getSupportedConstraints();
 
     final MediaStreamConstraints constraints;
 
@@ -190,7 +191,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
     try {
       // Retrieving the media devices requests the camera permission.
       final videoStream =
-          await window.navigator.mediaDevices.getUserMedia(constraints).toDart;
+          await mediaDevices.getUserMedia(constraints).toDart;
 
       return videoStream;
     } on DOMException catch (error, stackTrace) {
@@ -235,13 +236,14 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
   @override
   Future<Set<CameraLensType>> getSupportedLenses() async {
-    if (window.navigator.mediaDevices.isUndefinedOrNull) {
+    final mediaDevices = window.navigator.mediaDevicesNullable;
+
+    if (mediaDevices == null) {
       return <CameraLensType>{};
     }
 
     try {
-      final jsDevices =
-          await window.navigator.mediaDevices.enumerateDevices().toDart;
+      final jsDevices = await mediaDevices.enumerateDevices().toDart;
       final devices = jsDevices.toDart;
 
       final hasVideoInput = devices.any(

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -17,6 +17,7 @@ import 'package:mobile_scanner/src/objects/start_options.dart';
 import 'package:mobile_scanner/src/web/barcode_reader.dart';
 import 'package:mobile_scanner/src/web/media_track_constraints_delegate.dart';
 import 'package:mobile_scanner/src/web/media_track_extension.dart';
+import 'package:mobile_scanner/src/web/web_camera_utility.dart';
 import 'package:mobile_scanner/src/web/zxing/zxing_barcode_reader.dart';
 import 'package:web/web.dart';
 
@@ -134,29 +135,6 @@ class MobileScannerWeb extends MobileScannerPlatform {
     _settingsController.add(settings);
   }
 
-  /// Flip the [videoElement] horizontally,
-  /// if the camera is facing the user.
-  void _maybeFlipVideoPreview(
-    HTMLVideoElement videoElement,
-    MediaStream videoStream,
-    CameraFacing cameraDirection,
-  ) {
-    final tracks = videoStream.getVideoTracks().toDart;
-
-    if (tracks.isEmpty) {
-      return;
-    }
-
-    // On mobile browsers, the facing mode is reliably reported in settings.
-    // On desktop browsers, facingMode is never reported (null), because desktop
-    // cameras have no hardware facing mode. Fall back to the requested
-    // camera direction instead.
-    final facingMode = tracks.first.getSettings().facingModeNullable?.toDart;
-
-    if (facingMode == 'user' || facingMode == null) {
-      videoElement.style.transform = 'scaleX(-1)';
-    }
-  }
 
   /// Apply focus, exposure and white-balance constraints to [track] if the
   /// browser supports them (part of the Image Capture API).
@@ -468,11 +446,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
       _videoElement = _createVideoElement(_textureId);
 
-      _maybeFlipVideoPreview(
-        _videoElement,
-        videoStream,
-        startOptions.cameraDirection,
-      );
+      maybeFlipVideoPreview(_videoElement, videoStream);
 
       await _barcodeReader?.start(
         startOptions,

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -150,7 +150,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
       final constraints = MediaTrackConstraints();
 
-      final focusModes = caps.focusMode.toDart.map((e) => e.toDart).toList();
+      final focusModes = caps.focusMode.toDart.map((e) => e.toDart).toSet();
       if (focusModes.contains(_kModeContinuous)) {
         constraints.focusMode = _kModeContinuous.toJS;
         hasConstraints = true;
@@ -160,14 +160,14 @@ class MobileScannerWeb extends MobileScannerPlatform {
       }
 
       final exposureModes =
-          caps.exposureMode.toDart.map((e) => e.toDart).toList();
+          caps.exposureMode.toDart.map((e) => e.toDart).toSet();
       if (exposureModes.contains(_kModeContinuous)) {
         constraints.exposureMode = _kModeContinuous.toJS;
         hasConstraints = true;
       }
 
       final wbModes =
-          caps.whiteBalanceMode.toDart.map((e) => e.toDart).toList();
+          caps.whiteBalanceMode.toDart.map((e) => e.toDart).toSet();
       if (wbModes.contains(_kModeContinuous)) {
         constraints.whiteBalanceMode = _kModeContinuous.toJS;
         hasConstraints = true;

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -67,8 +67,8 @@ class MobileScannerWeb extends MobileScannerPlatform {
   late HTMLVideoElement _videoElement;
 
   /// Storage for the preferred camera device ID across sessions.
-  final PreferredDeviceStorage _preferredDeviceStorage =
-      const PreferredDeviceStorage();
+  static const PreferredDeviceStorage _preferredDeviceStorage =
+      PreferredDeviceStorage();
 
   /// Get the view type for the platform view factory.
   String _getViewType(int textureId) => 'mobile-scanner-view-$textureId';
@@ -273,13 +273,17 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
         // Persist the device ID so the same camera is preferred next time.
         final deviceId = videoTrack.getSettings().deviceIdNullable?.toDart;
-        if (deviceId != null) _preferredDeviceStorage.write(deviceId);
+        if (deviceId != null) {
+          _preferredDeviceStorage.write(deviceId);
+        }
       }
 
       return videoStream;
     } on DOMException catch (error, stackTrace) {
       // If the stored device ID failed, clear it so we don't retry it.
-      if (useStoredDevice) _preferredDeviceStorage.remove();
+      if (useStoredDevice) {
+        _preferredDeviceStorage.remove();
+      }
       final errorMessage = error.toString();
 
       var errorCode = MobileScannerErrorCode.genericError;

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -153,8 +153,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
     // camera direction instead.
     final facingMode = tracks.first.getSettings().facingModeNullable?.toDart;
 
-    if (facingMode == 'user' ||
-        (facingMode == null)) {
+    if (facingMode == 'user' || (facingMode == null)) {
       videoElement.style.transform = 'scaleX(-1)';
     }
   }
@@ -170,8 +169,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
       final constraints = MediaTrackConstraints();
 
-      final focusModes =
-          caps.focusMode.toDart.map((e) => e.toDart).toList();
+      final focusModes = caps.focusMode.toDart.map((e) => e.toDart).toList();
       if (focusModes.contains('continuous')) {
         constraints.focusMode = 'continuous'.toJS;
         hasConstraints = true;
@@ -270,17 +268,18 @@ class MobileScannerWeb extends MobileScannerPlatform {
       useStoredDevice =
           storedDeviceId != null && await _isValidDeviceId(storedDeviceId);
 
-      constraints = useStoredDevice
-          ? MediaStreamConstraints(
-              video: MediaTrackConstraintSet(
-                deviceId: storedDeviceId.toJS,
-                width: width,
-                height: height,
-              ),
-            )
-          : MediaStreamConstraints(
-              video: MediaTrackConstraintSet(width: width, height: height),
-            );
+      constraints =
+          useStoredDevice
+              ? MediaStreamConstraints(
+                video: MediaTrackConstraintSet(
+                  deviceId: storedDeviceId.toJS,
+                  width: width,
+                  height: height,
+                ),
+              )
+              : MediaStreamConstraints(
+                video: MediaTrackConstraintSet(width: width, height: height),
+              );
     } else {
       // facingMode is supported (mobile). Always use it so that switching
       // between front and back cameras works correctly.
@@ -297,8 +296,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
     try {
       // Retrieving the media devices requests the camera permission.
-      final videoStream =
-          await mediaDevices.getUserMedia(constraints).toDart;
+      final videoStream = await mediaDevices.getUserMedia(constraints).toDart;
 
       // Apply focus, exposure and white-balance constraints if supported.
       final videoTrack = videoStream.getVideoTracks().toDart.firstOrNull;

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -27,6 +27,9 @@ class MobileScannerWeb extends MobileScannerPlatform {
   /// Constructs a [MobileScannerWeb] instance.
   MobileScannerWeb();
 
+  static const String _kModeContinuous = 'continuous';
+  static const String _kModeSingleShot = 'single-shot';
+
   /// The alternate script url for the barcode library.
   String? _alternateScriptUrl;
 
@@ -148,25 +151,25 @@ class MobileScannerWeb extends MobileScannerPlatform {
       final constraints = MediaTrackConstraints();
 
       final focusModes = caps.focusMode.toDart.map((e) => e.toDart).toList();
-      if (focusModes.contains('continuous')) {
-        constraints.focusMode = 'continuous'.toJS;
+      if (focusModes.contains(_kModeContinuous)) {
+        constraints.focusMode = _kModeContinuous.toJS;
         hasConstraints = true;
-      } else if (focusModes.contains('single-shot')) {
-        constraints.focusMode = 'single-shot'.toJS;
+      } else if (focusModes.contains(_kModeSingleShot)) {
+        constraints.focusMode = _kModeSingleShot.toJS;
         hasConstraints = true;
       }
 
       final exposureModes =
           caps.exposureMode.toDart.map((e) => e.toDart).toList();
-      if (exposureModes.contains('continuous')) {
-        constraints.exposureMode = 'continuous'.toJS;
+      if (exposureModes.contains(_kModeContinuous)) {
+        constraints.exposureMode = _kModeContinuous.toJS;
         hasConstraints = true;
       }
 
       final wbModes =
           caps.whiteBalanceMode.toDart.map((e) => e.toDart).toList();
-      if (wbModes.contains('continuous')) {
-        constraints.whiteBalanceMode = 'continuous'.toJS;
+      if (wbModes.contains(_kModeContinuous)) {
+        constraints.whiteBalanceMode = _kModeContinuous.toJS;
         hasConstraints = true;
       }
 

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -153,7 +153,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
     // camera direction instead.
     final facingMode = tracks.first.getSettings().facingModeNullable?.toDart;
 
-    if (facingMode == 'user' || (facingMode == null)) {
+    if (facingMode == 'user' || facingMode == null) {
       videoElement.style.transform = 'scaleX(-1)';
     }
   }

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -17,6 +17,7 @@ import 'package:mobile_scanner/src/objects/start_options.dart';
 import 'package:mobile_scanner/src/web/barcode_reader.dart';
 import 'package:mobile_scanner/src/web/media_track_constraints_delegate.dart';
 import 'package:mobile_scanner/src/web/media_track_extension.dart';
+import 'package:mobile_scanner/src/web/preferred_device_storage.dart';
 import 'package:mobile_scanner/src/web/web_camera_utility.dart';
 import 'package:mobile_scanner/src/web/zxing/zxing_barcode_reader.dart';
 import 'package:web/web.dart';
@@ -65,9 +66,9 @@ class MobileScannerWeb extends MobileScannerPlatform {
   /// The video element for the camera view.
   late HTMLVideoElement _videoElement;
 
-  /// The localStorage key used to persist the preferred camera device ID.
-  static const String _kPreferredDeviceIdKey =
-      'mobile_scanner_preferred_device_id';
+  /// Storage for the preferred camera device ID across sessions.
+  final PreferredDeviceStorage _preferredDeviceStorage =
+      const PreferredDeviceStorage();
 
   /// Get the view type for the platform view factory.
   String _getViewType(int textureId) => 'mobile-scanner-view-$textureId';
@@ -181,24 +182,6 @@ class MobileScannerWeb extends MobileScannerPlatform {
     }
   }
 
-  /// Return the preferred camera device ID stored in localStorage, or null.
-  String? _getStoredDeviceId() {
-    try {
-      return window.localStorage.getItem(_kPreferredDeviceIdKey);
-    } on DOMException catch (_) {
-      return null;
-    }
-  }
-
-  /// Persist [deviceId] to localStorage for use on the next start.
-  void _storeDeviceId(String deviceId) {
-    try {
-      window.localStorage.setItem(_kPreferredDeviceIdKey, deviceId);
-    } on DOMException catch (_) {
-      // Ignore — e.g. Safari private browsing mode disables storage.
-    }
-  }
-
   /// Validate that [deviceId] refers to a currently available video input.
   Future<bool> _isValidDeviceId(String deviceId) async {
     try {
@@ -251,7 +234,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
     if (capabilities.isUndefinedOrNull || !capabilities.facingMode) {
       // facingMode is not supported (desktop). Try to reuse the previously
       // chosen device to keep the same camera across restarts.
-      final storedDeviceId = _getStoredDeviceId();
+      final storedDeviceId = _preferredDeviceStorage.read();
       useStoredDevice =
           storedDeviceId != null && await _isValidDeviceId(storedDeviceId);
 
@@ -292,13 +275,13 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
         // Persist the device ID so the same camera is preferred next time.
         final deviceId = videoTrack.getSettings().deviceIdNullable?.toDart;
-        if (deviceId != null) _storeDeviceId(deviceId);
+        if (deviceId != null) _preferredDeviceStorage.write(deviceId);
       }
 
       return videoStream;
     } on DOMException catch (error, stackTrace) {
       // If the stored device ID failed, clear it so we don't retry it.
-      if (useStoredDevice) _storeDeviceId('');
+      if (useStoredDevice) _preferredDeviceStorage.write('');
       final errorMessage = error.toString();
 
       var errorCode = MobileScannerErrorCode.genericError;

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -61,6 +61,10 @@ class MobileScannerWeb extends MobileScannerPlatform {
   /// The video element for the camera view.
   late HTMLVideoElement _videoElement;
 
+  /// The localStorage key used to persist the preferred camera device ID.
+  static const String _kPreferredDeviceIdKey =
+      'mobile_scanner_preferred_device_id';
+
   /// Get the view type for the platform view factory.
   String _getViewType(int textureId) => 'mobile-scanner-view-$textureId';
 
@@ -131,26 +135,102 @@ class MobileScannerWeb extends MobileScannerPlatform {
   }
 
   /// Flip the [videoElement] horizontally,
-  /// if the [videoStream] indicates that is facing the user.
+  /// if the camera is facing the user.
   void _maybeFlipVideoPreview(
     HTMLVideoElement videoElement,
     MediaStream videoStream,
+    CameraFacing cameraDirection,
   ) {
-    final settings = _settingsDelegate.getSettings(videoStream);
+    final tracks = videoStream.getVideoTracks().toDart;
 
-    // First try checking the facing mode.
-    if (settings?.facingModeNullable?.toDart == 'user') {
-      videoElement.style.transform = 'scaleX(-1)';
-
+    if (tracks.isEmpty) {
       return;
     }
 
-    final videoTrack = videoStream.getVideoTracks().toDart.first;
+    // On mobile browsers, the facing mode is reliably reported in settings.
+    // On desktop browsers, facingMode is never reported (null), because desktop
+    // cameras have no hardware facing mode. Fall back to the requested
+    // camera direction instead.
+    final facingMode = tracks.first.getSettings().facingModeNullable?.toDart;
 
-    // On MacOS, even though the facing mode is supported, it is not reported.
-    // Use the label for FaceTime cameras to detect the user facing webcam.
-    if (videoTrack.label.contains('FaceTime')) {
+    if (facingMode == 'user' ||
+        (facingMode == null)) {
       videoElement.style.transform = 'scaleX(-1)';
+    }
+  }
+
+  /// Apply focus, exposure and white-balance constraints to [track] if the
+  /// browser supports them (part of the Image Capture API).
+  ///
+  /// Silently ignores any errors — these constraints are best-effort.
+  Future<void> _applyFocusConstraints(MediaStreamTrack track) async {
+    try {
+      final caps = track.getCapabilities();
+      var hasConstraints = false;
+
+      final constraints = MediaTrackConstraints();
+
+      final focusModes =
+          caps.focusMode.toDart.map((e) => e.toDart).toList();
+      if (focusModes.contains('continuous')) {
+        constraints.focusMode = 'continuous'.toJS;
+        hasConstraints = true;
+      } else if (focusModes.contains('single-shot')) {
+        constraints.focusMode = 'single-shot'.toJS;
+        hasConstraints = true;
+      }
+
+      final exposureModes =
+          caps.exposureMode.toDart.map((e) => e.toDart).toList();
+      if (exposureModes.contains('continuous')) {
+        constraints.exposureMode = 'continuous'.toJS;
+        hasConstraints = true;
+      }
+
+      final wbModes =
+          caps.whiteBalanceMode.toDart.map((e) => e.toDart).toList();
+      if (wbModes.contains('continuous')) {
+        constraints.whiteBalanceMode = 'continuous'.toJS;
+        hasConstraints = true;
+      }
+
+      if (!hasConstraints) return;
+
+      await track.applyConstraints(constraints).toDart;
+    } on Object catch (_) {
+      // Not supported on this browser or device.
+    }
+  }
+
+  /// Return the preferred camera device ID stored in localStorage, or null.
+  String? _getStoredDeviceId() {
+    try {
+      return window.localStorage.getItem(_kPreferredDeviceIdKey);
+    } on Object catch (_) {
+      return null;
+    }
+  }
+
+  /// Persist [deviceId] to localStorage for use on the next start.
+  void _storeDeviceId(String deviceId) {
+    try {
+      window.localStorage.setItem(_kPreferredDeviceIdKey, deviceId);
+    } on Object catch (_) {
+      // Ignore — e.g. Safari private browsing mode disables storage.
+    }
+  }
+
+  /// Validate that [deviceId] refers to a currently available video input.
+  Future<bool> _isValidDeviceId(String deviceId) async {
+    try {
+      final devices =
+          (await window.navigator.mediaDevices.enumerateDevices().toDart)
+              .toDart;
+      return devices.any(
+        (d) => d.kind == 'videoinput' && d.deviceId == deviceId,
+      );
+    } on Object catch (_) {
+      return false;
     }
   }
 
@@ -176,11 +256,24 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
     final capabilities = mediaDevices.getSupportedConstraints();
 
+    var useStoredDevice = false;
     final MediaStreamConstraints constraints;
 
     if (capabilities.isUndefinedOrNull || !capabilities.facingMode) {
-      constraints = MediaStreamConstraints(video: true.toJS);
+      // facingMode is not supported (desktop). Try to reuse the previously
+      // chosen device to keep the same camera across restarts.
+      final storedDeviceId = _getStoredDeviceId();
+      useStoredDevice =
+          storedDeviceId != null && await _isValidDeviceId(storedDeviceId);
+
+      constraints = useStoredDevice
+          ? MediaStreamConstraints(
+              video: MediaTrackConstraintSet(deviceId: storedDeviceId.toJS),
+            )
+          : MediaStreamConstraints(video: true.toJS);
     } else {
+      // facingMode is supported (mobile). Always use it so that switching
+      // between front and back cameras works correctly.
       final facingMode = _settingsDelegate.getFacingMode(cameraDirection);
 
       constraints = MediaStreamConstraints(
@@ -193,8 +286,20 @@ class MobileScannerWeb extends MobileScannerPlatform {
       final videoStream =
           await mediaDevices.getUserMedia(constraints).toDart;
 
+      // Apply focus, exposure and white-balance constraints if supported.
+      final videoTrack = videoStream.getVideoTracks().toDart.firstOrNull;
+      if (videoTrack != null) {
+        await _applyFocusConstraints(videoTrack);
+
+        // Persist the device ID so the same camera is preferred next time.
+        final deviceId = videoTrack.getSettings().deviceIdNullable?.toDart;
+        if (deviceId != null) _storeDeviceId(deviceId);
+      }
+
       return videoStream;
     } on DOMException catch (error, stackTrace) {
+      // If the stored device ID failed, clear it so we don't retry it.
+      if (useStoredDevice) _storeDeviceId('');
       final errorMessage = error.toString();
 
       var errorCode = MobileScannerErrorCode.genericError;
@@ -342,7 +447,11 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
       _videoElement = _createVideoElement(_textureId);
 
-      _maybeFlipVideoPreview(_videoElement, videoStream);
+      _maybeFlipVideoPreview(
+        _videoElement,
+        videoStream,
+        startOptions.cameraDirection,
+      );
 
       await _barcodeReader?.start(
         startOptions,

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -281,7 +281,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
       return videoStream;
     } on DOMException catch (error, stackTrace) {
       // If the stored device ID failed, clear it so we don't retry it.
-      if (useStoredDevice) _preferredDeviceStorage.write('');
+      if (useStoredDevice) _preferredDeviceStorage.remove();
       final errorMessage = error.toString();
 
       var errorCode = MobileScannerErrorCode.genericError;

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -139,7 +139,6 @@ class MobileScannerWeb extends MobileScannerPlatform {
     _settingsController.add(settings);
   }
 
-
   /// Apply focus, exposure, and white-balance constraints to [track] if the
   /// browser supports them (part of the Image Capture API).
   ///
@@ -167,8 +166,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
         hasConstraints = true;
       }
 
-      final wbModes =
-          caps.whiteBalanceMode.toDart.map((e) => e.toDart).toSet();
+      final wbModes = caps.whiteBalanceMode.toDart.map((e) => e.toDart).toSet();
       if (wbModes.contains(_kModeContinuous)) {
         constraints.whiteBalanceMode = _kModeContinuous.toJS;
         hasConstraints = true;

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -140,11 +140,11 @@ class MobileScannerWeb extends MobileScannerPlatform {
   }
 
 
-  /// Apply focus, exposure and white-balance constraints to [track] if the
+  /// Apply focus, exposure, and white-balance constraints to [track] if the
   /// browser supports them (part of the Image Capture API).
   ///
   /// Silently ignores any errors — these constraints are best-effort.
-  Future<void> _applyFocusConstraints(MediaStreamTrack track) async {
+  Future<void> _applyVideoConstraints(MediaStreamTrack track) async {
     try {
       final caps = track.getCapabilities();
       var hasConstraints = false;
@@ -271,7 +271,7 @@ class MobileScannerWeb extends MobileScannerPlatform {
       // Apply focus, exposure and white-balance constraints if supported.
       final videoTrack = videoStream.getVideoTracks().toDart.firstOrNull;
       if (videoTrack != null) {
-        await _applyFocusConstraints(videoTrack);
+        await _applyVideoConstraints(videoTrack);
 
         // Persist the device ID so the same camera is preferred next time.
         final deviceId = videoTrack.getSettings().deviceIdNullable?.toDart;

--- a/lib/src/web/preferred_device_storage.dart
+++ b/lib/src/web/preferred_device_storage.dart
@@ -17,11 +17,18 @@ class PreferredDeviceStorage {
   }
 
   /// Persists [deviceId] for use on the next start.
-  ///
-  /// Pass an empty string to clear the stored value.
   void write(String deviceId) {
     try {
       window.localStorage.setItem(_kKey, deviceId);
+    } on DOMException catch (_) {
+      // Ignore, e.g. Safari private browsing mode disables storage.
+    }
+  }
+
+  /// Removes the stored device ID.
+  void remove() {
+    try {
+      window.localStorage.removeItem(_kKey);
     } on DOMException catch (_) {
       // Ignore, e.g. Safari private browsing mode disables storage.
     }

--- a/lib/src/web/preferred_device_storage.dart
+++ b/lib/src/web/preferred_device_storage.dart
@@ -1,0 +1,29 @@
+import 'package:web/web.dart';
+
+/// Persists and retrieves the preferred camera device ID using localStorage.
+class PreferredDeviceStorage {
+  /// Construct a [PreferredDeviceStorage] instance.
+  const PreferredDeviceStorage();
+
+  static const String _kKey = 'mobile_scanner_preferred_device_id';
+
+  /// Returns the stored device ID, or null if absent or storage is unavailable.
+  String? read() {
+    try {
+      return window.localStorage.getItem(_kKey);
+    } on DOMException catch (_) {
+      return null;
+    }
+  }
+
+  /// Persists [deviceId] for use on the next start.
+  ///
+  /// Pass an empty string to clear the stored value.
+  void write(String deviceId) {
+    try {
+      window.localStorage.setItem(_kKey, deviceId);
+    } on DOMException catch (_) {
+      // Ignore, e.g. Safari private browsing mode disables storage.
+    }
+  }
+}

--- a/lib/src/web/web_camera_utility.dart
+++ b/lib/src/web/web_camera_utility.dart
@@ -1,0 +1,67 @@
+import 'dart:js_interop';
+import 'dart:ui';
+
+import 'package:mobile_scanner/src/objects/barcode.dart';
+import 'package:mobile_scanner/src/web/media_track_extension.dart';
+import 'package:web/web.dart' as web;
+
+/// Returns true if the video stream should be mirrored horizontally.
+///
+/// Mirrors when facingMode is 'user' (front camera on mobile), or when
+/// facingMode is null (desktop cameras mainly face the user).
+bool shouldMirrorStream(web.MediaStream? videoStream) {
+  final tracks = videoStream?.getVideoTracks().toDart;
+
+  if (tracks == null || tracks.isEmpty) {
+    return false;
+  }
+
+  final facingMode = tracks.first.getSettings().facingModeNullable?.toDart;
+
+  return facingMode == 'user' || facingMode == null;
+}
+
+/// Apply a horizontal CSS mirror transform to [videoElement] if the camera
+/// is facing the user.
+void maybeFlipVideoPreview(
+  web.HTMLVideoElement videoElement,
+  web.MediaStream videoStream,
+) {
+  if (shouldMirrorStream(videoStream)) {
+    videoElement.style.transform = 'scaleX(-1)';
+  }
+}
+
+/// Returns a copy of [barcode] with all corner x-coordinates mirrored
+/// relative to [videoWidth].
+Barcode mirrorBarcodeX(Barcode barcode, double videoWidth) {
+  final corners = barcode.corners;
+
+  if (corners.isEmpty) {
+    return barcode;
+  }
+
+  // Mirror each x-coordinate.
+  final mirrored = corners.map((c) => Offset(videoWidth - c.dx, c.dy)).toList();
+
+  // Mirroring x reverses the clockwise winding order from
+  // [TL, TR, BR, BL] to [TR_m, TL_m, BL_m, BR_m].
+  // Swap TL↔TR and BL↔BR to restore [TL_m, TR_m, BR_m, BL_m].
+  final reordered =
+      mirrored.length == 4
+          ? [mirrored[1], mirrored[0], mirrored[3], mirrored[2]]
+          : mirrored;
+
+  return Barcode(
+    corners: reordered,
+    format: barcode.format,
+    displayValue: barcode.displayValue,
+    // Populate deprecated rawBytes for backward compatibility.
+    // ignore: deprecated_member_use_from_same_package
+    rawBytes: barcode.rawBytes,
+    rawDecodedBytes: barcode.rawDecodedBytes,
+    rawValue: barcode.rawValue,
+    size: barcode.size,
+    type: barcode.type,
+  );
+}

--- a/lib/src/web/zxing/zxing_barcode_reader.dart
+++ b/lib/src/web/zxing/zxing_barcode_reader.dart
@@ -5,11 +5,13 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/mobile_scanner_exception.dart';
+import 'package:mobile_scanner/src/objects/barcode.dart';
 import 'package:mobile_scanner/src/objects/barcode_capture.dart';
 import 'package:mobile_scanner/src/objects/start_options.dart';
 import 'package:mobile_scanner/src/web/barcode_reader.dart';
 import 'package:mobile_scanner/src/web/javascript_map.dart';
 import 'package:mobile_scanner/src/web/media_track_constraints_delegate.dart';
+import 'package:mobile_scanner/src/web/media_track_extension.dart';
 import 'package:mobile_scanner/src/web/zxing/result.dart';
 import 'package:mobile_scanner/src/web/zxing/zxing_browser_multi_format_reader.dart';
 import 'package:mobile_scanner/src/web/zxing/zxing_exception.dart';
@@ -103,6 +105,49 @@ final class ZXingBarcodeReader extends BarcodeReader {
     }
   }
 
+  /// Returns true if the video preview is currently mirrored horizontally,
+  /// meaning barcode corner coordinates must be flipped to match.
+  ///
+  /// Must stay in sync with the logic in `_maybeFlipVideoPreview`.
+  bool _shouldMirrorX() {
+    final tracks = videoStream?.getVideoTracks().toDart;
+
+    if (tracks == null || tracks.isEmpty) {
+      return false;
+    }
+
+    final facingMode = tracks.first.getSettings().facingModeNullable?.toDart;
+
+    // Mirror when facingMode is 'user' (front camera on mobile), or when
+    // facingMode is null (desktop — cameras always face the user).
+    return facingMode == 'user' || facingMode == null;
+  }
+
+  /// Returns a copy of [barcode] with all corner x-coordinates mirrored
+  /// relative to [videoWidth].
+  Barcode _mirrorBarcodeX(Barcode barcode, double videoWidth) {
+    final corners = barcode.corners;
+
+    if (corners.isEmpty) {
+      return barcode;
+    }
+
+    return Barcode(
+      corners: corners
+          .map((c) => Offset(videoWidth - c.dx, c.dy))
+          .toList(),
+      format: barcode.format,
+      displayValue: barcode.displayValue,
+      // Populate deprecated rawBytes for backward compatibility.
+      // ignore: deprecated_member_use_from_same_package
+      rawBytes: barcode.rawBytes,
+      rawDecodedBytes: barcode.rawDecodedBytes,
+      rawValue: barcode.rawValue,
+      size: barcode.size,
+      type: barcode.type,
+    );
+  }
+
   @override
   Stream<BarcodeCapture> detectBarcodes() {
     final controller = StreamController<BarcodeCapture>();
@@ -124,8 +169,14 @@ final class ZXingBarcodeReader extends BarcodeReader {
             }
 
             if (result != null) {
+              var barcode = result.toBarcode;
+
+              if (_shouldMirrorX()) {
+                barcode = _mirrorBarcodeX(barcode, videoSize.width);
+              }
+
               controller.add(
-                BarcodeCapture(barcodes: [result.toBarcode], size: videoSize),
+                BarcodeCapture(barcodes: [barcode], size: videoSize),
               );
             }
           }.toJS,

--- a/lib/src/web/zxing/zxing_barcode_reader.dart
+++ b/lib/src/web/zxing/zxing_barcode_reader.dart
@@ -133,16 +133,16 @@ final class ZXingBarcodeReader extends BarcodeReader {
     }
 
     // Mirror each x-coordinate.
-    final mirrored = corners
-        .map((c) => Offset(videoWidth - c.dx, c.dy))
-        .toList();
+    final mirrored =
+        corners.map((c) => Offset(videoWidth - c.dx, c.dy)).toList();
 
     // Mirroring x reverses the clockwise winding order from
     // [TL, TR, BR, BL] to [TR_m, TL_m, BL_m, BR_m].
     // Swap TL↔TR and BL↔BR to restore [TL_m, TR_m, BR_m, BL_m].
-    final reordered = mirrored.length == 4
-        ? [mirrored[1], mirrored[0], mirrored[3], mirrored[2]]
-        : mirrored;
+    final reordered =
+        mirrored.length == 4
+            ? [mirrored[1], mirrored[0], mirrored[3], mirrored[2]]
+            : mirrored;
 
     return Barcode(
       corners: reordered,

--- a/lib/src/web/zxing/zxing_barcode_reader.dart
+++ b/lib/src/web/zxing/zxing_barcode_reader.dart
@@ -5,13 +5,12 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:mobile_scanner/src/enums/barcode_format.dart';
 import 'package:mobile_scanner/src/mobile_scanner_exception.dart';
-import 'package:mobile_scanner/src/objects/barcode.dart';
 import 'package:mobile_scanner/src/objects/barcode_capture.dart';
 import 'package:mobile_scanner/src/objects/start_options.dart';
 import 'package:mobile_scanner/src/web/barcode_reader.dart';
 import 'package:mobile_scanner/src/web/javascript_map.dart';
 import 'package:mobile_scanner/src/web/media_track_constraints_delegate.dart';
-import 'package:mobile_scanner/src/web/media_track_extension.dart';
+import 'package:mobile_scanner/src/web/web_camera_utility.dart';
 import 'package:mobile_scanner/src/web/zxing/result.dart';
 import 'package:mobile_scanner/src/web/zxing/zxing_browser_multi_format_reader.dart';
 import 'package:mobile_scanner/src/web/zxing/zxing_exception.dart';
@@ -105,59 +104,6 @@ final class ZXingBarcodeReader extends BarcodeReader {
     }
   }
 
-  /// Returns true if the video preview is currently mirrored horizontally,
-  /// meaning barcode corner coordinates must be flipped to match.
-  ///
-  /// Must stay in sync with the logic in `_maybeFlipVideoPreview`.
-  bool _shouldMirrorX() {
-    final tracks = videoStream?.getVideoTracks().toDart;
-
-    if (tracks == null || tracks.isEmpty) {
-      return false;
-    }
-
-    final facingMode = tracks.first.getSettings().facingModeNullable?.toDart;
-
-    // Mirror when facingMode is 'user' (front camera on mobile), or when
-    // facingMode is null (desktop — cameras always face the user).
-    return facingMode == 'user' || facingMode == null;
-  }
-
-  /// Returns a copy of [barcode] with all corner x-coordinates mirrored
-  /// relative to [videoWidth].
-  Barcode _mirrorBarcodeX(Barcode barcode, double videoWidth) {
-    final corners = barcode.corners;
-
-    if (corners.isEmpty) {
-      return barcode;
-    }
-
-    // Mirror each x-coordinate.
-    final mirrored =
-        corners.map((c) => Offset(videoWidth - c.dx, c.dy)).toList();
-
-    // Mirroring x reverses the clockwise winding order from
-    // [TL, TR, BR, BL] to [TR_m, TL_m, BL_m, BR_m].
-    // Swap TL↔TR and BL↔BR to restore [TL_m, TR_m, BR_m, BL_m].
-    final reordered =
-        mirrored.length == 4
-            ? [mirrored[1], mirrored[0], mirrored[3], mirrored[2]]
-            : mirrored;
-
-    return Barcode(
-      corners: reordered,
-      format: barcode.format,
-      displayValue: barcode.displayValue,
-      // Populate deprecated rawBytes for backward compatibility.
-      // ignore: deprecated_member_use_from_same_package
-      rawBytes: barcode.rawBytes,
-      rawDecodedBytes: barcode.rawDecodedBytes,
-      rawValue: barcode.rawValue,
-      size: barcode.size,
-      type: barcode.type,
-    );
-  }
-
   @override
   Stream<BarcodeCapture> detectBarcodes() {
     final controller = StreamController<BarcodeCapture>();
@@ -181,8 +127,8 @@ final class ZXingBarcodeReader extends BarcodeReader {
             if (result != null) {
               var barcode = result.toBarcode;
 
-              if (_shouldMirrorX()) {
-                barcode = _mirrorBarcodeX(barcode, videoSize.width);
+              if (shouldMirrorStream(videoStream)) {
+                barcode = mirrorBarcodeX(barcode, videoSize.width);
               }
 
               controller.add(

--- a/lib/src/web/zxing/zxing_barcode_reader.dart
+++ b/lib/src/web/zxing/zxing_barcode_reader.dart
@@ -132,10 +132,20 @@ final class ZXingBarcodeReader extends BarcodeReader {
       return barcode;
     }
 
+    // Mirror each x-coordinate.
+    final mirrored = corners
+        .map((c) => Offset(videoWidth - c.dx, c.dy))
+        .toList();
+
+    // Mirroring x reverses the clockwise winding order from
+    // [TL, TR, BR, BL] to [TR_m, TL_m, BL_m, BR_m].
+    // Swap TL↔TR and BL↔BR to restore [TL_m, TR_m, BR_m, BL_m].
+    final reordered = mirrored.length == 4
+        ? [mirrored[1], mirrored[0], mirrored[3], mirrored[2]]
+        : mirrored;
+
     return Barcode(
-      corners: corners
-          .map((c) => Offset(videoWidth - c.dx, c.dy))
-          .toList(),
+      corners: reordered,
       format: barcode.format,
       displayValue: barcode.displayValue,
       // Populate deprecated rawBytes for backward compatibility.


### PR DESCRIPTION
This PR is a continuation of #1517, with some other improvements.

From the changelog:

> * [Web] The preferred camera device ID is now persisted in localStorage and reused on the next start.
> * [Web] Focus, exposure, and white-balance constraints are now applied automatically when supported by the browser (Image Capture API).
> * [Web] The camera now requests 1920×1080 as the ideal resolution for improved barcode detection.
> * [Web] The barcode overlay is now mirrored when the video preview is mirrored (e.g. front camera).