### PR TITLE
fix: ensure capture output queue is not the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Bug Fixes**
 
 * [Apple] Fixed a race condition in `captureOutput` where `latestBuffer` was read on a background thread after being deallocated on the main thread, causing a crash in `VTCreateCGImageFromCVPixelBuffer`.
+* [Apple] Fixed an issue where `captureOutput` was being processed on the main thread, causing overheating issues on device.
 
 ## 7.2.0
 

--- a/darwin/mobile_scanner/Sources/mobile_scanner/BarcodeTypeDetector.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/BarcodeTypeDetector.swift
@@ -10,76 +10,72 @@ extension String {
     ///
     /// If any error occurs during detection, returns 0 (BarcodeType.unknown).
     func detectBarcodeType() -> Int {
-        do {
-            let trimmed = self.trimmingCharacters(in: .whitespacesAndNewlines)
-            
-            // Return unknown if empty
-            if trimmed.isEmpty {
-                return 0 // BarcodeType.unknown
-            }
-            
-            let uppercased = trimmed.uppercased()
-            
-            // Check for ContactInfo (VCARD) - most specific structured format
-            if uppercased.hasPrefix("BEGIN:VCARD") {
-                return 1 // BarcodeType.contactInfo
-            }
+        let trimmed = self.trimmingCharacters(in: .whitespacesAndNewlines)
         
-            // Check for CalendarEvent (VCALENDAR) - iCalendar format
-            if uppercased.hasPrefix("BEGIN:VCALENDAR") {
-                return 11 // BarcodeType.calendarEvent
-            }
-            
-            // Check for WiFi
-            if uppercased.hasPrefix("WIFI:") {
-                return 9 // BarcodeType.wifi
-            }
-            
-            // Check for Email
-            if uppercased.hasPrefix("MAILTO:") {
-                return 2 // BarcodeType.email
-            }
-            
-            // Check for Phone
-            if uppercased.hasPrefix("TEL:") {
-                return 4 // BarcodeType.phone
-            }
-            
-            // Check for SMS
-            if uppercased.hasPrefix("SMS:") {
-                return 6 // BarcodeType.sms
-            }
-            
-            // Check for Geo
-            if uppercased.hasPrefix("GEO:") {
-                return 10 // BarcodeType.geo
-            }
-            
-            // Check for URL bookmark (MEBKM format)
-            if uppercased.hasPrefix("MEBKM:") {
-                return 8 // BarcodeType.url
-            }
-            
-            // Check for HTTP/HTTPS URLs
-            if uppercased.hasPrefix("HTTP://") || uppercased.hasPrefix("HTTPS://") {
-                return 8 // BarcodeType.url
-            }
-            
-            // Check for ISBN
-            if isISBN() {
-                return 3 // BarcodeType.isbn
-            }
-            
-            // Check for Product codes (EAN/UPC)
-            if isProductCode() {
-                return 5 // BarcodeType.product
-            }
-            
-            // Default to text for unrecognized patterns
-            return 7 // BarcodeType.text
-        } catch {
+        // Return unknown if empty
+        if trimmed.isEmpty {
             return 0 // BarcodeType.unknown
         }
+        
+        let uppercased = trimmed.uppercased()
+        
+        // Check for ContactInfo (VCARD) - most specific structured format
+        if uppercased.hasPrefix("BEGIN:VCARD") {
+            return 1 // BarcodeType.contactInfo
+        }
+    
+        // Check for CalendarEvent (VCALENDAR) - iCalendar format
+        if uppercased.hasPrefix("BEGIN:VCALENDAR") {
+            return 11 // BarcodeType.calendarEvent
+        }
+        
+        // Check for WiFi
+        if uppercased.hasPrefix("WIFI:") {
+            return 9 // BarcodeType.wifi
+        }
+        
+        // Check for Email
+        if uppercased.hasPrefix("MAILTO:") {
+            return 2 // BarcodeType.email
+        }
+        
+        // Check for Phone
+        if uppercased.hasPrefix("TEL:") {
+            return 4 // BarcodeType.phone
+        }
+        
+        // Check for SMS
+        if uppercased.hasPrefix("SMS:") {
+            return 6 // BarcodeType.sms
+        }
+        
+        // Check for Geo
+        if uppercased.hasPrefix("GEO:") {
+            return 10 // BarcodeType.geo
+        }
+        
+        // Check for URL bookmark (MEBKM format)
+        if uppercased.hasPrefix("MEBKM:") {
+            return 8 // BarcodeType.url
+        }
+        
+        // Check for HTTP/HTTPS URLs
+        if uppercased.hasPrefix("HTTP://") || uppercased.hasPrefix("HTTPS://") {
+            return 8 // BarcodeType.url
+        }
+        
+        // Check for ISBN
+        if isISBN() {
+            return 3 // BarcodeType.isbn
+        }
+        
+        // Check for Product codes (EAN/UPC)
+        if isProductCode() {
+            return 5 // BarcodeType.product
+        }
+        
+        // Default to text for unrecognized patterns
+        return 7 // BarcodeType.text
     }
     
     /// Checks if the string matches ISBN-10 or ISBN-13 format.

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -894,8 +894,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
             details: nil
         ))
         return
-#endif
-
+#else
         let argReader = MapArgumentReader(call.arguments as? [String: Any])
         let symbologies:[VNBarcodeSymbology] = argReader.toSymbology()
 
@@ -971,6 +970,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
                     message: error.localizedDescription, details: nil))
             }
         }
+#endif
     }
 
     // Observer for torch state

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -37,6 +37,11 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
     /// This is static to avoid accessing `self` in the `VNDetectBarcodesRequest` callback.
     private static var returnImage: Bool = false
 
+    /// The dispatch queue that will process ``captureOutput(_:didOutput:from:)`` calls.
+    ///
+    /// This queue is user initiated because it is tied to an ``AVCaptureSession``.
+    private let sampleBufferQueue = DispatchQueue(label: "com.juliansteenbakker.mobile_scanner.captureOutputQueue", qos: .userInitiated)
+
     var detectionSpeed: DetectionSpeed = DetectionSpeed.noDuplicates
 
     var timeoutSeconds: Double = 0
@@ -443,7 +448,7 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
         let format = getPreferredVideoFormat(videoOutput: videoOutput)
         videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: format]
         videoOutput.alwaysDiscardsLateVideoFrames = true
-        videoOutput.setSampleBufferDelegate(self, queue: DispatchQueue.main)
+        videoOutput.setSampleBufferDelegate(self, queue: self.sampleBufferQueue)
         captureSession!.addOutput(videoOutput)
         let deviceVideoOrientation = self.getVideoOrientation()
 


### PR DESCRIPTION
This pull request fixes a reported overheating issue on device, since `captureOutput` was being called on the main thread.

Tested on MacOS and scanning still works.

Also fixed 2 warnings in code:
- an unused do/catch, because there was no `try` (Star Wars jokes, anyone?)
- an `#if def` was complaining about a return, because we forgot to configure the `#else` after it

Fixes https://github.com/juliansteenbakker/mobile_scanner/issues/1694

cc @juliansteenbakker Since this should fix an overheating issue I'd like to publish 7.2.1 with this fix included.

cc @sawan-scapia Could you confirm the overheating issue is gone, with this patch? I only managed to verify on MacOS at this time.