### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,6 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     if (project.android.hasProperty("namespace")) {


### PR DESCRIPTION
removed (apply plugin: 'kotlin-android') from "android/build.gradle" to fix the build-in kotlin warning.