### PR TITLE
chore(example): remove redundant unawaited on Navigator.push

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:mobile_scanner_example/screens/mobile_scanner_advanced.dart';
@@ -87,11 +85,9 @@ class _ExampleHome extends StatelessWidget {
   ) {
     return GestureDetector(
       onTap: () {
-        unawaited(
-          Navigator.of(
-            context,
-          ).push(MaterialPageRoute<void>(builder: (context) => page)),
-        );
+        Navigator.of(
+          context,
+        ).push(MaterialPageRoute<void>(builder: (context) => page));
       },
       child: Card(
         elevation: 5,


### PR DESCRIPTION
## Description

`Navigator.push` is annotated `@awaitNotRequired` on current Flutter, so the `unawaited(...)` wrapper in the example app now trips the new `unnecessary_unawaited` lint and fails the `Analysis (get, .)` job. This has been failing on `develop` since a82ce11. The `dart:async` import was only there for `unawaited`, so it goes too.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`) — this is required by CI and drives the automated changelog/release.
- [x] (Optional) Each individual commit also follows Conventional Commits — if so, we'll merge with a real merge commit to preserve your full history; otherwise we'll squash the PR into one commit.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.