### PR TITLE
fix(macos): wrap deprecated devices(for:) in #if os(iOS)

### DIFF
--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerCameraSelector.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerCameraSelector.swift
@@ -97,10 +97,14 @@ class MobileScannerCameraSelector {
             return nil
         }
 
-        // Legacy fallback for older OS versions: filter by position
+#if os(iOS)
+        // Legacy fallback for iOS < 13.0: filter by position.
+        // On macOS, DiscoverySession handles 10.15+; older macOS falls
+        // through to AVCaptureDevice.default(for:) below.
         if let device = AVCaptureDevice.devices(for: .video).filter({ $0.position == position }).first {
             return device
         }
+#endif
 
         // Ultimate fallback: any available video device
         return AVCaptureDevice.default(for: .video)


### PR DESCRIPTION
## Summary

Wraps the legacy `AVCaptureDevice.devices(for:)` fallback in `#if os(iOS)` to eliminate the deprecation warning on macOS builds.

## Problem

`AVCaptureDevice.devices(for:)` has been deprecated since macOS 10.15. When building the plugin for macOS, Xcode emits:

```
'devices(for:)' was deprecated in macOS 10.15
```

See #1558.

## Solution

The legacy `devices(for:)` call at line ~101 of `MobileScannerCameraSelector.swift` is a fallback for iOS versions before 13.0. On macOS, the `AVCaptureDevice.DiscoverySession` path (already guarded by `#available(macOS 10.15, *)`) handles device discovery, and the existing `AVCaptureDevice.default(for: .video)` serves as the ultimate fallback.

This PR wraps the legacy fallback in `#if os(iOS)` so it only compiles for iOS, silencing the macOS deprecation warning while preserving the fallback behavior on older iOS versions.

## Testing

- Verified the fix compiles without deprecation warnings on macOS
- No behavioral change on iOS (the legacy fallback still applies for iOS < 13.0)

Closes #1558
