### PR TITLE
fix(ios): CVPixelBuffer race condition crash in captureOutput

### DIFF
--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -161,12 +161,13 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         if ((detectionSpeed == DetectionSpeed.normal || detectionSpeed == DetectionSpeed.noDuplicates) && eligibleForScan || detectionSpeed == DetectionSpeed.unrestricted) {
             nextScanTime = currentTime + timeoutSeconds
             imagesCurrentlyBeingProcessed = true
-            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                guard let self = self else {
-                    return
-                }
-                
-                guard let buffer = self.latestBuffer else {
+               let bufferToProcess = latestBuffer
+               DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                   guard let self = self else {
+                       return
+                   }
+                   
+                   guard let buffer = bufferToProcess else {
                     self.imagesCurrentlyBeingProcessed = false
                     return
                 }


### PR DESCRIPTION
## Summary

Fixes a race condition in `captureOutput` where `self.latestBuffer` is read on a background thread (`DispatchQueue.global(qos: .userInitiated)`) after being deallocated or overwritten on the main thread by the next camera frame or `releaseCamera()`.

The fix captures a strong reference to the buffer **before** dispatching to the background queue, ensuring the `CVPixelBuffer` is retained for the duration of the background processing.

## Crash Stack Trace (from Xcode Organizer)

Thread 1 Crashed:
0  CoreVideo        CVPixelBufferGetWidth + 28
1  VideoToolbox     VTCreateCGImageFromCVPixelBuffer
2  mobile_scanner   closure #1 in MobileScannerPlugin.captureOutput(_:didOutput:from:)
3  mobile_scanner   MobileScannerPlugin.captureOutput(_:didOutput:from:) (partial)
4  libdispatch      _dispatch_call_block_and_release
5  libdispatch      _dispatch_client_callout

## Environment

- mobile_scanner: 7.2.0
- iOS: 26.0.1
- Devices affected: 54 (iPhone 16 Pro Max, iPhone 15 Pro Max, and others)
- Architecture: ARM-64
- Distribution: App Store

## Related Issue

Fixes #1545