### PR TITLE
fix: do not dispose platform resources of another active controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   * `WebBarcodeReader.zxingJs`, the legacy ZXing JavaScript backend, retained for backward compatibility.
 * [Web] Added `MobileScannerPlatform.instance.activeWebReader` to query which backend is currently active.
 
+**Bug Fixes**
+
+* Fixed disposing a `MobileScannerController` also disposing the platform resources of a different controller. Disposing a controller that does not hold the active camera session no longer tears down the camera of the controller that does. ([#1631](https://github.com/juliansteenbakker/mobile_scanner/issues/1631))
+* Fixed a subscription leak where a controller that was disposed without being stopped kept its internal event stream subscriptions alive.
+
 ## 7.2.1
 
 **Improvements**

--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -155,6 +155,26 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   // called its `initState()` lifecycle method.
   final Completer<void> _isAttachedCompleter = Completer<void>();
 
+  // The controller that currently holds the platform camera session.
+  //
+  // Only one camera session can be active at a time,
+  // but multiple controllers can exist simultaneously,
+  // for instance when two routes with a scanner are on the navigation stack.
+  //
+  // A controller that does not hold the session must not tear down the
+  // platform resources, as that would break the controller that does.
+  // See https://github.com/juliansteenbakker/mobile_scanner/issues/1631
+  static MobileScannerController? _platformSessionOwner;
+
+  /// Reset the shared platform camera session owner.
+  ///
+  /// This is only intended for use in tests,
+  /// to prevent state from leaking between test cases.
+  @visibleForTesting
+  static void resetPlatformSessionOwner() {
+    _platformSessionOwner = null;
+  }
+
   void _disposeListeners() {
     unawaited(_barcodesSubscription?.cancel());
     unawaited(_torchStateSubscription?.cancel());
@@ -469,6 +489,9 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
         options,
       );
 
+      // This controller now holds the platform camera session.
+      _platformSessionOwner = this;
+
       if (!_isDisposed) {
         value = value.copyWith(
           availableCameras: viewAttributes.numberOfCameras,
@@ -510,6 +533,13 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
   /// Does nothing if the camera is already stopped.
   Future<void> stop() async {
     if (_stop()) {
+      // Stopping releases the platform camera session,
+      // so that another controller can start it.
+      // Pausing does not, as a paused session is resumed by its own owner.
+      if (identical(_platformSessionOwner, this)) {
+        _platformSessionOwner = null;
+      }
+
       await MobileScannerPlatform.instance.stop();
     }
   }
@@ -750,8 +780,19 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
     }
 
     _isDisposed = true;
+    _disposeListeners();
     unawaited(_barcodesController.close());
     super.dispose();
+
+    // If another controller currently holds the platform camera session,
+    // disposing the platform resources would break that controller.
+    // In that case only this controller's own resources are cleaned up.
+    if (_platformSessionOwner != null &&
+        !identical(_platformSessionOwner, this)) {
+      return;
+    }
+
+    _platformSessionOwner = null;
 
     await MobileScannerPlatform.instance.dispose();
   }

--- a/test/mobile_scanner_controller/dispose_test.dart
+++ b/test/mobile_scanner_controller/dispose_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/camera_facing.dart';
+import 'package:mobile_scanner/src/enums/torch_state.dart';
+import 'package:mobile_scanner/src/mobile_scanner_controller.dart';
+import 'package:mobile_scanner/src/mobile_scanner_platform_interface.dart';
+import 'package:mobile_scanner/src/mobile_scanner_view_attributes.dart';
+import 'package:mobile_scanner/src/objects/barcode_capture.dart';
+import 'package:mobile_scanner/src/objects/start_options.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeMobileScannerPlatform platform;
+
+  setUp(() {
+    platform = FakeMobileScannerPlatform();
+    MobileScannerPlatform.instance = platform;
+    MobileScannerController.resetPlatformSessionOwner();
+  });
+
+  group('dispose', () {
+    test('disposing the only controller disposes the platform', () async {
+      final controller = MobileScannerController(autoStart: false)..attach();
+
+      await controller.start();
+      await controller.dispose();
+
+      expect(platform.disposeCalls, 1);
+    });
+
+    test(
+      'disposing a controller that never started does not dispose the '
+      'platform while another controller holds the camera session',
+      () async {
+        final first = MobileScannerController(autoStart: false)..attach();
+        await first.start();
+
+        final second = MobileScannerController(autoStart: false);
+        await second.dispose();
+
+        expect(platform.disposeCalls, 0);
+        expect(platform.stopCalls, 0);
+        expect(first.value.isRunning, isTrue);
+
+        await first.dispose();
+
+        expect(platform.disposeCalls, 1);
+      },
+    );
+
+    test(
+      'disposing a stopped controller does not dispose the platform '
+      'while another controller holds the camera session',
+      () async {
+        final first = MobileScannerController(autoStart: false)..attach();
+        await first.start();
+        await first.stop();
+
+        final second = MobileScannerController(autoStart: false)..attach();
+        await second.start();
+
+        await first.dispose();
+
+        expect(platform.disposeCalls, 0);
+        expect(second.value.isRunning, isTrue);
+
+        await second.dispose();
+
+        expect(platform.disposeCalls, 1);
+      },
+    );
+
+    test(
+      'disposing all controllers when none hold the camera session '
+      'disposes the platform',
+      () async {
+        final controller = MobileScannerController(autoStart: false)..attach();
+
+        await controller.start();
+        await controller.stop();
+        await controller.dispose();
+
+        expect(platform.disposeCalls, 1);
+      },
+    );
+  });
+}
+
+class FakeMobileScannerPlatform extends MobileScannerPlatform {
+  int disposeCalls = 0;
+  int stopCalls = 0;
+
+  @override
+  Stream<BarcodeCapture?> get barcodesStream => const Stream.empty();
+
+  @override
+  Stream<TorchState> get torchStateStream =>
+      Stream.value(TorchState.unavailable);
+
+  @override
+  Stream<double> get zoomScaleStateStream => Stream.value(1);
+
+  @override
+  Future<MobileScannerViewAttributes> start(StartOptions startOptions) {
+    return Future.value(
+      const MobileScannerViewAttributes(
+        cameraDirection: CameraFacing.back,
+        currentTorchMode: TorchState.unavailable,
+        size: Size(200, 200),
+        numberOfCameras: 3,
+        initialDeviceOrientation: DeviceOrientation.portraitUp,
+      ),
+    );
+  }
+
+  @override
+  Future<void> stop() {
+    stopCalls++;
+    return Future.value();
+  }
+
+  @override
+  Future<void> dispose() {
+    disposeCalls++;
+    return Future.value();
+  }
+}


### PR DESCRIPTION
Disposing a MobileScannerController unconditionally called MobileScannerPlatform.instance.dispose(), tearing down the camera session and event streams of a different controller that was still using them, for instance when two routes with a scanner are on the navigation stack.

The controller that most recently started the camera is now tracked as the platform session owner. A controller that does not hold the session only cleans up its own resources on dispose, leaving the active controller untouched. Ownership is released on stop and transfers when another controller starts the camera.

Also cancel the controller's own stream subscriptions on dispose, which previously stayed alive when a controller was disposed without being stopped first.

Fixes #1631, superceeds #1672