### PR TITLE
fix(web): remove no-op @JS annotations on extension type constructors

### DIFF
--- a/lib/src/web/barcode_detector/barcode_detector_js.dart
+++ b/lib/src/web/barcode_detector/barcode_detector_js.dart
@@ -24,7 +24,6 @@ extension type NativeBarcodeDetector._(JSObject _) implements JSObject {
   external factory NativeBarcodeDetector();
 
   /// Constructs a detector restricted to the given [options].
-  @JS('BarcodeDetector')
   external factory NativeBarcodeDetector.withOptions(
     BarcodeDetectorInit options,
   );

--- a/lib/src/web/zxing_wasm/zxing_wasm_result.dart
+++ b/lib/src/web/zxing_wasm/zxing_wasm_result.dart
@@ -46,7 +46,6 @@ extension type ZXingWasmReaderOptions._(JSObject _) implements JSObject {
   ///
   /// Pass a non-empty list of format strings (e.g. `['QRCode', 'EAN13']`).
   /// Passing an empty list or omitting formats detects all supported formats.
-  @JS('ZXingWasmReaderOptions')
   external factory ZXingWasmReaderOptions.withFormats({
     /// Barcode format filter.
     JSArray<JSString> formats,


### PR DESCRIPTION
Dart 3.14 (Flutter 3.48) adds a new compile-time check that rejects `@JS` annotations on extension type constructors, breaking web builds. 
The annotations were already no-ops: the JS constructor is resolved from the extension type's own `@JS` name, and `ZXingWasmReaderOptions.withFormats` is an object-literal constructor.
Removing them changes no behavior.

Fixes #1773

## Description

<!-- What does this PR change, and why? -->

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`) — this is required by CI and drives the automated changelog/release.
- [x] (Optional) Each individual commit also follows Conventional Commits — if so, we'll merge with a real merge commit to preserve your full history; otherwise we'll squash the PR into one commit.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
