### PR TITLE
fix(android): prevent host-app crash when CameraX fails to initialize in start()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.4.1
+
+**Bug Fixes**
+
+* [Android] Fixed a host-app crash when CameraX fails to initialize while starting the scanner (e.g. "Available cameras: 0", the camera being held by another process, or a transient HAL error). The failure is now routed through the normal error callback so it can be surfaced via `errorBuilder` instead of terminating the app.
+
 ## 7.4.0
 
 **New features**

--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/MobileScanner.kt
@@ -401,7 +401,19 @@ class MobileScanner(
         val mainExecutor = ContextCompat.getMainExecutor(activity)
 
         cameraProviderFuture.addListener({
-            cameraProvider = cameraProviderFuture.get()
+            try {
+                cameraProvider = cameraProviderFuture.get()
+            } catch (e: Exception) {
+                // CameraX can fail to initialize on some devices (e.g.
+                // "Available cameras: 0", camera held by another process, or a
+                // transient HAL error). get() rethrows that as an uncaught
+                // ExecutionException here, which crashes the host app. Route it
+                // through the normal error callback instead so the Dart side can
+                // surface it via errorBuilder rather than terminating.
+                mobileScannerErrorCallback(NoCamera())
+
+                return@addListener
+            }
             val numberOfCameras = cameraProvider?.availableCameraInfos?.size
 
             if (cameraProvider == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal Flutter barcode and QR code scanner using CameraX/ML Kit for Android, AVFoundation/Apple Vision for iOS & macOS, and ZXing for web.
-version: 7.4.0
+version: 7.4.1
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 screenshots:


### PR DESCRIPTION
## Problem

On some Android devices, opening the scanner crashes the entire host app with:

```
androidx.camera.core.InitializationException: CameraUnavailableException:
Device reporting less cameras than anticipated. Available cameras: 0
  at androidx.camera.core.CameraX.lambda$initAndRetryRecursively$2 (CameraX.java:507)
  ...
  at dev.steenbakker.mobile_scanner.MobileScanner.start$lambda$16 (MobileScanner.java:404)
```

In `MobileScanner.start()`, `cameraProviderFuture.get()` is called **outside any
try/catch**:

```kotlin
cameraProviderFuture.addListener({
    cameraProvider = cameraProviderFuture.get()   // <-- unguarded
    ...
```

When CameraX fails to initialize (device reports `Available cameras: 0`, the
camera is held by another process, or a transient HAL error), the stored
`InitializationException` is rethrown here as an uncaught `ExecutionException`
on the listener's executor, **terminating the host app**.

Every *other* failure in `start()` is routed through `mobileScannerErrorCallback`
(and surfaced to Dart via `errorBuilder`) — only this path crashes instead of
being recoverable.

## Fix

Wrap the `get()` call and route the failure through the existing `NoCamera()`
error, so the host app receives a recoverable error (and can show a retry UI)
instead of crashing:

```kotlin
cameraProviderFuture.addListener({
    try {
        cameraProvider = cameraProviderFuture.get()
    } catch (e: Exception) {
        mobileScannerErrorCallback(NoCamera())
        return@addListener
    }
    ...
```

No behavior change on the success path. Single, minimal change.

## Related

- Fixes #1453
- Related: #1109 (Android 11, "camera not found")