### PR TITLE
fix(ios): CVPixelBuffer race condition crash in captureOutput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 7.2.1
 
 **Improvements**
 
@@ -6,6 +6,10 @@
 * [Web] Focus, exposure, and white-balance constraints are now applied automatically when supported by the browser (Image Capture API).
 * [Web] The camera now uses `StartOptions.cameraResolution` as the ideal resolution, falling back to 1920×1080.
 * [Web] The barcode overlay is now mirrored when the video preview is mirrored (e.g. front camera).
+
+**Bug Fixes**
+
+* [Apple] Fixed a race condition in `captureOutput` where `latestBuffer` was read on a background thread after being deallocated on the main thread, causing a crash in `VTCreateCGImageFromCVPixelBuffer`.
 
 ## 7.2.0
 

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -161,12 +161,13 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         if ((detectionSpeed == DetectionSpeed.normal || detectionSpeed == DetectionSpeed.noDuplicates) && eligibleForScan || detectionSpeed == DetectionSpeed.unrestricted) {
             nextScanTime = currentTime + timeoutSeconds
             imagesCurrentlyBeingProcessed = true
+            let bufferToProcess = latestBuffer
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 guard let self = self else {
                     return
                 }
-                
-                guard let buffer = self.latestBuffer else {
+
+                guard let buffer = bufferToProcess else {
                     self.imagesCurrentlyBeingProcessed = false
                     return
                 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal Flutter barcode and QR code scanner using CameraX/ML Kit for Android, AVFoundation/Apple Vision for iOS & macOS, and ZXing for web.
-version: 7.2.0
+version: 7.2.1
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 screenshots:


### PR DESCRIPTION
## Summary

Fixes a race condition in `captureOutput` where `self.latestBuffer` is read on a background thread (`DispatchQueue.global(qos: .userInitiated)`) after being deallocated or overwritten on the main thread by the next camera frame or `releaseCamera()`.

The fix captures a strong reference to the buffer **before** dispatching to the background queue, ensuring the `CVPixelBuffer` is retained for the duration of the background processing.

Also adds a changelog entry and bumps the patch version to 7.2.1.

## Crash Stack Trace (from Xcode Organizer)

Thread 1 Crashed:
0  CoreVideo        CVPixelBufferGetWidth + 28
1  VideoToolbox     VTCreateCGImageFromCVPixelBuffer
2  mobile_scanner   closure #1 in MobileScannerPlugin.captureOutput(_:didOutput:from:)
3  mobile_scanner   MobileScannerPlugin.captureOutput(_:didOutput:from:) (partial)
4  libdispatch      _dispatch_call_block_and_release
5  libdispatch      _dispatch_client_callout

## Environment

- mobile_scanner: 7.2.0
- iOS: 26.0.1
- Devices affected: 54 (iPhone 16 Pro Max, iPhone 15 Pro Max, and others)
- Architecture: ARM-64
- Distribution: App Store

## Related Issue

Fixes #1545