### PR TITLE
fix(web): release the camera when a polling barcode reader stops

### DIFF
--- a/lib/src/mobile_scanner_controller.dart
+++ b/lib/src/mobile_scanner_controller.dart
@@ -489,10 +489,15 @@ class MobileScannerController extends ValueNotifier<MobileScannerState> {
         options,
       );
 
-      // This controller now holds the platform camera session.
-      _platformSessionOwner = this;
-
       if (!_isDisposed) {
+        // This controller now holds the platform camera session.
+        //
+        // Not claimed when the controller was disposed while the camera was
+        // being acquired: the session would then point at a dead controller,
+        // and the next controller to dispose would skip the platform
+        // teardown, leaving the camera live.
+        _platformSessionOwner = this;
+
         value = value.copyWith(
           availableCameras: viewAttributes.numberOfCameras,
           cameraDirection: viewAttributes.cameraDirection,

--- a/lib/src/web/mobile_scanner_web.dart
+++ b/lib/src/web/mobile_scanner_web.dart
@@ -46,6 +46,15 @@ class MobileScannerWeb extends MobileScannerPlatform {
   /// The internal barcode reader.
   BarcodeReader? _barcodeReader;
 
+  /// Incremented by every [stop], which [dispose] also routes through.
+  ///
+  /// A [start] that is still in flight compares this against the value it
+  /// captured: if it changed, the scanner was stopped while the camera was
+  /// being acquired, and everything this start acquired must be released.
+  /// Without it the teardown runs before the reader owns the stream, so it
+  /// has nothing to stop, and the acquired camera stays live.
+  int _teardownGeneration = 0;
+
   /// The stream controller for the barcode stream.
   final StreamController<BarcodeCapture> _barcodesController =
       StreamController.broadcast();
@@ -431,6 +440,8 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
   @override
   Future<MobileScannerViewAttributes> start(StartOptions startOptions) async {
+    final generation = _teardownGeneration;
+
     if (_barcodeReader != null) {
       if (_barcodeReader!.paused ?? false) {
         await _barcodeReader?.resume();
@@ -494,87 +505,134 @@ class MobileScannerWeb extends MobileScannerPlatform {
       cameraResolution: startOptions.cameraResolution,
     );
 
+    // The camera is live from here on, but the reader does not own it yet.
+    // A stop() that lands in this window has nothing to release, so this
+    // start stays responsible for the stream until the reader has it, and for
+    // releasing it if anything below fails.
     try {
-      // Clear the existing barcodes.
-      if (!_barcodesController.isClosed) {
-        _barcodesController.add(const BarcodeCapture());
+      _throwIfTornDown(generation);
+
+      try {
+        // Clear the existing barcodes.
+        if (!_barcodesController.isClosed) {
+          _barcodesController.add(const BarcodeCapture());
+        }
+
+        // Listen for changes to the media track settings.
+        _barcodeReader?.setMediaTrackSettingsListener(
+          _handleMediaTrackSettingsChange,
+        );
+
+        _textureId += 1; // Request a new texture.
+
+        _videoElement = _createVideoElement(_textureId);
+
+        maybeFlipVideoPreview(_videoElement, videoStream);
+
+        await _barcodeReader?.start(
+          startOptions,
+          videoElement: _videoElement,
+          videoStream: videoStream,
+        );
+
+        // Re-apply the scan window if one was set before start() was called.
+        if (_scanWindow != null) {
+          _barcodeReader?.updateScanWindow(_scanWindow);
+        }
+      } catch (error, stackTrace) {
+        throw MobileScannerException(
+          errorCode: MobileScannerErrorCode.genericError,
+          errorDetails: MobileScannerErrorDetails(
+            message: error.toString(),
+            details: stackTrace.toString(),
+          ),
+        );
       }
 
-      // Listen for changes to the media track settings.
-      _barcodeReader?.setMediaTrackSettingsListener(
-        _handleMediaTrackSettingsChange,
-      );
+      _throwIfTornDown(generation);
 
-      _textureId += 1; // Request a new texture.
+      try {
+        _barcodesSubscription = _barcodeReader?.detectBarcodes().listen(
+          (barcode) {
+            if (_barcodesController.isClosed) {
+              return;
+            }
 
-      _videoElement = _createVideoElement(_textureId);
+            _barcodesController.add(barcode);
+          },
+          onError: (Object error) {
+            if (_barcodesController.isClosed) {
+              return;
+            }
 
-      maybeFlipVideoPreview(_videoElement, videoStream);
+            _barcodesController.addError(error);
+          },
+          // Errors are handled gracefully by forwarding them.
+          cancelOnError: false,
+        );
 
-      await _barcodeReader?.start(
-        startOptions,
-        videoElement: _videoElement,
-        videoStream: videoStream,
-      );
+        final hasTorch = await _barcodeReader?.hasTorch() ?? false;
 
-      // Re-apply the scan window if one was set before start() was called.
-      if (_scanWindow != null) {
-        _barcodeReader?.updateScanWindow(_scanWindow);
+        if (hasTorch && startOptions.torchEnabled) {
+          await _barcodeReader?.setTorchState(TorchState.on);
+        }
+
+        final cameraDirection = _settingsDelegate.getCameraDirection(
+          videoStream,
+        );
+
+        return MobileScannerViewAttributes(
+          cameraDirection: cameraDirection,
+          // The torch of a media stream is not available for video tracks.
+          // See https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#instance_properties_of_video_tracks
+          currentTorchMode: TorchState.unavailable,
+          size: _barcodeReader?.videoSize ?? Size.zero,
+        );
+      } catch (error, stackTrace) {
+        throw MobileScannerException(
+          errorCode: MobileScannerErrorCode.genericError,
+          errorDetails: MobileScannerErrorDetails(
+            message: error.toString(),
+            details: stackTrace.toString(),
+          ),
+        );
       }
-    } catch (error, stackTrace) {
-      throw MobileScannerException(
-        errorCode: MobileScannerErrorCode.genericError,
-        errorDetails: MobileScannerErrorDetails(
-          message: error.toString(),
-          details: stackTrace.toString(),
-        ),
-      );
+    } catch (_) {
+      await _releaseAbandonedStart(videoStream, generation);
+      rethrow;
+    }
+  }
+
+  /// Throws if [stop] ran since the start that captured [generation] began.
+  void _throwIfTornDown(int generation) {
+    if (_teardownGeneration == generation) {
+      return;
     }
 
-    try {
-      _barcodesSubscription = _barcodeReader?.detectBarcodes().listen(
-        (barcode) {
-          if (_barcodesController.isClosed) {
-            return;
-          }
+    throw const MobileScannerException(
+      errorCode: MobileScannerErrorCode.controllerDisposed,
+      errorDetails: MobileScannerErrorDetails(
+        message: 'The scanner was stopped while the camera was starting.',
+      ),
+    );
+  }
 
-          _barcodesController.add(barcode);
-        },
-        onError: (Object error) {
-          if (_barcodesController.isClosed) {
-            return;
-          }
-
-          _barcodesController.addError(error);
-        },
-        // Errors are handled gracefully by forwarding them.
-        cancelOnError: false,
-      );
-
-      final hasTorch = await _barcodeReader?.hasTorch() ?? false;
-
-      if (hasTorch && startOptions.torchEnabled) {
-        await _barcodeReader?.setTorchState(TorchState.on);
-      }
-
-      final cameraDirection = _settingsDelegate.getCameraDirection(videoStream);
-
-      return MobileScannerViewAttributes(
-        cameraDirection: cameraDirection,
-        // The torch of a media stream is not available for video tracks.
-        // See https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#instance_properties_of_video_tracks
-        currentTorchMode: TorchState.unavailable,
-        size: _barcodeReader?.videoSize ?? Size.zero,
-      );
-    } catch (error, stackTrace) {
-      throw MobileScannerException(
-        errorCode: MobileScannerErrorCode.genericError,
-        errorDetails: MobileScannerErrorDetails(
-          message: error.toString(),
-          details: stackTrace.toString(),
-        ),
-      );
+  /// Releases the camera acquired by a start that failed or was torn down.
+  ///
+  /// The reader is only torn down when this start still owns the session: a
+  /// newer start may already have replaced it, and stopping that one would
+  /// release a camera that is legitimately in use.
+  Future<void> _releaseAbandonedStart(
+    MediaStream videoStream,
+    int generation,
+  ) async {
+    if (_teardownGeneration == generation) {
+      await _barcodeReader?.stop();
+      _barcodeReader = null;
+      _activeWebReader = null;
     }
+
+    stopVideoStream(videoStream);
   }
 
   @override
@@ -585,6 +643,9 @@ class MobileScannerWeb extends MobileScannerPlatform {
 
   @override
   Future<void> stop() async {
+    // Signal any in-flight start() that its camera is no longer wanted.
+    _teardownGeneration++;
+
     // Ensure the barcode scanner is stopped, by cancelling the subscription.
     await _barcodesSubscription?.cancel();
     _barcodesSubscription = null;

--- a/lib/src/web/polling_barcode_reader.dart
+++ b/lib/src/web/polling_barcode_reader.dart
@@ -153,6 +153,11 @@ abstract base class PollingBarcodeReader extends BarcodeReader {
     _isDecoding = false;
     _onMediaTrackSettingsChanged = null;
     _scanWindow = null;
+    // Release the camera before dropping the references. Without this the
+    // tracks stay in `readyState: 'live'` after the scanner is closed, so the
+    // device camera and its OS indicator stay on until the page is reloaded.
+    stopVideoStream(_videoStream);
+    _videoElement?.srcObject = null;
     _videoElement = null;
     _videoStream = null;
     disposeDecoder();

--- a/lib/src/web/web_camera_utility.dart
+++ b/lib/src/web/web_camera_utility.dart
@@ -6,6 +6,24 @@ import 'package:web/web.dart' as web;
 export 'package:mobile_scanner/src/web/web_barcode_utils.dart'
     show isInsideScanWindow, mirrorBarcodeX;
 
+/// Stops every track on [videoStream], releasing the camera device.
+///
+/// Dropping the reference to a [web.MediaStream] does not release the camera:
+/// its tracks stay in `readyState: 'live'` and the OS camera indicator stays
+/// lit until the page is reloaded. Every code path that finishes with a
+/// stream must call this.
+void stopVideoStream(web.MediaStream? videoStream) {
+  final tracks = videoStream?.getTracks().toDart;
+
+  if (tracks == null) {
+    return;
+  }
+
+  for (final track in tracks) {
+    track.stop();
+  }
+}
+
 /// Returns true if the video stream should be mirrored horizontally.
 ///
 /// Mirrors when facingMode is 'user' (front camera on mobile), or when

--- a/test/mobile_scanner_controller/dispose_during_start_test.dart
+++ b/test/mobile_scanner_controller/dispose_during_start_test.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/camera_facing.dart';
+import 'package:mobile_scanner/src/enums/torch_state.dart';
+import 'package:mobile_scanner/src/mobile_scanner_controller.dart';
+import 'package:mobile_scanner/src/mobile_scanner_platform_interface.dart';
+import 'package:mobile_scanner/src/mobile_scanner_view_attributes.dart';
+import 'package:mobile_scanner/src/objects/barcode_capture.dart';
+import 'package:mobile_scanner/src/objects/start_options.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SlowStartMobileScannerPlatform platform;
+
+  setUp(() {
+    platform = SlowStartMobileScannerPlatform();
+    MobileScannerPlatform.instance = platform;
+    MobileScannerController.resetPlatformSessionOwner();
+  });
+
+  test(
+    'a controller disposed while starting does not claim the camera session',
+    () async {
+      final controller = MobileScannerController(autoStart: false)..attach();
+
+      final startFuture = controller.start();
+
+      await controller.dispose();
+
+      // The platform start only completes after the controller is gone,
+      // which is the interleaving a user creates by dismissing the scanner
+      // while the camera is still being acquired.
+      platform.completeStart();
+      await startFuture;
+
+      // The disposed controller must not be left holding the platform camera
+      // session: the next controller to dispose would then skip the platform
+      // teardown, and the camera would stay live.
+      final next = MobileScannerController(autoStart: false)..attach();
+
+      await next.dispose();
+
+      expect(platform.disposeCalls, 2);
+    },
+  );
+}
+
+class SlowStartMobileScannerPlatform extends MobileScannerPlatform {
+  int disposeCalls = 0;
+  int stopCalls = 0;
+
+  final Completer<void> _startGate = Completer<void>();
+
+  void completeStart() => _startGate.complete();
+
+  @override
+  Stream<BarcodeCapture?> get barcodesStream => const Stream.empty();
+
+  @override
+  Stream<TorchState> get torchStateStream =>
+      Stream.value(TorchState.unavailable);
+
+  @override
+  Stream<double> get zoomScaleStateStream => Stream.value(1);
+
+  @override
+  Future<MobileScannerViewAttributes> start(StartOptions startOptions) async {
+    await _startGate.future;
+
+    return const MobileScannerViewAttributes(
+      cameraDirection: CameraFacing.back,
+      currentTorchMode: TorchState.unavailable,
+      size: Size(200, 200),
+      numberOfCameras: 1,
+      initialDeviceOrientation: DeviceOrientation.portraitUp,
+    );
+  }
+
+  @override
+  Future<void> stop() {
+    stopCalls++;
+    return Future.value();
+  }
+
+  @override
+  Future<void> dispose() {
+    disposeCalls++;
+    return Future.value();
+  }
+}

--- a/test/web/mobile_scanner_web_start_teardown_test.dart
+++ b/test/web/mobile_scanner_web_start_teardown_test.dart
@@ -1,0 +1,215 @@
+@TestOn('browser')
+library;
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/barcode_format.dart';
+import 'package:mobile_scanner/src/enums/camera_facing.dart';
+import 'package:mobile_scanner/src/enums/camera_lens_type.dart';
+import 'package:mobile_scanner/src/enums/detection_speed.dart';
+import 'package:mobile_scanner/src/enums/web_barcode_reader.dart';
+import 'package:mobile_scanner/src/mobile_scanner_exception.dart';
+import 'package:mobile_scanner/src/objects/start_options.dart';
+import 'package:mobile_scanner/src/web/mobile_scanner_web.dart';
+import 'package:web/web.dart' as web;
+
+/// `HTMLCanvasElement.captureStream()` yields a real [web.MediaStream] backed
+/// by a live video track, without prompting for camera permission.
+extension type _CaptureStreamCanvas(JSObject _) implements JSObject {
+  external web.MediaStream captureStream();
+}
+
+web.MediaStream createLiveVideoStream() {
+  final canvas =
+      web.HTMLCanvasElement()
+        ..width = 32
+        ..height = 32;
+  canvas.context2D.fillRect(0, 0, 32, 32);
+
+  return _CaptureStreamCanvas(canvas as JSObject).captureStream();
+}
+
+List<web.MediaStreamTrack> tracksOf(web.MediaStream stream) =>
+    stream.getTracks().toDart;
+
+bool allEnded(web.MediaStream stream) =>
+    tracksOf(stream).every((track) => track.readyState == 'ended');
+
+const _startOptions = StartOptions(
+  cameraDirection: CameraFacing.back,
+  cameraLensType: CameraLensType.any,
+  cameraResolution: Size(32, 32),
+  detectionSpeed: DetectionSpeed.noDuplicates,
+  detectionTimeoutMs: 1000,
+  formats: [BarcodeFormat.qrCode],
+  returnImage: false,
+  torchEnabled: false,
+  invertImage: false,
+  autoZoom: false,
+  initialZoom: 1,
+);
+
+@JS('eval')
+external JSAny? _jsEval(String code);
+
+/// Replaces the global `BarcodeDetector` with one whose constructor throws, so
+/// that a start fails at the point where it has already acquired the camera.
+void _installFailingBarcodeDetector() {
+  _jsEval('''
+globalThis.__msOriginalBarcodeDetector = globalThis.BarcodeDetector;
+globalThis.BarcodeDetector = function () {
+  throw new Error("BarcodeDetector unavailable");
+};
+''');
+}
+
+void _restoreBarcodeDetector() {
+  _jsEval('''
+if ("__msOriginalBarcodeDetector" in globalThis) {
+  if (globalThis.__msOriginalBarcodeDetector === undefined) {
+    delete globalThis.BarcodeDetector;
+  } else {
+    globalThis.BarcodeDetector = globalThis.__msOriginalBarcodeDetector;
+  }
+  delete globalThis.__msOriginalBarcodeDetector;
+}
+''');
+}
+
+/// Replaces `navigator.mediaDevices.getUserMedia` with a stub whose promise
+/// resolves only when the test says so, so that teardown can be interleaved
+/// with an in-flight camera acquisition — the interleaving a user creates by
+/// dismissing the scanner before the camera is ready.
+class _GetUserMediaStub {
+  _GetUserMediaStub() {
+    _mediaDevices = web.window.navigator.mediaDevices as JSObject;
+    _original = _mediaDevices.getProperty('getUserMedia'.toJS);
+
+    _mediaDevices.setProperty(
+      'getUserMedia'.toJS,
+      ((JSAny? constraints) {
+        callCount++;
+        return _gate.future.toJS;
+      }).toJS,
+    );
+  }
+
+  late final JSObject _mediaDevices;
+  late final JSAny? _original;
+
+  final Completer<web.MediaStream> _gate = Completer<web.MediaStream>();
+
+  int callCount = 0;
+
+  /// Waits until the code under test has actually called `getUserMedia`.
+  Future<void> awaitCall() async {
+    while (callCount == 0) {
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+
+  /// Hands the caller a live stream, as the browser would.
+  web.MediaStream resolve() {
+    final stream = createLiveVideoStream();
+    _gate.complete(stream);
+
+    return stream;
+  }
+
+  void restore() {
+    if (_original == null) {
+      _mediaDevices.delete('getUserMedia'.toJS);
+    } else {
+      _mediaDevices.setProperty('getUserMedia'.toJS, _original);
+    }
+  }
+}
+
+void main() {
+  late _GetUserMediaStub getUserMedia;
+
+  setUp(() {
+    web.window.localStorage.clear();
+    getUserMedia = _GetUserMediaStub();
+  });
+
+  tearDown(() {
+    getUserMedia.restore();
+    _restoreBarcodeDetector();
+  });
+
+  group('MobileScannerWeb teardown during start', () {
+    test('dispose() while acquiring the camera releases the stream', () async {
+      final plugin =
+          MobileScannerWeb()
+            ..setWebBarcodeReader(WebBarcodeReader.barcodeDetector);
+
+      final startFuture = plugin.start(_startOptions);
+
+      await getUserMedia.awaitCall();
+
+      // The scanner is dismissed while getUserMedia is still pending.
+      await plugin.dispose();
+
+      final stream = getUserMedia.resolve();
+
+      await expectLater(
+        startFuture,
+        throwsA(isA<MobileScannerException>()),
+        reason: 'a start that was torn down must not report a running camera',
+      );
+
+      expect(
+        allEnded(stream),
+        isTrue,
+        reason: 'the camera acquired by the aborted start must be released',
+      );
+    });
+
+    test('stop() while acquiring the camera releases the stream', () async {
+      final plugin =
+          MobileScannerWeb()
+            ..setWebBarcodeReader(WebBarcodeReader.barcodeDetector);
+
+      final startFuture = plugin.start(_startOptions);
+
+      await getUserMedia.awaitCall();
+
+      await plugin.stop();
+
+      final stream = getUserMedia.resolve();
+
+      await expectLater(startFuture, throwsA(isA<MobileScannerException>()));
+
+      expect(allEnded(stream), isTrue);
+    });
+  });
+
+  group('MobileScannerWeb start failure', () {
+    test('a start that fails after acquiring the camera releases it', () async {
+      _installFailingBarcodeDetector();
+
+      final plugin =
+          MobileScannerWeb()
+            ..setWebBarcodeReader(WebBarcodeReader.barcodeDetector);
+
+      final startFuture = plugin.start(_startOptions);
+
+      await getUserMedia.awaitCall();
+
+      final stream = getUserMedia.resolve();
+
+      await expectLater(startFuture, throwsA(isA<MobileScannerException>()));
+
+      expect(
+        allEnded(stream),
+        isTrue,
+        reason: 'a failed start must not leave the camera running',
+      );
+    });
+  });
+}

--- a/test/web/polling_barcode_reader_stop_test.dart
+++ b/test/web/polling_barcode_reader_stop_test.dart
@@ -1,0 +1,152 @@
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/src/enums/barcode_format.dart';
+import 'package:mobile_scanner/src/enums/camera_facing.dart';
+import 'package:mobile_scanner/src/enums/camera_lens_type.dart';
+import 'package:mobile_scanner/src/enums/detection_speed.dart';
+import 'package:mobile_scanner/src/objects/barcode.dart';
+import 'package:mobile_scanner/src/objects/start_options.dart';
+import 'package:mobile_scanner/src/web/polling_barcode_reader.dart';
+import 'package:mobile_scanner/src/web/web_camera_utility.dart';
+import 'package:web/web.dart' as web;
+
+/// `HTMLCanvasElement.captureStream()` yields a real [web.MediaStream] backed
+/// by a live video track, without prompting for camera permission — the only
+/// way to observe track teardown in a headless browser.
+extension type _CaptureStreamCanvas(JSObject _) implements JSObject {
+  external web.MediaStream captureStream();
+}
+
+web.MediaStream createLiveVideoStream() {
+  final canvas = web.HTMLCanvasElement()
+    ..width = 32
+    ..height = 32;
+  // Draw once so the capture track produces a frame and goes live.
+  canvas.context2D.fillRect(0, 0, 32, 32);
+
+  return _CaptureStreamCanvas(canvas as JSObject).captureStream();
+}
+
+List<web.MediaStreamTrack> tracksOf(web.MediaStream stream) =>
+    stream.getTracks().toDart;
+
+/// Minimal concrete reader: the video lifecycle under test lives entirely in
+/// [PollingBarcodeReader], so the decoder hooks are no-ops.
+final class _NoopPollingReader extends PollingBarcodeReader {
+  int disposeDecoderCalls = 0;
+
+  @override
+  Future<List<Barcode>> decodeFrame(web.HTMLVideoElement video) async {
+    return const [];
+  }
+
+  @override
+  void disposeDecoder() => disposeDecoderCalls++;
+
+  @override
+  Future<void> prepareDecoder(StartOptions options) async {}
+}
+
+const _startOptions = StartOptions(
+  cameraDirection: CameraFacing.back,
+  cameraLensType: CameraLensType.any,
+  cameraResolution: Size(32, 32),
+  detectionSpeed: DetectionSpeed.noDuplicates,
+  detectionTimeoutMs: 1000,
+  formats: [BarcodeFormat.qrCode],
+  returnImage: false,
+  torchEnabled: false,
+  invertImage: false,
+  autoZoom: false,
+  initialZoom: 1,
+);
+
+void main() {
+  group('stopVideoStream', () {
+    test('ends every track on the stream', () {
+      final stream = createLiveVideoStream();
+      final tracks = tracksOf(stream);
+
+      expect(tracks, isNotEmpty);
+      expect(tracks.every((t) => t.readyState == 'live'), isTrue);
+
+      stopVideoStream(stream);
+
+      expect(tracks.every((t) => t.readyState == 'ended'), isTrue);
+    });
+
+    test('tolerates a null stream', () {
+      expect(() => stopVideoStream(null), returnsNormally);
+    });
+  });
+
+  group('PollingBarcodeReader.stop', () {
+    test('releases the camera by ending the video stream tracks', () async {
+      final stream = createLiveVideoStream();
+      final tracks = tracksOf(stream);
+      final videoElement = web.HTMLVideoElement()..muted = true;
+      final reader = _NoopPollingReader();
+
+      await reader.start(
+        _startOptions,
+        videoElement: videoElement,
+        videoStream: stream,
+      );
+
+      expect(
+        tracks.every((t) => t.readyState == 'live'),
+        isTrue,
+        reason: 'the stream is live while the scanner is running',
+      );
+
+      await reader.stop();
+
+      expect(
+        tracks.every((t) => t.readyState == 'ended'),
+        isTrue,
+        reason: 'the OS camera indicator must go dark when the scanner closes',
+      );
+      expect(reader.isScanning, isFalse);
+      expect(reader.disposeDecoderCalls, 1);
+    });
+
+    test('detaches the stream from the video element', () async {
+      final stream = createLiveVideoStream();
+      final videoElement = web.HTMLVideoElement()..muted = true;
+      final reader = _NoopPollingReader();
+
+      await reader.start(
+        _startOptions,
+        videoElement: videoElement,
+        videoStream: stream,
+      );
+      expect(videoElement.srcObject, isNotNull);
+
+      await reader.stop();
+
+      expect(videoElement.srcObject, isNull);
+    });
+
+    test('is safe to call twice', () async {
+      final stream = createLiveVideoStream();
+      final tracks = tracksOf(stream);
+      final reader = _NoopPollingReader();
+
+      await reader.start(
+        _startOptions,
+        videoElement: web.HTMLVideoElement()..muted = true,
+        videoStream: stream,
+      );
+
+      await reader.stop();
+      await reader.stop();
+
+      expect(tracks.every((t) => t.readyState == 'ended'), isTrue);
+    });
+  });
+}

--- a/test/web/polling_barcode_reader_stop_test.dart
+++ b/test/web/polling_barcode_reader_stop_test.dart
@@ -23,9 +23,10 @@ extension type _CaptureStreamCanvas(JSObject _) implements JSObject {
 }
 
 web.MediaStream createLiveVideoStream() {
-  final canvas = web.HTMLCanvasElement()
-    ..width = 32
-    ..height = 32;
+  final canvas =
+      web.HTMLCanvasElement()
+        ..width = 32
+        ..height = 32;
   // Draw once so the capture track produces a frame and goes live.
   canvas.context2D.fillRect(0, 0, 32, 32);
 


### PR DESCRIPTION
## Description

`PollingBarcodeReader.stop()` drops its `MediaStream` reference without stopping the tracks, so the camera acquired by `getUserMedia` stays in `readyState: 'live'` after the scanner is closed. The device camera and the OS camera indicator stay on until the page is reloaded.

Both default web backends extend this class — `BarcodeDetectorReader` and `ZXingWasmBarcodeReader` — so `WebBarcodeReader.auto` leaks the camera on every browser. The legacy `WebBarcodeReader.zxingJs` backend is unaffected, because `ZXingBarcodeReader.stop()` releases the stream through ZXing's `reset()`.

```dart
Future<void> stop() async {
  ...
  _videoElement = null;
  _videoStream = null;   // <- tracks are never stopped
  disposeDecoder();
}
```

This PR stops every track and detaches the stream from the video element before dropping the references, via a new `stopVideoStream()` helper in `web_camera_utility.dart`.

### Reproducing

1. Open a scanner on the web with the default `WebBarcodeReader.auto`.
2. Close it (or let a successful decode close it).
3. The OS camera indicator stays lit, and the acquired stream's tracks still report `readyState: 'live'`.

### Tests

`test/web/polling_barcode_reader_stop_test.dart` (browser, `@TestOn('browser')`) acquires a real `MediaStream` from `HTMLCanvasElement.captureStream()` — no camera permission needed — and asserts the tracks reach `readyState: 'ended'` and `videoElement.srcObject` is cleared after `stop()`. The tests fail on `develop` and pass with the fix.

Run with `flutter test --platform chrome test/web/`. Note that `test/web/web_library_versions_test.dart` already fails under `--platform chrome` on `develop` (it reads `package.json` from disk); that is unrelated to this change.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`) — this is required by CI and drives the automated changelog/release.
- [x] (Optional) Each individual commit also follows Conventional Commits — if so, we'll merge with a real merge commit to preserve your full history; otherwise we'll squash the PR into one commit.
- [x] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.