### PR TITLE
fix: [Apple] notify the texture registry on the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.4.2
+
+**Bug Fixes**
+
+* [iOS/macOS] Fixed a use-after-free crash (`EXC_BAD_ACCESS`) when the app is terminated while the scanner is running. The texture registry was notified directly from the capture output queue, which could call into the Flutter engine while it was being destroyed on the main thread. The notification is now dispatched to the main queue, so it is serialized against engine teardown. The plugin also implements `detachFromEngineForRegistrar:` to release the camera and texture deterministically.
+
 ## 7.4.1
 
 **Bug Fixes**

--- a/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
+++ b/darwin/mobile_scanner/Sources/mobile_scanner/MobileScannerPlugin.swift
@@ -89,6 +89,13 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
 #endif
     }
     
+    public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+        // Release the camera deterministically when the engine detaches this plugin, so the
+        // capture session stops delivering frames instead of outliving the engine.
+        releaseCamera()
+        releaseTexture()
+    }
+
     init(_ registry: FlutterTextureRegistry) {
         self.registry = registry
         super.init()
@@ -161,8 +168,30 @@ public class MobileScannerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler,
             return
         }
         latestBuffer = imageBuffer
-        registry.textureFrameAvailable(textureId)
-        
+
+        // Notify the texture registry on the main thread.
+        //
+        // This method runs on `sampleBufferQueue`, while the Flutter engine is torn down
+        // synchronously on the main thread (`-[FlutterViewController appOrSceneWillTerminate]` ->
+        // `-[FlutterEngine destroyContext]`). Calling `textureFrameAvailable` directly from this
+        // queue can therefore land in the middle of the engine's `dealloc`, which crashes with
+        // EXC_BAD_ACCESS. `FlutterTextureRegistryRelay` holds its parent weakly, but a weak
+        // reference is only cleared after `dealloc` completes, so it does not guard against a call
+        // that arrives during teardown.
+        //
+        // Hopping to the main queue serializes this call against the teardown itself, instead of
+        // relying on notification or plugin-detach ordering. A block that is enqueued after the
+        // engine is gone finds the relay's parent already nil and becomes a no-op.
+        let frameTextureId: Int64 = textureId
+        DispatchQueue.main.async { [weak self] in
+            // Drop the frame if the texture was released while this block was queued.
+            guard let self, self.textureId != nil else {
+                return
+            }
+
+            self.registry.textureFrameAvailable(frameTextureId)
+        }
+
         let currentTime = Date().timeIntervalSince1970
         let eligibleForScan = currentTime > nextScanTime && !imagesCurrentlyBeingProcessed
         if ((detectionSpeed == DetectionSpeed.normal || detectionSpeed == DetectionSpeed.noDuplicates) && eligibleForScan || detectionSpeed == DetectionSpeed.unrestricted) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_scanner
 description: A universal Flutter barcode and QR code scanner using CameraX/ML Kit for Android, AVFoundation/Apple Vision for iOS & macOS, and ZXing for web.
-version: 7.4.1
+version: 7.4.2
 repository: https://github.com/juliansteenbakker/mobile_scanner
 
 screenshots:


### PR DESCRIPTION
## Problem

`MobileScannerPlugin.captureOutput(_:didOutput:from:)` runs on the plugin's own
`sampleBufferQueue` (`com.juliansteenbakker.mobile_scanner.captureOutputQueue`) and calls
`registry.textureFrameAvailable(textureId)` directly from that queue.

The Flutter engine, however, is destroyed **synchronously on the main thread**
(`-[FlutterViewController appOrSceneWillTerminate]` → `-[FlutterEngine destroyContext]` →
`Shell::~Shell`). If a frame callback is in flight on the capture queue at that moment, it calls
`-[FlutterEngine textureFrameAvailable:]` on an engine that is already mid-`dealloc`, with a
partially destroyed `Shell` → `EXC_BAD_ACCESS`.

`FlutterTextureRegistryRelay` forwards to a weak `parent`, but a weak reference is only cleared
*after* `dealloc` completes, so it does not protect against a call that arrives *during* teardown.

We see this in production on physical iPhones, release builds, on the order of hundreds of crashes
per day for a screen that keeps a scanner running.

### Crash stack (redacted)

```
Crashed: com.juliansteenbakker.mobile_scanner.captureOutputQueue
0  Flutter    -[FlutterEngine textureFrameAvailable:] + 84 (ref_ptr.h:84)
1  Flutter    -[FlutterTextureRegistryRelay textureFrameAvailable:] + 34
2  Runner     specialized MobileScannerPlugin.captureOutput(_:didOutput:from:) + 166 (MobileScannerPlugin.swift:166)
3  Runner     @objc MobileScannerPlugin.captureOutput(_:didOutput:from:)
4  AVFCapture -[AVCaptureVideoDataOutput _processSampleBuffer:] + 300
5  AVFCapture __47-[AVCaptureVideoDataOutput _updateRemoteQueue:]_block_invoke + 88
...

com.apple.main-thread
7  Flutter    std::shared_ptr<impeller::Texture>::~shared_ptr()
8  Flutter    impeller::DlImageImpeller::~DlImageImpeller()
13 Flutter    dart::Isolate::Shutdown() + 2650
14 Flutter    Dart_ShutdownIsolate + 1167
17 Flutter    flutter::Engine::~Engine() + 284
20 Flutter    flutter::Shell::~Shell() + 403
22 Flutter    -[FlutterEngine destroyContext] + 44
23 Flutter    -[FlutterViewController appOrSceneWillTerminate] + 1089 (FlutterViewController.mm:1089)
29 UIKitCore  -[UIApplication _terminateWithStatus:] + 236
```

## Steps to reproduce

1. Release or profile build on a physical iPhone.
2. Show a `MobileScanner` widget with the camera running.
3. Swipe-kill the app from the app switcher while the preview is live.
4. Repeat ~20×. It is a race, so it does not fire on every attempt.

## Why a Dart-side workaround cannot fix this

Stopping the camera from `didChangeAppLifecycleState(inactive/paused/detached)` does not help: it
needs a platform-channel round trip, while termination is synchronous inside the notification
callout and the Dart isolate is shut down in that same call chain (`Dart_ShutdownIsolate` is visible
in the stack above). The stop message is never delivered.

Stopping the session natively is not sufficient on its own either — `captureSession.stopRunning()`
does not drain a callback that is already executing on the capture queue.

## Fix

Hop the texture notification to the main queue. Since engine teardown also runs on the main thread,
the queue itself serializes the two, so correctness no longer depends on notification or
plugin-detach ordering. A block enqueued after the engine is gone finds the relay's parent already
nil and becomes a no-op, and the `textureId != nil` re-check drops frames whose texture was released
while the block was queued.

Barcode analysis stays off the main thread exactly as before — only the registry notification moves,
which just marks the texture dirty and schedules a frame.

Additionally, `detachFromEngineForRegistrar:` is now implemented to release the camera and texture
deterministically when the engine detaches the plugin (defense in depth; the main-queue hop is what
actually closes the race).

Not touched: the separate `latestBuffer` / `copyPixelBuffer()` interaction with the raster thread —
out of scope for this fix.

## Notes

- No changelog entry added, since the changelog is generated from the Conventional Commit PR title.
- Happy to adjust the approach — for example coalescing pending notifications if the extra main-queue
  hop per frame is a concern on lower-end devices.
  
  Fixes #1768 
