### PR TITLE
build(android): migrate Kotlin compiler options

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,6 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -36,9 +35,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -78,5 +74,10 @@ android {
                 showStandardStreams = true
             }
         }
+    }
+}
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     if (project.android.hasProperty("namespace")) {


### PR DESCRIPTION
## Draft status

This PR keeps the existing Kotlin Gradle Plugin application for current repository CI compatibility, while migrating deprecated Android `kotlinOptions` blocks to top-level `kotlin { compilerOptions { ... } }`.

This is intentionally not the full AGP 9 built-in Kotlin removal. Removing `kotlin-android` should be handled separately only when this repository is ready to require AGP 9 built-in Kotlin.

## Scope

Only Android Gradle build configuration is changed. No Dart APIs, Android manifests, SDK versions, or runtime code are changed.

## Verification

- `rg "kotlinOptions"` on touched Android Gradle files returns no matches.
- `rg "compilerOptions"` confirms JVM target configuration exists.
- `git diff --check`
