### PR TITLE
feat: add allowedLengths filter to MobileScannerController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+**Improvements**
+
+* Added `allowedLengths` parameter to `MobileScannerController` for filtering scanned barcodes by `rawValue` length. When non-empty, barcodes whose length is not in the set are dropped, and captures with no surviving barcodes are suppressed. This is useful for formats without a checksum or end-of-barcode indicator (e.g. ITF / Interleaved 2 of 5), where the decoder can return a truncated prefix of the actual code.
+
 ## 7.2.1
 
 **Improvements**

--- a/README.md
+++ b/README.md
@@ -133,12 +133,27 @@ final MobileScannerController controller = MobileScannerController(
   detectionSpeed: detectionSpeed,
   detectionTimeoutMs: detectionTimeout,
   formats: selectedFormats,
+  allowedLengths: {14}, // optional, see "Filtering by length" below
   returnImage: returnImage,
   torchEnabled: true,
   invertImage: invertImage,
   autoZoom: autoZoom,
 );
 ```
+
+#### Filtering by length
+
+Formats like ITF (Interleaved 2 of 5) have no checksum and no end-of-barcode indicator, so the decoder may return a truncated prefix of the actual code as if it were a complete scan. The `allowedLengths` parameter lets you restrict scanner output to barcodes whose `rawValue.length` is in the given set; non-matching barcodes are dropped, and a capture is suppressed entirely when every barcode in it is dropped.
+
+```dart
+// Only accept full ITF-14 codes.
+final controller = MobileScannerController(
+  formats: const [BarcodeFormat.itf14],
+  allowedLengths: const {14},
+);
+```
+
+If `allowedLengths` is empty (the default), no length filtering is applied.
 
 ```dart
 MobileScanner(

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -33,6 +33,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
     int detectionTimeoutMs = 250,
     this.facing = CameraFacing.back,
     this.formats = const <BarcodeFormat>[],
+    this.allowedLengths = const <int>{},
     this.returnImage = false,
     this.torchEnabled = false,
     this.invertImage = false,
@@ -102,6 +103,25 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   ///
   /// If this is empty, all supported formats are detected.
   final List<BarcodeFormat> formats;
+
+  /// The set of allowed `rawValue` lengths for scanned barcodes.
+  ///
+  /// When this set is non-empty, any barcode whose `rawValue.length` is not
+  /// contained in it is dropped before being delivered to listeners.
+  /// If every barcode in a capture is dropped, the capture event itself is
+  /// suppressed and no [BarcodeCapture] is emitted for that frame.
+  ///
+  /// This is primarily useful for formats that have no checksum or
+  /// end-of-barcode indicator, such as ITF (Interleaved 2 of 5), where the
+  /// decoder may return a truncated prefix of the actual code. For example,
+  /// a scanner configured for ITF-14 can set `allowedLengths: {14}` to drop
+  /// any partial reads.
+  ///
+  /// Barcodes whose `rawValue` is null are dropped when this set is
+  /// non-empty, because their length cannot be validated.
+  ///
+  /// If this set is empty (the default), no length filtering is applied.
+  final Set<int> allowedLengths;
 
   /// Whether the [BarcodeCapture.image] bytes should be provided.
   ///
@@ -175,7 +195,12 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
               return;
             }
 
-            _barcodesController.add(barcode);
+            final filtered = _applyAllowedLengths(barcode);
+            if (filtered == null) {
+              return;
+            }
+
+            _barcodesController.add(filtered);
           },
           onError: (Object error) {
             if (_barcodesController.isClosed) {
@@ -294,8 +319,52 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   Future<BarcodeCapture?> analyzeImage(
     String path, {
     List<BarcodeFormat> formats = const <BarcodeFormat>[],
-  }) {
-    return MobileScannerPlatform.instance.analyzeImage(path, formats: formats);
+  }) async {
+    final result = await MobileScannerPlatform.instance.analyzeImage(
+      path,
+      formats: formats,
+    );
+
+    if (result == null) {
+      return null;
+    }
+
+    return _applyAllowedLengths(result);
+  }
+
+  /// Apply [allowedLengths] to [capture].
+  ///
+  /// Returns [capture] unchanged when [allowedLengths] is empty.
+  /// Returns a new [BarcodeCapture] with the filtered barcodes when at least
+  /// one barcode passes the filter.
+  /// Returns null when every barcode in [capture] is dropped, so the caller
+  /// can suppress the capture event entirely.
+  BarcodeCapture? _applyAllowedLengths(BarcodeCapture capture) {
+    if (allowedLengths.isEmpty) {
+      return capture;
+    }
+
+    final filtered = capture.barcodes
+        .where((barcode) {
+          final rawValue = barcode.rawValue;
+          return rawValue != null && allowedLengths.contains(rawValue.length);
+        })
+        .toList(growable: false);
+
+    if (filtered.isEmpty) {
+      return null;
+    }
+
+    if (filtered.length == capture.barcodes.length) {
+      return capture;
+    }
+
+    return BarcodeCapture(
+      barcodes: filtered,
+      image: capture.image,
+      raw: capture.raw,
+      size: capture.size,
+    );
   }
 
   /// Build a camera preview widget.

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -195,7 +195,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
               return;
             }
 
-            final filtered = _applyAllowedLengths(barcode);
+            final filtered = barcode.filterByAllowedLengths(allowedLengths);
             if (filtered == null) {
               return;
             }
@@ -329,42 +329,7 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
       return null;
     }
 
-    return _applyAllowedLengths(result);
-  }
-
-  /// Apply [allowedLengths] to [capture].
-  ///
-  /// Returns [capture] unchanged when [allowedLengths] is empty.
-  /// Returns a new [BarcodeCapture] with the filtered barcodes when at least
-  /// one barcode passes the filter.
-  /// Returns null when every barcode in [capture] is dropped, so the caller
-  /// can suppress the capture event entirely.
-  BarcodeCapture? _applyAllowedLengths(BarcodeCapture capture) {
-    if (allowedLengths.isEmpty) {
-      return capture;
-    }
-
-    final filtered = capture.barcodes
-        .where((barcode) {
-          final rawValue = barcode.rawValue;
-          return rawValue != null && allowedLengths.contains(rawValue.length);
-        })
-        .toList(growable: false);
-
-    if (filtered.isEmpty) {
-      return null;
-    }
-
-    if (filtered.length == capture.barcodes.length) {
-      return capture;
-    }
-
-    return BarcodeCapture(
-      barcodes: filtered,
-      image: capture.image,
-      raw: capture.raw,
-      size: capture.size,
-    );
+    return result.filterByAllowedLengths(allowedLengths);
   }
 
   /// Build a camera preview widget.

--- a/lib/src/objects/barcode_capture.dart
+++ b/lib/src/objects/barcode_capture.dart
@@ -39,4 +39,52 @@ class BarcodeCapture {
   /// For example if the camera resolution is 1920x1080 pixels,
   /// this will be a [Size] with a width of 1920 and a height of 1080.
   final Size size;
+
+  /// Returns a copy of this [BarcodeCapture] with the given fields replaced.
+  BarcodeCapture copyWith({
+    List<Barcode>? barcodes,
+    Uint8List? image,
+    Object? raw,
+    Size? size,
+  }) {
+    return BarcodeCapture(
+      barcodes: barcodes ?? this.barcodes,
+      image: image ?? this.image,
+      raw: raw ?? this.raw,
+      size: size ?? this.size,
+    );
+  }
+
+  /// Returns a copy of this capture with only the [barcodes] whose
+  /// `rawValue.length` is contained in [allowedLengths].
+  ///
+  /// Returns this capture unchanged when [allowedLengths] is empty: no
+  /// filtering is applied.
+  /// Returns `null` when [allowedLengths] is non-empty and every barcode is
+  /// dropped, so the caller can suppress the capture event entirely.
+  ///
+  /// Barcodes whose [Barcode.rawValue] is null are dropped when
+  /// [allowedLengths] is non-empty, because their length cannot be validated.
+  BarcodeCapture? filterByAllowedLengths(Set<int> allowedLengths) {
+    if (allowedLengths.isEmpty) {
+      return this;
+    }
+
+    final filtered = <Barcode>[
+      for (final barcode in barcodes)
+        if (barcode.rawValue case final rawValue?
+            when allowedLengths.contains(rawValue.length))
+          barcode,
+    ];
+
+    if (filtered.isEmpty) {
+      return null;
+    }
+
+    if (filtered.length == barcodes.length) {
+      return this;
+    }
+
+    return copyWith(barcodes: filtered);
+  }
 }

--- a/test/mobile_scanner_controller/allowed_lengths_test.dart
+++ b/test/mobile_scanner_controller/allowed_lengths_test.dart
@@ -1,36 +1,44 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<(MobileScannerController, _FakeMobileScannerPlatform)> pumpScanner(
+  late _FakeMobileScannerPlatform fakePlatform;
+
+  setUp(() {
+    fakePlatform = _FakeMobileScannerPlatform();
+    MobileScannerPlatform.instance = fakePlatform;
+  });
+
+  Future<MobileScannerController> pumpScanner(
     WidgetTester tester, {
     required Set<int> allowedLengths,
   }) async {
-    final fakePlatform = _FakeMobileScannerPlatform();
-    MobileScannerPlatform.instance = fakePlatform;
-
     final controller = MobileScannerController(allowedLengths: allowedLengths);
 
     await tester.pumpWidget(
-      MaterialApp(home: Scaffold(body: MobileScanner(controller: controller))),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 200,
+          height: 200,
+          child: MobileScanner(controller: controller),
+        ),
+      ),
     );
     await tester.pumpAndSettle();
 
-    return (controller, fakePlatform);
+    return controller;
   }
 
   testWidgets('empty allowedLengths forwards every barcode capture unchanged', (
     tester,
   ) async {
-    final (controller, fakePlatform) = await pumpScanner(
-      tester,
-      allowedLengths: const <int>{},
-    );
+    final controller = await pumpScanner(tester, allowedLengths: const <int>{});
     addTearDown(controller.dispose);
 
     final received = <BarcodeCapture>[];
@@ -53,10 +61,7 @@ void main() {
   testWidgets(
     'allowedLengths drops barcodes whose rawValue length is not allowed',
     (tester) async {
-      final (controller, fakePlatform) = await pumpScanner(
-        tester,
-        allowedLengths: const {14},
-      );
+      final controller = await pumpScanner(tester, allowedLengths: const {14});
       addTearDown(controller.dispose);
 
       final received = <BarcodeCapture>[];
@@ -80,38 +85,31 @@ void main() {
     },
   );
 
-  testWidgets('allowedLengths suppresses captures with no surviving barcodes', (
-    tester,
-  ) async {
-    final (controller, fakePlatform) = await pumpScanner(
-      tester,
-      allowedLengths: const {14},
-    );
-    addTearDown(controller.dispose);
+  testWidgets(
+    'allowedLengths suppresses captures when no barcodes survive the filter',
+    (tester) async {
+      final controller = await pumpScanner(tester, allowedLengths: const {14});
+      addTearDown(controller.dispose);
 
-    final received = <BarcodeCapture>[];
-    final subscription = controller.barcodes.listen(received.add);
-    addTearDown(subscription.cancel);
+      final received = <BarcodeCapture>[];
+      final subscription = controller.barcodes.listen(received.add);
+      addTearDown(subscription.cancel);
 
-    fakePlatform.addBarcode(
-      const BarcodeCapture(barcodes: [Barcode(rawValue: '12345')]),
-    );
-    fakePlatform.addBarcode(
-      const BarcodeCapture(barcodes: [Barcode(rawValue: '12345678901234')]),
-    );
-    await tester.pumpAndSettle();
+      fakePlatform.addBarcode(
+        const BarcodeCapture(
+          barcodes: [Barcode(rawValue: '12345'), Barcode(rawValue: '678')],
+        ),
+      );
+      await tester.pumpAndSettle();
 
-    expect(received, hasLength(1));
-    expect(received.single.barcodes.single.rawValue, '12345678901234');
-  });
+      expect(received, isEmpty);
+    },
+  );
 
   testWidgets('allowedLengths drops barcodes whose rawValue is null', (
     tester,
   ) async {
-    final (controller, fakePlatform) = await pumpScanner(
-      tester,
-      allowedLengths: const {14},
-    );
+    final controller = await pumpScanner(tester, allowedLengths: const {14});
     addTearDown(controller.dispose);
 
     final received = <BarcodeCapture>[];
@@ -129,81 +127,14 @@ void main() {
     expect(received.single.barcodes, hasLength(1));
     expect(received.single.barcodes.single.rawValue, '12345678901234');
   });
-
-  testWidgets('analyzeImage applies allowedLengths to the platform result', (
-    tester,
-  ) async {
-    final (controller, fakePlatform) = await pumpScanner(
-      tester,
-      allowedLengths: const {14},
-    );
-    addTearDown(controller.dispose);
-
-    fakePlatform.nextAnalyzeImageResult = const BarcodeCapture(
-      barcodes: [
-        Barcode(rawValue: '12345'),
-        Barcode(rawValue: '12345678901234'),
-      ],
-    );
-
-    final result = await controller.analyzeImage('ignored.png');
-
-    expect(result, isNotNull);
-    expect(result!.barcodes.map((b) => b.rawValue).toList(), const [
-      '12345678901234',
-    ]);
-  });
-
-  testWidgets(
-    'analyzeImage returns null when every barcode is dropped by allowedLengths',
-    (tester) async {
-      final (controller, fakePlatform) = await pumpScanner(
-        tester,
-        allowedLengths: const {14},
-      );
-      addTearDown(controller.dispose);
-
-      fakePlatform.nextAnalyzeImageResult = const BarcodeCapture(
-        barcodes: [Barcode(rawValue: '12345')],
-      );
-
-      final result = await controller.analyzeImage('ignored.png');
-
-      expect(result, isNull);
-    },
-  );
-
-  testWidgets('analyzeImage propagates a null platform result', (tester) async {
-    final (controller, fakePlatform) = await pumpScanner(
-      tester,
-      allowedLengths: const {14},
-    );
-    addTearDown(controller.dispose);
-
-    fakePlatform.nextAnalyzeImageResult = null;
-
-    final result = await controller.analyzeImage('ignored.png');
-
-    expect(result, isNull);
-  });
 }
 
 class _FakeMobileScannerPlatform extends MobileScannerPlatform {
   final StreamController<BarcodeCapture> _barcodeStreamController =
       StreamController<BarcodeCapture>.broadcast();
 
-  BarcodeCapture? nextAnalyzeImageResult;
-
   @override
   Stream<BarcodeCapture?> get barcodesStream => _barcodeStreamController.stream;
-
-  @override
-  Future<BarcodeCapture?> analyzeImage(
-    String path, {
-    List<BarcodeFormat> formats = const <BarcodeFormat>[],
-  }) async {
-    return nextAnalyzeImageResult;
-  }
 
   @override
   Stream<TorchState> get torchStateStream =>

--- a/test/mobile_scanner_controller/allowed_lengths_test.dart
+++ b/test/mobile_scanner_controller/allowed_lengths_test.dart
@@ -1,0 +1,246 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<(MobileScannerController, _FakeMobileScannerPlatform)> pumpScanner(
+    WidgetTester tester, {
+    required Set<int> allowedLengths,
+  }) async {
+    final fakePlatform = _FakeMobileScannerPlatform();
+    MobileScannerPlatform.instance = fakePlatform;
+
+    final controller = MobileScannerController(allowedLengths: allowedLengths);
+
+    await tester.pumpWidget(
+      MaterialApp(home: Scaffold(body: MobileScanner(controller: controller))),
+    );
+    await tester.pumpAndSettle();
+
+    return (controller, fakePlatform);
+  }
+
+  testWidgets('empty allowedLengths forwards every barcode capture unchanged', (
+    tester,
+  ) async {
+    final (controller, fakePlatform) = await pumpScanner(
+      tester,
+      allowedLengths: const <int>{},
+    );
+    addTearDown(controller.dispose);
+
+    final received = <BarcodeCapture>[];
+    final subscription = controller.barcodes.listen(received.add);
+    addTearDown(subscription.cancel);
+
+    const capture = BarcodeCapture(
+      barcodes: [
+        Barcode(rawValue: '12345'),
+        Barcode(rawValue: '12345678901234'),
+      ],
+    );
+    fakePlatform.addBarcode(capture);
+    await tester.pumpAndSettle();
+
+    expect(received, hasLength(1));
+    expect(identical(received.single, capture), isTrue);
+  });
+
+  testWidgets(
+    'allowedLengths drops barcodes whose rawValue length is not allowed',
+    (tester) async {
+      final (controller, fakePlatform) = await pumpScanner(
+        tester,
+        allowedLengths: const {14},
+      );
+      addTearDown(controller.dispose);
+
+      final received = <BarcodeCapture>[];
+      final subscription = controller.barcodes.listen(received.add);
+      addTearDown(subscription.cancel);
+
+      fakePlatform.addBarcode(
+        const BarcodeCapture(
+          barcodes: [
+            Barcode(rawValue: '12345'),
+            Barcode(rawValue: '12345678901234'),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(received, hasLength(1));
+      expect(received.single.barcodes.map((b) => b.rawValue).toList(), const [
+        '12345678901234',
+      ]);
+    },
+  );
+
+  testWidgets('allowedLengths suppresses captures with no surviving barcodes', (
+    tester,
+  ) async {
+    final (controller, fakePlatform) = await pumpScanner(
+      tester,
+      allowedLengths: const {14},
+    );
+    addTearDown(controller.dispose);
+
+    final received = <BarcodeCapture>[];
+    final subscription = controller.barcodes.listen(received.add);
+    addTearDown(subscription.cancel);
+
+    fakePlatform.addBarcode(
+      const BarcodeCapture(barcodes: [Barcode(rawValue: '12345')]),
+    );
+    fakePlatform.addBarcode(
+      const BarcodeCapture(barcodes: [Barcode(rawValue: '12345678901234')]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(received, hasLength(1));
+    expect(received.single.barcodes.single.rawValue, '12345678901234');
+  });
+
+  testWidgets('allowedLengths drops barcodes whose rawValue is null', (
+    tester,
+  ) async {
+    final (controller, fakePlatform) = await pumpScanner(
+      tester,
+      allowedLengths: const {14},
+    );
+    addTearDown(controller.dispose);
+
+    final received = <BarcodeCapture>[];
+    final subscription = controller.barcodes.listen(received.add);
+    addTearDown(subscription.cancel);
+
+    fakePlatform.addBarcode(
+      const BarcodeCapture(
+        barcodes: [Barcode(), Barcode(rawValue: '12345678901234')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(received, hasLength(1));
+    expect(received.single.barcodes, hasLength(1));
+    expect(received.single.barcodes.single.rawValue, '12345678901234');
+  });
+
+  testWidgets('analyzeImage applies allowedLengths to the platform result', (
+    tester,
+  ) async {
+    final (controller, fakePlatform) = await pumpScanner(
+      tester,
+      allowedLengths: const {14},
+    );
+    addTearDown(controller.dispose);
+
+    fakePlatform.nextAnalyzeImageResult = const BarcodeCapture(
+      barcodes: [
+        Barcode(rawValue: '12345'),
+        Barcode(rawValue: '12345678901234'),
+      ],
+    );
+
+    final result = await controller.analyzeImage('ignored.png');
+
+    expect(result, isNotNull);
+    expect(result!.barcodes.map((b) => b.rawValue).toList(), const [
+      '12345678901234',
+    ]);
+  });
+
+  testWidgets(
+    'analyzeImage returns null when every barcode is dropped by allowedLengths',
+    (tester) async {
+      final (controller, fakePlatform) = await pumpScanner(
+        tester,
+        allowedLengths: const {14},
+      );
+      addTearDown(controller.dispose);
+
+      fakePlatform.nextAnalyzeImageResult = const BarcodeCapture(
+        barcodes: [Barcode(rawValue: '12345')],
+      );
+
+      final result = await controller.analyzeImage('ignored.png');
+
+      expect(result, isNull);
+    },
+  );
+
+  testWidgets('analyzeImage propagates a null platform result', (tester) async {
+    final (controller, fakePlatform) = await pumpScanner(
+      tester,
+      allowedLengths: const {14},
+    );
+    addTearDown(controller.dispose);
+
+    fakePlatform.nextAnalyzeImageResult = null;
+
+    final result = await controller.analyzeImage('ignored.png');
+
+    expect(result, isNull);
+  });
+}
+
+class _FakeMobileScannerPlatform extends MobileScannerPlatform {
+  final StreamController<BarcodeCapture> _barcodeStreamController =
+      StreamController<BarcodeCapture>.broadcast();
+
+  BarcodeCapture? nextAnalyzeImageResult;
+
+  @override
+  Stream<BarcodeCapture?> get barcodesStream => _barcodeStreamController.stream;
+
+  @override
+  Future<BarcodeCapture?> analyzeImage(
+    String path, {
+    List<BarcodeFormat> formats = const <BarcodeFormat>[],
+  }) async {
+    return nextAnalyzeImageResult;
+  }
+
+  @override
+  Stream<TorchState> get torchStateStream =>
+      Stream.value(TorchState.unavailable);
+
+  @override
+  Stream<double> get zoomScaleStateStream => Stream.value(1);
+
+  @override
+  Future<MobileScannerViewAttributes> start(StartOptions startOptions) {
+    return Future.value(
+      const MobileScannerViewAttributes(
+        cameraDirection: CameraFacing.back,
+        currentTorchMode: TorchState.unavailable,
+        size: Size(200, 200),
+        numberOfCameras: 1,
+      ),
+    );
+  }
+
+  @override
+  Widget buildCameraView() {
+    return const SizedBox.square(dimension: 100);
+  }
+
+  void addBarcode(BarcodeCapture barcodeCapture) {
+    _barcodeStreamController.add(barcodeCapture);
+  }
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> updateScanWindow(Rect? window) async {}
+
+  @override
+  Future<void> dispose() {
+    return _barcodeStreamController.close();
+  }
+}

--- a/test/mobile_scanner_controller/analyze_image_test.dart
+++ b/test/mobile_scanner_controller/analyze_image_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeMobileScannerPlatform fakePlatform;
+
+  setUp(() {
+    fakePlatform = _FakeMobileScannerPlatform();
+    MobileScannerPlatform.instance = fakePlatform;
+  });
+
+  test('empty allowedLengths returns the platform result unchanged', () async {
+    final controller = MobileScannerController(autoStart: false);
+    addTearDown(controller.dispose);
+
+    const platformResult = BarcodeCapture(
+      barcodes: [
+        Barcode(rawValue: '12345'),
+        Barcode(rawValue: '12345678901234'),
+      ],
+    );
+    fakePlatform.nextAnalyzeImageResult = platformResult;
+
+    final result = await controller.analyzeImage('ignored.png');
+
+    expect(identical(result, platformResult), isTrue);
+  });
+
+  test('applies allowedLengths to the platform result', () async {
+    final controller = MobileScannerController(
+      autoStart: false,
+      allowedLengths: const {14},
+    );
+    addTearDown(controller.dispose);
+
+    fakePlatform.nextAnalyzeImageResult = const BarcodeCapture(
+      barcodes: [
+        Barcode(rawValue: '12345'),
+        Barcode(rawValue: '12345678901234'),
+      ],
+    );
+
+    final result = await controller.analyzeImage('ignored.png');
+
+    expect(result, isNotNull);
+    expect(result!.barcodes.map((b) => b.rawValue).toList(), const [
+      '12345678901234',
+    ]);
+  });
+
+  test(
+    'returns null when every barcode is dropped by allowedLengths',
+    () async {
+      final controller = MobileScannerController(
+        autoStart: false,
+        allowedLengths: const {14},
+      );
+      addTearDown(controller.dispose);
+
+      fakePlatform.nextAnalyzeImageResult = const BarcodeCapture(
+        barcodes: [Barcode(rawValue: '12345')],
+      );
+
+      final result = await controller.analyzeImage('ignored.png');
+
+      expect(result, isNull);
+    },
+  );
+}
+
+class _FakeMobileScannerPlatform extends MobileScannerPlatform {
+  BarcodeCapture? nextAnalyzeImageResult;
+
+  @override
+  Future<BarcodeCapture?> analyzeImage(
+    String path, {
+    List<BarcodeFormat> formats = const <BarcodeFormat>[],
+  }) async {
+    return nextAnalyzeImageResult;
+  }
+
+  @override
+  Stream<BarcodeCapture?> get barcodesStream => const Stream.empty();
+
+  @override
+  Stream<TorchState> get torchStateStream =>
+      Stream.value(TorchState.unavailable);
+
+  @override
+  Stream<double> get zoomScaleStateStream => Stream.value(1);
+
+  @override
+  Future<MobileScannerViewAttributes> start(StartOptions startOptions) {
+    return Future.value(
+      const MobileScannerViewAttributes(
+        cameraDirection: CameraFacing.back,
+        currentTorchMode: TorchState.unavailable,
+        size: Size(200, 200),
+        numberOfCameras: 1,
+      ),
+    );
+  }
+
+  @override
+  Widget buildCameraView() {
+    return const SizedBox.square(dimension: 100);
+  }
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> updateScanWindow(Rect? window) async {}
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/test/mobile_scanner_controller/create_controller_test.dart
+++ b/test/mobile_scanner_controller/create_controller_test.dart
@@ -21,4 +21,19 @@ void main() {
       expect(controller.lensType, lensType);
     }
   });
+
+  test('controller defaults allowedLengths to an empty set', () {
+    final controller = MobileScannerController(autoStart: false);
+
+    expect(controller.allowedLengths, isEmpty);
+  });
+
+  test('controller exposes the allowedLengths it was created with', () {
+    final controller = MobileScannerController(
+      autoStart: false,
+      allowedLengths: const {14},
+    );
+
+    expect(controller.allowedLengths, const {14});
+  });
 }


### PR DESCRIPTION
Allows callers to restrict scanner output to barcodes whose rawValue.length is in a given set. When every barcode in a capture is dropped, the capture itself is suppressed. Also applied to analyzeImage results.

This is primarily useful for formats without a checksum or end-of-barcode indicator (e.g. ITF / Interleaved 2 of 5 or CODE39), where the decoder can return a truncated prefix of the actual code.

This is related to issue #1536 