### PR TITLE
fix(android): defer orientation sensor listener until camera start

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/mobile_scanner/DeviceOrientationListener.kt
+++ b/android/src/main/kotlin/dev/steenbakker/mobile_scanner/DeviceOrientationListener.kt
@@ -61,7 +61,9 @@ class DeviceOrientationListener(
     // the two landscape orientations. The actual orientation is still read
     // from the display rotation in [checkRotation], so the system rotation
     // lock and the app's preferred orientations remain respected.
-    private val orientationEventListener = object : OrientationEventListener(activity) {
+    private var orientationEventListener: OrientationEventListener? = null
+
+    private fun createOrientationEventListener() = object : OrientationEventListener(activity) {
         override fun onOrientationChanged(orientation: Int) {
             if (orientation == ORIENTATION_UNKNOWN) {
                 return
@@ -98,8 +100,10 @@ class DeviceOrientationListener(
         lastSensorQuadrant = -1
         val displayManager = activity.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
         displayManager.registerDisplayListener(displayListener, handler)
-        if (orientationEventListener.canDetectOrientation()) {
-            orientationEventListener.enable()
+        val sensorListener = orientationEventListener
+            ?: createOrientationEventListener().also { orientationEventListener = it }
+        if (sensorListener.canDetectOrientation()) {
+            sensorListener.enable()
         }
         // Emit the orientation on every camera start, so that listeners that
         // survive a stop/start cycle (e.g. when switching cameras) are
@@ -116,7 +120,7 @@ class DeviceOrientationListener(
      * Stop listening to display orientation changes.
      */
     fun stop() {
-        orientationEventListener.disable()
+        orientationEventListener?.disable()
         val displayManager = activity.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
         displayManager.unregisterDisplayListener(displayListener)
         handler.removeCallbacks(rotationCheck)


### PR DESCRIPTION
## Description

Fixes #1801 by only starting orientation listener after camera start.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`) — this is required by CI and drives the automated changelog/release.
- [x] (Optional) Each individual commit also follows Conventional Commits — if so, we'll merge with a real merge commit to preserve your full history; otherwise we'll squash the PR into one commit.
- [x] Tests were added or updated, if applicable.
- [x] Documentation (`README.md`) was updated, if applicable.
